### PR TITLE
put back list of files in the final build archive and add cue.mod folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           enable_go: true
       - uses: ./.github/perses-ci/actions/install_percli
         with:
-          cli_version: "main-2024-11-13-e99df92a-distroless" # To replace by latest when `percli plugin update` command will be released
+          cli_version: "v0.50.0-rc.0"
       - run: go run ./scripts/get-schemas-deps/get-schemas-deps.go
       - name: store plugin schema dependencies
         uses: actions/upload-artifact@v4

--- a/scripts/build-archive/build-archive.go
+++ b/scripts/build-archive/build-archive.go
@@ -22,14 +22,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var pluginFiles = []string{
+	"dist/",
+	"cue.mod/",
+	"schemas/",
+	"package.json",
+	"README.md",
+}
+
 func createArchive(pluginName string) error {
 	manifest, err := npm.ReadManifest(pluginName)
 	if err != nil {
 		return err
 	}
 	newArchiveFolder := path.Join(pluginName, pluginName)
-	if execErr := exec.Command("cp", "-r", path.Join(pluginName, "dist/"), newArchiveFolder).Run(); execErr != nil {
-		return fmt.Errorf("unable to copy the dist folder: %w", execErr)
+	for _, f := range pluginFiles {
+		if execErr := exec.Command("cp", "-r", path.Join(pluginName, f), newArchiveFolder).Run(); execErr != nil {
+			return fmt.Errorf("unable to copy the file or folder %s: %w", f, execErr)
+		}
 	}
 
 	// Then let's create the archive with the folder previously created


### PR DESCRIPTION
Putting back in the archive a list of files and folders require to be a valid plugin.

I am also adding the the folder `cue.mod` and `schemas` that will be required later in the backend to allow the plugin in the database.