### PR TITLE
add component keys to fix Perses e2e

### DIFF
--- a/Prometheus/package.json
+++ b/Prometheus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perses-dev/prometheus",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/Prometheus/src/components/PromQLEditor.tsx
+++ b/Prometheus/src/components/PromQLEditor.tsx
@@ -112,6 +112,7 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
               onClick={handleShowTreeView}
               sx={{ position: 'absolute', right: '5px', top: '5px' }}
               size="small"
+              key="tree-view-button"
             >
               <FileTreeIcon sx={{ fontSize: '18px' }} />
             </IconButton>
@@ -124,6 +125,7 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
                   onClick={() => setTreeViewVisible(false)}
                   sx={{ position: 'absolute', top: '5px', right: '5px' }}
                   size="small"
+                  key="tree-view-close-button"
                 >
                   <CloseIcon sx={{ fontSize: '18px' }} />
                 </IconButton>

--- a/Table/package.json
+++ b/Table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perses-dev/table",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/Table/src/CellsEditor/CellEditor.tsx
+++ b/Table/src/CellsEditor/CellEditor.tsx
@@ -225,7 +225,7 @@ export function CellEditor({ cell, onChange, onDelete, ...props }: CellEditorPro
       </Grid>
       <Grid size={{ xs: 1 }} textAlign="end">
         <Tooltip title="Remove cell settings" placement="top">
-          <IconButton size="small" sx={{ marginLeft: 'auto' }} onClick={onDelete}>
+          <IconButton size="small" sx={{ marginLeft: 'auto' }} onClick={onDelete} key="delete-cell-button">
             <DeleteIcon />
           </IconButton>
         </Tooltip>

--- a/Table/src/ColumnsEditor/ColumnEditorContainer.tsx
+++ b/Table/src/ColumnsEditor/ColumnEditorContainer.tsx
@@ -76,7 +76,7 @@ export function ColumnEditorContainer({
           {isCollapsed && (
             <>
               <Tooltip title={column.hide ? 'Show column' : 'Hide column'} placement="top">
-                <IconButton size="small" sx={{ marginLeft: 'auto' }} onClick={handleHideColumn}>
+                <IconButton size="small" sx={{ marginLeft: 'auto' }} onClick={handleHideColumn} key="hide-column">
                   {column.hide ? <EyeOffIcon /> : <EyeIcon />}
                 </IconButton>
               </Tooltip>
@@ -84,7 +84,7 @@ export function ColumnEditorContainer({
             </>
           )}
           <Tooltip title="Remove column settings" placement="top">
-            <IconButton size="small" sx={{ marginLeft: 'auto' }} onClick={onDelete}>
+            <IconButton size="small" sx={{ marginLeft: 'auto' }} onClick={onDelete} key="delete-column-button">
               <DeleteIcon />
             </IconButton>
           </Tooltip>
@@ -95,6 +95,7 @@ export function ColumnEditorContainer({
               menuSx={{
                 '.MuiPaper-root': { backgroundColor: (theme) => theme.palette.background.lighter },
               }}
+              key="reorder-column-button"
             />
           </Tooltip>
         </Stack>

--- a/TraceTable/package.json
+++ b/TraceTable/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perses-dev/trace-table",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/TraceTable/src/DataTable.tsx
+++ b/TraceTable/src/DataTable.tsx
@@ -158,7 +158,9 @@ export function DataTable(props: DataTableProps): ReactElement {
         display: 'flex',
         renderCell: ({ row }) => (
           <Tooltip title={UTC_DATE_FORMATTER(new Date(row.startTimeUnixMs))} placement="top" arrow>
-            <Typography display="inline">{DATE_FORMATTER(new Date(row.startTimeUnixMs))}</Typography>
+            <Typography display="inline" key={`st-${row.traceId}`}>
+              {DATE_FORMATTER(new Date(row.startTimeUnixMs))}
+            </Typography>
           </Tooltip>
         ),
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12455,7 +12455,7 @@
     },
     "Table": {
       "name": "@perses-dev/table",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@module-federation/enhanced": "^0.1.11",
         "@perses-dev/components": "^0.50.0-rc.1",
@@ -12681,7 +12681,7 @@
     },
     "TraceTable": {
       "name": "@perses-dev/trace-table",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@module-federation/enhanced": "^0.1.11",
         "@mui/x-data-grid": "^7.23.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12176,7 +12176,7 @@
     },
     "Prometheus": {
       "name": "@perses-dev/prometheus",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@module-federation/enhanced": "^0.1.11",
         "@prometheus-io/codemirror-promql": "^0.43.0",


### PR DESCRIPTION
This PR:

- bumps a new version of the Prometheus plugin
- Fixes an issue with federation and material UI Tooltips by adding keys to the components, this fixes e2e tests on https://github.com/perses/perses/pull/2557 see https://github.com/mui/material-ui/issues/34150