### PR TITLE
add a release script

### DIFF
--- a/scripts/npm/npm.go
+++ b/scripts/npm/npm.go
@@ -17,10 +17,24 @@ import (
 	"encoding/json"
 	"os"
 	"path"
+	"path/filepath"
 )
 
 type Package struct {
+	Version    string   `json:"version"`
 	Workspaces []string `json:"workspaces"`
+}
+
+func GetVersion(pluginPath string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(pluginPath, "package.json"))
+	if err != nil {
+		return "", err
+	}
+	pkg := Package{}
+	if unmarshalErr := json.Unmarshal(data, &pkg); unmarshalErr != nil {
+		return "", unmarshalErr
+	}
+	return pkg.Version, nil
 }
 
 func GetWorkspaces() ([]string, error) {

--- a/scripts/release/release.go
+++ b/scripts/release/release.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os/exec"
+
+	"github.com/perses/plugins/scripts/npm"
+	"github.com/sirupsen/logrus"
+)
+
+func release(pluginName string, optionalReleaseMessage string) {
+	version, err := npm.GetVersion(pluginName)
+	if err != nil {
+		logrus.WithError(err).Fatalf("unable to get the version of the plugin %s", pluginName)
+	}
+	releaseName := fmt.Sprintf("%s-%s", pluginName, version)
+	// ensure the tag does not already exist
+	if execErr := exec.Command("git", "rev-parse", "--verify", releaseName).Run(); execErr == nil {
+		logrus.Infof("release %s already exists", releaseName)
+		return
+	}
+	// create the GitHub release
+	if execErr := exec.Command("gh", "release", "create", releaseName, "-t", releaseName, "-n", optionalReleaseMessage).Run(); execErr != nil {
+		logrus.WithError(execErr).Fatalf("unable to create the release %s", releaseName)
+	}
+}
+
+// Here the usage of this script:
+// This will release every plugins that are not yet released
+//
+//	go run ./scripts/release/release.go --all
+//
+// This will release only the Tempo plugin
+//
+//	go run ./scripts/release/release.go --name=Tempo
+//
+// Add a release message that will appear in every release
+//
+//	go run ./scripts/release/release.go --all --message="Release message"
+func main() {
+	releaseAll := flag.Bool("all", false, "release all the plugins")
+	releaseSingleName := flag.String("name", "", "release a single plugin")
+	optionalReleaseMessage := flag.String("message", "", "release message")
+	flag.Parse()
+	// get all tags locally
+	if err := exec.Command("git", "fetch", "--tags").Run(); err != nil {
+		logrus.WithError(err).Fatal("unable to fetch the tags")
+	}
+	if !*releaseAll {
+		release(*releaseSingleName, *optionalReleaseMessage)
+	}
+	workspaces, err := npm.GetWorkspaces()
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to get the list of the workspaces")
+	}
+	for _, workspace := range workspaces {
+		logrus.Infof("releasing %s", workspace)
+		release(workspace, *optionalReleaseMessage)
+	}
+}


### PR DESCRIPTION
I am adding a release script to release the various plugin we have using a simple command line.
Note that you will need to install the [GitHub CLI](https://github.com/cli/cli?tab=readme-ov-file) to use this script.

Usage:

```bash
# This will release every plugins that are not yet released
go run ./scripts/release/release.go --all

# This will release only the Tempo plugin
go run ./scripts/release/release.go --name=Tempo

# Add a release message that will appear in every release
go run ./scripts/release/release.go --all --message="Release message"
```