### PR TITLE
last sync cuelang schema from perses/perses

### DIFF
--- a/StatChart/schemas/migrate/migrate.cue
+++ b/StatChart/schemas/migrate/migrate.cue
@@ -34,7 +34,10 @@ import "list"
 kind: "StatChart"
 spec: {
 	calculation: *commonMigrate.#mapping.calc[#panel.options.reduceOptions.calcs[0]] | commonMigrate.#defaultCalc // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
-
+    #metricLabel: *#panel.options.reduceOptions.fields | null
+	if #metricLabel != null {
+		metricLabel: #metricLabel
+	}
 	#unit: *commonMigrate.#mapping.unit[#panel.fieldConfig.defaults.unit] | null
 	if #unit != null {
 		format: unit: #unit

--- a/StatChart/schemas/stat.cue
+++ b/StatChart/schemas/stat.cue
@@ -20,10 +20,12 @@ import (
 kind: "StatChart"
 spec: close({
 	calculation:    common.#calculation
+	metricLabel?:   common.#metricLabel
 	format?:        common.#format
 	thresholds?:    common.#thresholds
 	sparkline?:     #sparkline
 	valueFontSize?: number
+	mappings?: [...common.#mappings]
 
 	#sparkline: {
 		color?: string

--- a/StatusHistoryChart/schemas/migrate/migrate.cue
+++ b/StatusHistoryChart/schemas/migrate/migrate.cue
@@ -12,25 +12,102 @@
 // limitations under the License.
 
 package migrate
+import (
+	commonMigrate "github.com/perses/perses/cue/schemas/common/migrate"
+)
+import "list"
 
 #grafanaType: "status-history"
 #panel:       _
 
+#mapping: {
+    type: string
+    options: [...{
+        key: string
+        value: string
+        text: string
+        color: string
+    }]
+}
+
 kind: "StatusHistoryChart"
 spec: {
-	#showLegend: *#panel.options.legend.showLegend | true
-	if #panel.options.legend != _|_ if #showLegend {
-		legend: {
-			if #panel.type == "status-history" {
-				position: [
-					if #panel.options.legend.placement != _|_ if #panel.options.legend.placement == "right" {"right"},
-					{"bottom"},
-				][0]
-				mode: [
-					if #panel.options.legend.displayMode == "list" {"list"},
-					if #panel.options.legend.displayMode == "table" {"table"},
-				][0]
+		#showLegend: *#panel.options.legend.showLegend | true
+		if #showLegend {
+			legend: {
+				position: *(#panel.options.legend.placement & "right") | "bottom"
+				mode:     *(#panel.options.legend.displayMode & "table") | "list"
 			}
 		}
+
+		// Using flatten to avoid having an array of arrays with "value" mappings
+		// (https://cuelang.org/docs/howto/use-list-flattenn-to-flatten-lists/)
+		let x = list.FlattenN([
+			if (*#panel.fieldConfig.defaults.mappings | null) != null for mapping in #panel.fieldConfig.defaults.mappings {
+				if mapping.type == "value" {
+					[for key, option in mapping.options {
+						{
+							kind: "Value"
+							spec: {
+								value: key
+								result: {
+									if option.text != _|_ {
+										value: option.text
+									}
+									if option.color != _|_ {
+										color: *commonMigrate.#mapping.color[option.color] | option.color
+									}
+								}
+							}
+						}
+
+					}]
+				}
+
+				if mapping.type == "range" || mapping.type == "regex" || mapping.type == "special" {
+					#result: {
+						value: *mapping.options.result.text | ""
+						if mapping.options.result.color != _|_ {
+							color: *commonMigrate.#mapping.color[mapping.options.result.color] | mapping.options.result.color
+						}
+					}
+					[//switch
+						if mapping.type == "range" {
+							kind: "Range"
+							spec: {
+								if mapping.options.from != _|_ {
+									from: mapping.options.from
+								}
+								if mapping.options.to != _|_ {
+									to: mapping.options.to
+								}
+								result: #result
+							}
+						},
+						if mapping.type == "regex" {
+							kind: "Regex"
+							spec: {
+								pattern: mapping.options.pattern
+								result:  #result
+							}
+						},
+						if mapping.type == "special" {
+							kind: "Misc"
+							spec: {
+								value: [//switch
+									if mapping.options.match == "nan" {"NaN"},
+									if mapping.options.match == "null+nan" {"null"},
+									mapping.options.match,
+								][0]
+								result: #result
+							}
+						},
+					][0]
+				}
+			},
+		], 1)
+
+		if len(x) > 0 {
+			mappings: x
+		}
 	}
-}

--- a/StatusHistoryChart/schemas/status-history.cue
+++ b/StatusHistoryChart/schemas/status-history.cue
@@ -17,8 +17,6 @@ import (
 	"github.com/perses/perses/cue/schemas/common"
 )
 
-#legendValue: common.#calculation
-
 #legend: {
 	position: "bottom" | "right"
 	mode?:    "list" | "table"
@@ -26,6 +24,8 @@ import (
 }
 
 kind: "StatusHistoryChart"
+
 spec: close({
 	legend?: #legend
+	mappings?: [...common.#mappings]
 })

--- a/scripts/get-schemas-deps/get-schemas-deps.go
+++ b/scripts/get-schemas-deps/get-schemas-deps.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Defined as a const and not as a flag or whatever because it's supposed to be removed when moving to CUE's dependencies management
-const percliVersion = "v0.50.0"
+const percliVersion = "v0.50.1"
 
 /*
  * Get the dependencies (= CUE packages imported) for the given plugin


### PR DESCRIPTION
This PR is the last one synchronising the Cuelang schema from perses/perses. After this PR schemas will be removed from `perses/perses` for the plugins

Evolution regarding them will have to be done on `perses/plugins`