### PR TITLE
[BUGFIX] GaugeChartPanel: fix empty state

### DIFF
--- a/GaugeChart/src/GaugeChartPanel.tsx
+++ b/GaugeChart/src/GaugeChartPanel.tsx
@@ -26,7 +26,7 @@ import {
 } from './gauge-chart-model';
 import { convertThresholds, defaultThresholdInput } from './thresholds';
 
-const EMPTY_GAUGE_SERIES: GaugeSeries = { label: '', value: null };
+const EMPTY_GAUGE_SERIES: GaugeSeries = { label: '', value: undefined };
 const GAUGE_MIN_WIDTH = 90;
 const PANEL_PADDING_OFFSET = 20;
 


### PR DESCRIPTION
Ref https://github.com/perses/perses/pull/2548

The `GaugeChart` only checks for `undefined`, not `null`, when deciding whether to show the no data display:
https://github.com/perses/perses/blob/c4a7621b138b903599743c7162526a5cbc7cb73e/ui/components/src/GaugeChart/GaugeChart.tsx#L52