### PR TITLE
[IGNORE] TimeSeriesChart: mystery fix for perses/perses migration unit tests 

### DIFF
--- a/TimeSeriesChart/package.json
+++ b/TimeSeriesChart/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perses-dev/timeseries-chart",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",

--- a/TimeSeriesChart/schemas/migrate/migrate.cue
+++ b/TimeSeriesChart/schemas/migrate/migrate.cue
@@ -101,11 +101,15 @@ spec: {
 	// visual
 	#lineWidth: *#panel.fieldConfig.defaults.custom.lineWidth | null
 	if #lineWidth != null {
-		visual: lineWidth: [// switch
-			if #lineWidth > 3 {3},       // line width can't go beyond 3 in Perses
-			if #lineWidth < 0.25 {0.25}, // line width can't go below 0.25 in Perses
-			#lineWidth,
-		][0]
+		if #lineWidth > 3 {
+			visual: lineWidth: 3 // line width can't go beyond 3 in Perses
+		}
+		if #lineWidth < 0.25 {
+			visual: lineWidth: 0.25 // line width can't go below 0.25 in Perses
+		}
+		if #lineWidth >= 0.25 && #lineWidth <= 3 {
+			visual: lineWidth: #lineWidth
+		}
 	}
 
 	#fillOpacity: *#panel.fieldConfig.defaults.custom.fillOpacity | null

--- a/package-lock.json
+++ b/package-lock.json
@@ -13154,7 +13154,7 @@
     },
     "Prometheus": {
       "name": "@perses-dev/prometheus",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@module-federation/enhanced": "^0.8.9",
         "@nexucis/fuzzy": "^0.5.1",
@@ -13605,7 +13605,7 @@
     },
     "Tempo": {
       "name": "@perses-dev/tempo",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
         "@grafana/lezer-traceql": "^0.0.20",
@@ -13900,7 +13900,7 @@
     },
     "TimeSeriesChart": {
       "name": "@perses-dev/timeseries-chart",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@module-federation/enhanced": "^0.8.9",
         "color-hash": "^2.0.2"


### PR DESCRIPTION
The previous code with the switch-like statement is strictly equivalent to new one, and it is working fine with Perses "live", no issue to migrate dashboards from the UI etc. but for some reason it is causing this error in the migrate unit tests with the bump to cue v0.12 on perses/perses side: `cue: marshal error: spec.visual.lineWidth: cannot convert incomplete value "_" to JSON.`

Ref https://github.com/perses/perses/pull/2599