### PR TITLE
downgrade promql code mirror to avoid warning, add keys to tooltip buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2852,6 +2852,35 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@prometheus-io/codemirror-promql": {
+      "version": "0.45.6",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.45.6.tgz",
+      "integrity": "sha512-/MLafOGFWFE4vGNDf5k0UodF16Ej7M22WO4q19I6DbncuYHsQAe3fKFDuA3B7noAitbi/XYoXL9kbOuq1VbI6g==",
+      "dependencies": {
+        "@prometheus-io/lezer-promql": "0.45.6",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/view": "^6.4.0",
+        "@lezer/common": "^1.0.1"
+      }
+    },
+    "node_modules/@prometheus-io/lezer-promql": {
+      "version": "0.45.6",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.45.6.tgz",
+      "integrity": "sha512-IIShcInrCT+pBFjKqvgfM9ylC3LVdgtLEt9HxbwDJEn7yRHRFmKZdmoSavsyPrzajcxQ+7vyRKw7qX9It4J/Zg==",
+      "peerDependencies": {
+        "@lezer/highlight": "^1.1.2",
+        "@lezer/lr": "^1.2.3"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.1.tgz",
@@ -9990,6 +10019,22 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-cache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/luxon": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
@@ -13154,12 +13199,12 @@
     },
     "prometheus": {
       "name": "@perses-dev/prometheus",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@module-federation/enhanced": "^0.8.9",
         "@nexucis/fuzzy": "^0.5.1",
         "@perses-dev/explore": "0.0.0-snapshot-explorer-plugin-c4a7621",
-        "@prometheus-io/codemirror-promql": "^0.301.0",
+        "@prometheus-io/codemirror-promql": "^0.45.6",
         "color-hash": "^2.0.2",
         "qs": "^6.13.0"
       },
@@ -13408,35 +13453,6 @@
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
-    "prometheus/node_modules/@prometheus-io/codemirror-promql": {
-      "version": "0.301.0",
-      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.301.0.tgz",
-      "integrity": "sha512-/LusHb5eLyq0K9JAZYCYd0b+TuBqhnI70JUxYAUHgnqyV0cC5uD4pIHErl3JQbUddrgqp3tKUwvfqnBRcGPqag==",
-      "dependencies": {
-        "@prometheus-io/lezer-promql": "0.301.0",
-        "lru-cache": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@codemirror/autocomplete": "^6.4.0",
-        "@codemirror/language": "^6.3.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/state": "^6.1.1",
-        "@codemirror/view": "^6.4.0",
-        "@lezer/common": "^1.0.1"
-      }
-    },
-    "prometheus/node_modules/@prometheus-io/lezer-promql": {
-      "version": "0.301.0",
-      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.301.0.tgz",
-      "integrity": "sha512-H87SUsGEjFI8OvY5VNrNspel2cXRsiZaSMvnu7m0bG6njFPwNA1vqjfmQ5up35lHNjV1eJiXYse5/CiSee132A==",
-      "peerDependencies": {
-        "@lezer/highlight": "^1.1.2",
-        "@lezer/lr": "^1.2.3"
-      }
-    },
     "prometheus/node_modules/@tanstack/query-core": {
       "version": "5.66.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.66.0.tgz",
@@ -13467,14 +13483,6 @@
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
       "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw=="
-    },
-    "prometheus/node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "prometheus/node_modules/marked": {
       "version": "4.3.0",

--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perses-dev/prometheus",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",
@@ -12,10 +12,10 @@
   "dependencies": {
     "@module-federation/enhanced": "^0.8.9",
     "@nexucis/fuzzy": "^0.5.1",
-    "@prometheus-io/codemirror-promql": "^0.301.0",
+    "@perses-dev/explore": "0.0.0-snapshot-explorer-plugin-c4a7621",
+    "@prometheus-io/codemirror-promql": "^0.45.6",
     "color-hash": "^2.0.2",
-    "qs": "^6.13.0",
-    "@perses-dev/explore": "0.0.0-snapshot-explorer-plugin-c4a7621"
+    "qs": "^6.13.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",

--- a/prometheus/src/components/PromQLEditor.tsx
+++ b/prometheus/src/components/PromQLEditor.tsx
@@ -103,6 +103,7 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
               onClick={handleShowTreeView}
               sx={{ position: 'absolute', right: '5px', top: '5px' }}
               size="small"
+              key="tree-view-button"
             >
               <FileTreeIcon sx={{ fontSize: '18px' }} />
             </IconButton>
@@ -115,6 +116,7 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
                   onClick={() => setTreeViewVisible(false)}
                   sx={{ position: 'absolute', top: '5px', right: '5px' }}
                   size="small"
+                  key="tree-view-close-button"
                 >
                   <CloseIcon sx={{ fontSize: '18px' }} />
                 </IconButton>


### PR DESCRIPTION
This PR:

- downgrades the `@prometheus-io/codemirror-promql` to avoid the [auto purge warning](https://github.com/prometheus/prometheus/blob/906f6a33b60cec2596018ac8cc97ac41b16b06b7/web/ui/module/codemirror-promql/src/client/prometheus.ts#L297)
- Adds keys to the buttons on tooltips to make react happy