### PR TITLE
update the way to release to be compliant with golang and submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           name: archives
           path: |
             **/*.tar.gz
+            **/dist/mf-manifest.json
             !node_modules
 
   lint:

--- a/scripts/build-archive/build-archive.go
+++ b/scripts/build-archive/build-archive.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/perses/plugins/scripts/npm"
@@ -37,16 +37,16 @@ func createArchive(pluginName string, createGroupArchive bool) error {
 	if err != nil {
 		return err
 	}
-	newArchiveFolder := path.Join(pluginName, pluginName)
+	newArchiveFolder := filepath.Join(pluginName, pluginName)
 	for _, f := range pluginFiles {
-		if execErr := exec.Command("cp", "-r", path.Join(pluginName, f), newArchiveFolder).Run(); execErr != nil {
+		if execErr := exec.Command("cp", "-r", filepath.Join(pluginName, f), newArchiveFolder).Run(); execErr != nil {
 			return fmt.Errorf("unable to copy the file or folder %s: %w", f, execErr)
 		}
 	}
 
 	// Then let's create the archive with the folder previously created
 	archiveName := fmt.Sprintf("%s-%s.tar.gz", manifest.ID, manifest.Metadata.BuildInfo.Version)
-	args := []string{"-czvf", path.Join(pluginName, archiveName), "-C", pluginName, pluginName}
+	args := []string{"-czvf", filepath.Join(pluginName, archiveName), "-C", pluginName, pluginName}
 
 	// Remove the copyfile metadata on macos
 	if runtime.GOOS == "darwin" {
@@ -58,7 +58,7 @@ func createArchive(pluginName string, createGroupArchive bool) error {
 	}
 
 	if createGroupArchive {
-		if execErr := exec.Command("cp", path.Join(pluginName, archiveName), path.Join("./plugins-archive", archiveName)).Run(); execErr != nil {
+		if execErr := exec.Command("cp", filepath.Join(pluginName, archiveName), filepath.Join("./plugins-archive", archiveName)).Run(); execErr != nil {
 			return execErr
 		}
 	}

--- a/scripts/npm/npm.go
+++ b/scripts/npm/npm.go
@@ -16,7 +16,6 @@ package npm
 import (
 	"encoding/json"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -65,7 +64,7 @@ type Manifest struct {
 }
 
 func ReadManifest(pluginPath string) (*Manifest, error) {
-	manifestFilePath := path.Join(pluginPath, "dist", "mf-manifest.json")
+	manifestFilePath := filepath.Join(pluginPath, "dist", "mf-manifest.json")
 	data, err := os.ReadFile(manifestFilePath)
 	if err != nil {
 		return nil, err

--- a/scripts/release/release.go
+++ b/scripts/release/release.go
@@ -27,7 +27,8 @@ func release(pluginName string, optionalReleaseMessage string) {
 	if err != nil {
 		logrus.WithError(err).Fatalf("unable to get the version of the plugin %s", pluginName)
 	}
-	releaseName := fmt.Sprintf("%s-%s", pluginName, version)
+	// To be compliant with Golang, the tag must be in the format `folder/vX.Y.Z`
+	releaseName := fmt.Sprintf("%s/v%s", pluginName, version)
 	// ensure the tag does not already exist
 	if execErr := exec.Command("git", "rev-parse", "--verify", releaseName).Run(); execErr == nil {
 		logrus.Infof("release %s already exists", releaseName)
@@ -41,22 +42,22 @@ func release(pluginName string, optionalReleaseMessage string) {
 
 // Prerequisites for running this script:
 // - Install the GitHub CLI (gh): https://github.com/cli/cli#installation
-// - Use it to login to GitHub: `gh auth login`
+// - Use it to log in to GitHub: `gh auth login`
 //
 // Usage:
-// This will release every plugins that are not yet released
+// This will release every plugin not yet released
 //
 //	go run ./scripts/release/release.go --all
 //
-// This will release only the Tempo plugin
+// This will release only the tempo plugin. Note that the `--name` flag is set with the folder name not the plugin name.
 //
-//	go run ./scripts/release/release.go --name=Tempo
+//	go run ./scripts/release/release.go --name=tempo
 //
 // Add a release message that will appear in every release
 //
 //	go run ./scripts/release/release.go --all --message="Release message"
 //
-// NB: this script doesn't handle the plugin archive creation, this is achieved by a CI task.
+// NB: this script doesn't handle the plugin archive creation, a CI task achieves this.
 func main() {
 	releaseAll := flag.Bool("all", false, "release all the plugins")
 	releaseSingleName := flag.String("name", "", "release a single plugin")


### PR DESCRIPTION
This PR is fixing the way to release the plugin and the way to upload the archive that has been broken after #50 was merged

It will change the release name convention. Before this PR, the tag release was following the pattern `PluginName-X.Y.Z`.

Now the pattern is `pluginFolderName/vX.Y.Z`. This is to be compliant with the golang submodule versioning. Doing that will allow user to get the plugins like that:

```bash
go get github.com/perses/plugins/prometheus@v0.5.1
```