### PR TITLE
[ENHANCEMENT] Metric finder: improve error displays

### DIFF
--- a/prometheus/src/explore/PrometheusMetricsFinder/overview/MetricOverview.tsx
+++ b/prometheus/src/explore/PrometheusMetricsFinder/overview/MetricOverview.tsx
@@ -135,7 +135,7 @@ export function MetricOverview({
   ...props
 }: MetricOverviewProps): ReactElement {
   const [tab, setTab] = useState(0);
-  const { metadata, isLoading: isMetadataLoading, error } = useMetricMetadata(metricName, datasource);
+  const { metadata, isLoading: isMetadataLoading } = useMetricMetadata(metricName, datasource);
 
   const filtersWithMetricName: LabelFilter[] = useMemo(() => {
     const result = filters.filter((filter) => filter.label !== '__name__');
@@ -152,10 +152,6 @@ export function MetricOverview({
     if (tab !== undefined) {
       setTab(tab);
     }
-  }
-
-  if (error) {
-    return <Stack {...props}>Error: {error.message}</Stack>;
   }
 
   return (

--- a/prometheus/src/explore/PrometheusMetricsFinder/utils.ts
+++ b/prometheus/src/explore/PrometheusMetricsFinder/utils.ts
@@ -132,13 +132,20 @@ export function useSeriesStates(
   series: Metric[] | undefined;
   labelValueCounters: Map<string, Array<{ labelValue: string; counter: number }>>;
   isLoading: boolean;
+  isError: boolean;
+  error: StatusError | null;
 } {
   const {
     absoluteTimeRange: { start, end },
   } = useTimeRange();
   const { data: client } = useDatasourceClient<PrometheusClient>(datasource);
 
-  const { data: seriesData, isLoading } = useQuery<SeriesResponse>({
+  const {
+    data: seriesData,
+    isLoading,
+    isError,
+    error,
+  } = useQuery<SeriesResponse, StatusError>({
     enabled: !!client,
     queryKey: ['series', metricName, 'datasource', datasource, 'start', start, 'end', 'filters', ...filters],
     queryFn: async () => {
@@ -178,5 +185,5 @@ export function useSeriesStates(
     return result;
   }, [seriesData]);
 
-  return { series: seriesData?.data, labelValueCounters, isLoading };
+  return { series: seriesData?.data, labelValueCounters, isLoading, isError, error };
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fixing issue: https://github.com/perses/perses/issues/2534
Improve display when there a request fail to fetch data in overview tab

# Screenshots

<!-- If there are UI changes -->
Metadata request failing:
![image](https://github.com/user-attachments/assets/b50fa991-9cab-479e-a215-626f6aa9d510)

Series request failing:
![image](https://github.com/user-attachments/assets/ff38b6cc-a1da-47f0-91ac-21b82e204705)

Both:
![image](https://github.com/user-attachments/assets/a127a741-923d-449c-90f7-585b8c73989a)



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [x] Visual tests are stable and unlikely to be flaky.
  See [Storybook](https://github.com/perses/perses/tree/main/ui/storybook#visual-tests)
  and [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues
  include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.