### PR TITLE
GaugeChart: re-add circular loading screen

### DIFF
--- a/gaugechart/src/GaugeChart.ts
+++ b/gaugechart/src/GaugeChart.ts
@@ -14,13 +14,14 @@
 import { PanelPlugin } from '@perses-dev/plugin-system';
 import { createInitialGaugeChartOptions, GaugeChartOptions } from './gauge-chart-model';
 import { GaugeChartOptionsEditorSettings } from './GaugeChartOptionsEditorSettings';
-import { GaugeChartPanel } from './GaugeChartPanel';
+import { GaugeChartLoading, GaugeChartPanel, GaugeChartPanelProps } from './GaugeChartPanel';
 
 /**
  * The core GaugeChart panel plugin for Perses.
  */
-export const GaugeChart: PanelPlugin<GaugeChartOptions> = {
+export const GaugeChart: PanelPlugin<GaugeChartOptions, GaugeChartPanelProps> = {
   PanelComponent: GaugeChartPanel,
+  LoadingComponent: GaugeChartLoading,
   supportedQueryTypes: ['TimeSeriesQuery'],
   panelOptionsEditorComponents: [
     {

--- a/gaugechart/src/GaugeChartPanel.tsx
+++ b/gaugechart/src/GaugeChartPanel.tsx
@@ -13,8 +13,8 @@
 
 import { Box, Skeleton, Stack } from '@mui/material';
 import { GaugeChart, GaugeSeries, useChartsTheme } from '@perses-dev/components';
-import { CalculationsMap, DEFAULT_CALCULATION } from '@perses-dev/core';
-import { PanelProps, useDataQueries } from '@perses-dev/plugin-system';
+import { CalculationsMap, DEFAULT_CALCULATION, TimeSeriesData } from '@perses-dev/core';
+import { PanelProps } from '@perses-dev/plugin-system';
 import type { GaugeSeriesOption } from 'echarts';
 import merge from 'lodash/merge';
 import { ReactElement, useMemo } from 'react';
@@ -30,15 +30,13 @@ const EMPTY_GAUGE_SERIES: GaugeSeries = { label: '', value: undefined };
 const GAUGE_MIN_WIDTH = 90;
 const PANEL_PADDING_OFFSET = 20;
 
-export type GaugeChartPanelProps = PanelProps<GaugeChartOptions>;
+export type GaugeChartPanelProps = PanelProps<GaugeChartOptions, TimeSeriesData>;
 
 export function GaugeChartPanel(props: GaugeChartPanelProps): ReactElement | null {
-  const { spec: pluginSpec, contentDimensions } = props;
+  const { spec: pluginSpec, contentDimensions, queryResults } = props;
   const { calculation, max } = pluginSpec;
 
   const { thresholds: thresholdsColors } = useChartsTheme();
-
-  const { queryResults, isLoading } = useDataQueries('TimeSeriesQuery');
 
   // ensures all default format properties set if undef
   const format = merge({}, DEFAULT_FORMAT, pluginSpec.format);
@@ -67,21 +65,7 @@ export function GaugeChartPanel(props: GaugeChartPanelProps): ReactElement | nul
     return seriesData;
   }, [queryResults, calculation]);
 
-  if (queryResults[0]?.error) throw queryResults[0]?.error;
-
   if (contentDimensions === undefined) return null;
-
-  // TODO: remove Skeleton, add loading state to match mockups
-  if (isLoading) {
-    return (
-      <Skeleton
-        sx={{ margin: '0 auto' }}
-        variant="circular"
-        width={contentDimensions.width > contentDimensions.height ? contentDimensions.height : contentDimensions.width}
-        height={contentDimensions.height}
-      />
-    );
-  }
 
   // needed for end value of last threshold color segment
   let thresholdMax = max;
@@ -151,5 +135,17 @@ export function GaugeChartPanel(props: GaugeChartPanelProps): ReactElement | nul
         );
       })}
     </Stack>
+  );
+}
+
+export function GaugeChartLoading({ contentDimensions }: GaugeChartPanelProps): React.ReactElement | null {
+  if (contentDimensions === undefined) return null;
+  return (
+    <Skeleton
+      sx={{ margin: '0 auto' }}
+      variant="circular"
+      width={contentDimensions.width > contentDimensions.height ? contentDimensions.height : contentDimensions.width}
+      height={contentDimensions.height}
+    />
   );
 }


### PR DESCRIPTION
**Note: This must be merged after commit https://github.com/perses/perses/commit/0e66fc6a0d75de295a654d7c2efd6eee00a6fb04 is in a released Perses version.**

In https://github.com/perses/perses/pull/2549, we unified the loading and error handling for all panels. The GaugeChart had a custom loading skeleton (a round skeleton instead of rectangular), which is configured in this commit.

https://github.com/user-attachments/assets/f7a95cae-32c6-48a0-be6f-4a451aad8070

