### PR TITLE
Fix default trace table link

### DIFF
--- a/tracetable/src/TraceTablePanel.tsx
+++ b/tracetable/src/TraceTablePanel.tsx
@@ -40,7 +40,7 @@ export function defaultTraceLink({
   query.spec.plugin.spec.query = traceId;
 
   const traceLinkParams = new URLSearchParams({
-    explorer: 'traces',
+    explorer: 'Tempo-TempoExplorer',
     data: JSON.stringify({ queries: [query] }),
   });
 


### PR DESCRIPTION
The explorer param changed from `traces` to `Tempo-TempoExplorer`.