### PR TITLE
Tempo: improve error message if server returns invalid JSON

### DIFF
--- a/tempo/src/model/tempo-client.ts
+++ b/tempo/src/model/tempo-client.ts
@@ -48,8 +48,12 @@ export interface QueryOptions {
 
 export const executeRequest = async <T>(...args: Parameters<typeof global.fetch>): Promise<T> => {
   const response = await fetch(...args);
-  const jsonData = await response.json();
-  return jsonData;
+  try {
+    return await response.json();
+  } catch (e) {
+    console.error('Invalid response from server', e);
+    throw new Error('Invalid response from server');
+  }
 };
 
 function fetchWithGet<T, TResponse>(apiURI: string, params: T | null, queryOptions: QueryOptions): Promise<TResponse> {


### PR DESCRIPTION
Instead of a technical error, let's show "Invalid response from server" if the server sends invalid JSON. The actual error message is logged to the JS console.

## Screenshots

Before:
![Bildschirmfoto vom 2025-03-19 18-16-46](https://github.com/user-attachments/assets/aac4253b-d46d-4b54-8bcf-87f17df069b7)

After:
![Bildschirmfoto vom 2025-03-19 18-16-58](https://github.com/user-attachments/assets/9a455084-a2e9-4ad5-9421-60564468e435)
