### PR TITLE
upgrade cue version for the release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
           enable_npm: false
           enable_go: true
           enable_cue: true
+          cue_version: "v0.12.0"
       - name: Download archive
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
the cue version is not the correct one for the release. See https://github.com/perses/plugins/actions/runs/13968911933/job/39106844660