### PR TITLE
[BUGFIX]: Add sort and format options from Table cue to go-sdk

### DIFF
--- a/table/sdk/go/table.go
+++ b/table/sdk/go/table.go
@@ -39,15 +39,24 @@ const (
 	RightAlign  Align = "right"
 )
 
+type Sort string
+
+const (
+	AscSort  Sort = "asc"
+	DescSort Sort = "desc"
+)
+
 type ColumnSettings struct {
-	Name              string  `json:"name" yaml:"name"`
-	Header            string  `json:"header,omitempty" yaml:"header,omitempty"`
-	HeaderDescription string  `json:"headerDescription,omitempty" yaml:"headerDescription,omitempty"`
-	CellDescription   string  `json:"cellDescription,omitempty" yaml:"cellDescription,omitempty"`
-	Align             Align   `json:"align,omitempty" yaml:"align,omitempty"`
-	EnableSorting     bool    `json:"enableSorting,omitempty" yaml:"enableSorting,omitempty"`
-	Width             float64 `json:"width,omitempty" yaml:"width,omitempty"`
-	Hide              bool    `json:"hide,omitempty" yaml:"hide,omitempty"`
+	Name              string        `json:"name" yaml:"name"`
+	Header            string        `json:"header,omitempty" yaml:"header,omitempty"`
+	HeaderDescription string        `json:"headerDescription,omitempty" yaml:"headerDescription,omitempty"`
+	CellDescription   string        `json:"cellDescription,omitempty" yaml:"cellDescription,omitempty"`
+	Format            common.Format `json:"format,omitempty" yaml:"format,omitempty"`
+	Align             Align         `json:"align,omitempty" yaml:"align,omitempty"`
+	EnableSorting     bool          `json:"enableSorting,omitempty" yaml:"enableSorting,omitempty"`
+	Sort              Sort          `json:"sort,omitempty" yaml:"sort,omitempty"`
+	Width             float64       `json:"width,omitempty" yaml:"width,omitempty"`
+	Hide              bool          `json:"hide,omitempty" yaml:"hide,omitempty"`
 }
 
 type ValueConditionSpec struct {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This commit ports the sort and format options in Table columnSettings, from Cue to Go SDK.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).