### PR TITLE
(blocked) [IGNORE] Rely on stable version of Perses's CUE module

### DIFF
--- a/barchart/cue.mod/module.cue
+++ b/barchart/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/gaugechart/cue.mod/module.cue
+++ b/gaugechart/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/piechart/cue.mod/module.cue
+++ b/piechart/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/prometheus/cue.mod/module.cue
+++ b/prometheus/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/statchart/cue.mod/module.cue
+++ b/statchart/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/staticlistvariable/cue.mod/module.cue
+++ b/staticlistvariable/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/statushistorychart/cue.mod/module.cue
+++ b/statushistorychart/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/table/cue.mod/module.cue
+++ b/table/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/tempo/cue.mod/module.cue
+++ b/tempo/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }

--- a/timeserieschart/cue.mod/module.cue
+++ b/timeserieschart/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v:       "v0.0.2-test"
+		v:       "v0.51.0"
 		default: true
 	}
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

**Pending release v0.51.0 on perses/perses side.**

This PR changes the CUE module file of all plugins in order to stop depending on a manually-published version of the perses/perses schemas, to instead use the stable version published with the latest release.

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).