### PR TITLE
[BUGFIX] Tempo: Fix auto-completion with empty string values

### DIFF
--- a/tempo/src/components/complete.ts
+++ b/tempo/src/components/complete.ts
@@ -255,12 +255,12 @@ async function completeTagValue(client: TempoClient, tag: string): Promise<Compl
   for (const { type, value } of response.tagValues) {
     switch (type) {
       case 'string':
-        completions.push({ label: value ?? "", displayLabel: value ?? "(empty string)", apply: applyQuotedCompletion });
+        completions.push({ label: value ?? '', displayLabel: value ?? '(empty string)', apply: applyQuotedCompletion });
         break;
 
       case 'keyword':
       case 'int':
-        completions.push({ label: value ?? "", displayLabel: value ?? "(empty string)" });
+        completions.push({ label: value ?? '', displayLabel: value ?? '(empty string)' });
         break;
     }
   }

--- a/tempo/src/components/complete.ts
+++ b/tempo/src/components/complete.ts
@@ -255,12 +255,12 @@ async function completeTagValue(client: TempoClient, tag: string): Promise<Compl
   for (const { type, value } of response.tagValues) {
     switch (type) {
       case 'string':
-        completions.push({ label: value, apply: applyQuotedCompletion });
+        completions.push({ label: value ?? "", displayLabel: value ?? "(empty string)", apply: applyQuotedCompletion });
         break;
 
       case 'keyword':
       case 'int':
-        completions.push({ label: value });
+        completions.push({ label: value ?? "", displayLabel: value ?? "(empty string)" });
         break;
     }
   }

--- a/tempo/src/model/api-types.ts
+++ b/tempo/src/model/api-types.ts
@@ -130,5 +130,6 @@ export interface SearchTagValuesResponse {
 
 export interface SearchTagValue {
   type: string;
-  value: string;
+  /** The tag value. Empty strings are omitted (i.e. undefined) in the response. */
+  value?: string;
 }


### PR DESCRIPTION
# Description

The Tempo API omits empty string values in the response: https://github.com/grafana/tempo/blob/d1286af14613dd9b5da65f35b474b17895fb4be6/pkg/tempopb/tempo.pb.go#L1755

Fixed the response type and handled this case in the auto-completion.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).