### PR TITLE
[IGNORE] Relax react-router-dom dependency constraints

### DIFF
--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -39,6 +39,7 @@
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0",
     "react-hook-form": "^7.52.2",
+    "react-router-dom": "^5 || ^6 || ^7",
     "use-resize-observer": "^9.0.0"
   },
   "devDependencies": {

--- a/tempo/rsbuild.config.ts
+++ b/tempo/rsbuild.config.ts
@@ -56,7 +56,6 @@ export default defineConfig({
         '@hookform/resolvers': { singleton: true },
         '@tanstack/react-query': { singleton: true },
         'react-hook-form': { singleton: true },
-        'react-router-dom': { singleton: true },
       },
       dts: false,
       runtime: false,

--- a/tracetable/package.json
+++ b/tracetable/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.17.21",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0",
-    "react-router-dom": "^6.11.0",
+    "react-router-dom": "^5 || ^6 || ^7",
     "use-resize-observer": "^9.0.0"
   },
   "files": [

--- a/tracingganttchart/package.json
+++ b/tracingganttchart/package.json
@@ -34,6 +34,7 @@
     "lodash": "^4.17.21",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0",
+    "react-router-dom": "^5 || ^6 || ^7",
     "use-resize-observer": "^9.0.0"
   },
   "files": [

--- a/tracingganttchart/rsbuild.config.ts
+++ b/tracingganttchart/rsbuild.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
       shared: {
         react: { requiredVersion: '18.2.0', singleton: true },
         'react-dom': { requiredVersion: '18.2.0', singleton: true },
+        'react-router-dom': { singleton: true },
         echarts: { singleton: true },
         'date-fns': { singleton: true },
         'date-fns-tz': { singleton: true },


### PR DESCRIPTION
# Description

Almost any version of react-router-dom should be suitable for the use cases in the Prometheus, TraceTable and TracingGanttChart plugins.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).