### PR TITLE
[BREAKINGCHANGE] PieChart: remove useless attributes

### DIFF
--- a/piechart/schemas/pie.cue
+++ b/piechart/schemas/pie.cue
@@ -26,35 +26,12 @@ import (
 	values?: [...#legendValue]
 }
 
-#palette: {
-	mode: "auto" | "categorical"
-}
-
-#visual: {
-	display?:      "line" | "bar"
-	lineWidth?:    number & >=0.25 & <=3
-	areaOpacity?:  number & >=0 & <=1
-	showPoints?:   "auto" | "always"
-	palette?:      #palette
-	pointRadius?:  number & >=0 & <=6
-	stack?:        "all" | "percent" // TODO: percent option is disabled until support is added
-	connectNulls?: bool
-}
-
 kind: "PieChart"
 spec: close({
 	legend?:        #legend
-	querySettings?: #querySettings
 	calculation:    common.#calculation
 	format?:        common.#format
 	sort?:          "asc" | "desc"
 	mode?:          "value" | "percentage"
-	visual?:        #visual
 	radius:         number
 })
-
-#querySettings: [...{
-	queryIndex: int & >=0
-	colorMode:  "fixed" | "fixed-single"       // NB: "palette" could be added later
-	colorValue: =~"^#(?:[0-9a-fA-F]{3}){1,2}$" // hexadecimal color code
-}]

--- a/piechart/src/PieChartPanel.tsx
+++ b/piechart/src/PieChartPanel.tsx
@@ -27,16 +27,15 @@ import { CalculationType, CalculationsMap, DEFAULT_LEGEND, TimeSeriesData } from
 import { PanelProps, validateLegendSpec } from '@perses-dev/plugin-system';
 import merge from 'lodash/merge';
 import { ReactElement, useMemo, useRef, useState } from 'react';
-import { QuerySettingsOptions } from './model';
 import { getSeriesColor } from './palette-gen';
-import { DEFAULT_VISUAL, PieChartOptions } from './pie-chart-model';
+import { PieChartOptions } from './pie-chart-model';
 import { calculatePercentages, sortSeriesData } from './utils';
 
 export type PieChartPanelProps = PanelProps<PieChartOptions, TimeSeriesData>;
 
 export function PieChartPanel(props: PieChartPanelProps): ReactElement | null {
   const {
-    spec: { calculation, sort, mode, querySettings: querySettingsList },
+    spec: { calculation, sort, mode },
     contentDimensions,
     queryResults,
   } = props;
@@ -45,10 +44,6 @@ export function PieChartPanel(props: PieChartPanelProps): ReactElement | null {
   const PADDING = chartsTheme.container.padding.default;
   const chartId = useId('time-series-panel');
   const categoricalPalette = chartsTheme.echartsTheme.color;
-
-  const visual = useMemo(() => {
-    return merge({}, DEFAULT_VISUAL, props.spec.visual);
-  }, [props.spec.visual]);
 
   const { pieChartData, legendItems } = useMemo(() => {
     const calculate = CalculationsMap[calculation as CalculationType];
@@ -60,24 +55,10 @@ export function PieChartPanel(props: PieChartPanelProps): ReactElement | null {
 
       let seriesIndex = 0;
       for (const seriesData of result?.data.series ?? []) {
-        // Retrieve querySettings for this query, if exists.
-        // queries & querySettings indices do not necessarily match, so we have to check the tail value of the $ref attribute
-        let querySettings: QuerySettingsOptions | undefined;
-        for (const item of querySettingsList ?? []) {
-          if (item.queryIndex === queryIndex) {
-            querySettings = item;
-            // We don't break the loop here just in case there are multiple querySettings defined for the
-            // same queryIndex, because in that case we want the last one to take precedence.
-          }
-        }
         const seriesColor = getSeriesColor({
           categoricalPalette: categoricalPalette as string[],
-          visual,
           muiPrimaryColor: muiTheme.palette.primary.main,
           seriesName: seriesData.name,
-          seriesIndex,
-          querySettings: querySettings,
-          queryHasMultipleResults: (queryResults[queryIndex]?.data?.series?.length ?? 0) > 1,
         });
         const series = {
           value: calculate(seriesData.values) ?? null,
@@ -109,17 +90,7 @@ export function PieChartPanel(props: PieChartPanelProps): ReactElement | null {
       pieChartData: sortedPieChartData,
       legendItems,
     };
-  }, [
-    calculation,
-    sort,
-    mode,
-    queryResults,
-    categoricalPalette,
-    visual,
-    muiTheme.palette.primary.main,
-    chartId,
-    querySettingsList,
-  ]);
+  }, [calculation, sort, mode, queryResults, categoricalPalette, muiTheme.palette.primary.main, chartId]);
 
   const contentPadding = chartsTheme.container.padding.default;
   const adjustedContentDimensions: typeof contentDimensions = contentDimensions

--- a/piechart/src/palette-gen.ts
+++ b/piechart/src/palette-gen.ts
@@ -11,52 +11,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ChartVisualOptions, QuerySettingsOptions } from './model';
 import { getConsistentColor } from './palette';
 
 export interface SeriesColorProps {
   categoricalPalette: string[];
-  visual: ChartVisualOptions;
   muiPrimaryColor: string;
   seriesName: string;
-  seriesIndex: number;
-  querySettings?: QuerySettingsOptions;
-  queryHasMultipleResults?: boolean;
 }
 
 /**
  * Get line color as well as color for tooltip and legend, account for whether palette is 'categorical' or 'auto' aka generative
  */
 export function getSeriesColor(props: SeriesColorProps): string {
-  const {
-    categoricalPalette,
-    visual,
-    muiPrimaryColor,
-    seriesName,
-    seriesIndex,
-    querySettings,
-    queryHasMultipleResults,
-  } = props;
-
-  // Use color overrides defined in query settings in priority, if applicable
-  if (querySettings) {
-    if (querySettings.colorMode === 'fixed') {
-      return querySettings.colorValue;
-    } else if (querySettings.colorMode === 'fixed-single' && !queryHasMultipleResults) {
-      return querySettings.colorValue;
-    }
-  }
+  const { categoricalPalette, muiPrimaryColor, seriesName } = props;
 
   // Fallback is unlikely to set unless echarts theme palette in charts theme provider is undefined.
   const fallbackColor =
     Array.isArray(categoricalPalette) && categoricalPalette[0]
       ? (categoricalPalette[0] as string) // Needed since echarts color property isn't always an array.
       : muiPrimaryColor;
-
-  // Explicit way to always cycle through classical palette instead of changing when based on number of series.
-  if (visual.palette?.mode === 'categorical') {
-    return getCategoricalPaletteColor(categoricalPalette, seriesIndex, fallbackColor);
-  }
 
   return getAutoPaletteColor(seriesName, fallbackColor);
 }

--- a/piechart/src/pie-chart-model.ts
+++ b/piechart/src/pie-chart-model.ts
@@ -15,81 +15,22 @@ import { ModeOption, SortOption } from '@perses-dev/components';
 import { CalculationType, DEFAULT_CALCULATION, Definition, FormatOptions } from '@perses-dev/core';
 import { LegendSpecOptions, OptionsEditorProps } from '@perses-dev/plugin-system';
 
-import { QuerySettingsOptions, StackOptions } from './model';
-
-export const DEFAULT_CONNECT_NULLS = false;
-export const POINT_SIZE_OFFSET = 1.5;
 export const DEFAULT_FORMAT: FormatOptions = { unit: 'decimal', shortValues: true };
 export const DEFAULT_SORT: SortOption = 'desc';
 export const DEFAULT_MODE: ModeOption = 'value';
-export const DEFAULT_LINE_WIDTH = 1.25;
-export const DEFAULT_AREA_OPACITY = 0;
-export const DEFAULT_POINT_RADIUS = DEFAULT_LINE_WIDTH + POINT_SIZE_OFFSET;
-
-export const VISUAL_CONFIG = {
-  lineWidth: {
-    label: 'Line Width',
-    testId: 'slider-line-width',
-    min: 0.25,
-    max: 3,
-    step: 0.25,
-  },
-  pointRadius: {
-    label: 'Point Radius',
-    testId: 'slider-point-radius',
-    min: 0,
-    max: 6,
-    step: 0.25,
-  },
-  areaOpacity: {
-    label: 'Area Opacity',
-    testId: 'slider-area-opacity',
-    min: 0,
-    max: 1,
-    step: 0.05,
-  },
-  stack: {
-    label: 'Stack Series',
-  },
-  connectNulls: {
-    label: 'Connect Nulls',
-  },
-};
 
 export interface BarChartDefinition extends Definition<PieChartOptions> {
   kind: 'PieChart';
 }
-export const DEFAULT_VISUAL: PieChartVisualOptions = {
-  lineWidth: DEFAULT_LINE_WIDTH,
-  areaOpacity: DEFAULT_AREA_OPACITY,
-  pointRadius: DEFAULT_POINT_RADIUS,
-  connectNulls: DEFAULT_CONNECT_NULLS,
-};
-export interface PieChartPaletteOptions {
-  mode: 'auto' | 'categorical';
-}
 
 export interface PieChartOptions {
   legend?: LegendSpecOptions;
-  visual?: PieChartVisualOptions;
-  querySettings?: QuerySettingsOptions[];
   calculation: CalculationType;
   radius: number;
   format?: FormatOptions;
   sort?: SortOption;
   mode?: ModeOption;
 }
-
-export type PieChartVisualOptions = {
-  display?: 'line' | 'bar';
-  lineWidth?: number;
-  areaOpacity?: number;
-  showPoints?: 'auto' | 'always';
-  palette?: PieChartPaletteOptions;
-  pointRadius?: number;
-  stack?: StackOptions;
-  connectNulls?: boolean;
-};
 
 export type PieChartOptionsEditorProps = OptionsEditorProps<PieChartOptions>;
 
@@ -100,6 +41,5 @@ export function createInitialPieChartOptions(): PieChartOptions {
     radius: 50,
     sort: DEFAULT_SORT,
     mode: DEFAULT_MODE,
-    visual: DEFAULT_VISUAL,
   };
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Closes https://github.com/perses/perses/issues/2786. Technically a breaking change but shouldn't cause any issue anyway since these attributes were completely useless here.

# Screenshots

(No impact)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).