### PR TITLE
[IGNORE] relax @mui/x-data-grid dependency requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16747,6 +16747,7 @@
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0",
         "react-hook-form": "^7.52.2",
+        "react-router-dom": "^5 || ^6 || ^7",
         "use-resize-observer": "^9.0.0"
       }
     },
@@ -17209,7 +17210,7 @@
       "name": "@perses-dev/trace-table-plugin",
       "version": "0.6.0",
       "dependencies": {
-        "@mui/x-data-grid": "^7.23.1"
+        "@mui/x-data-grid": "^7.20.0"
       },
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -17224,7 +17225,7 @@
         "lodash": "^4.17.21",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0",
-        "react-router-dom": "^6.11.0",
+        "react-router-dom": "^5 || ^6 || ^7",
         "use-resize-observer": "^9.0.0"
       }
     },
@@ -17250,6 +17251,7 @@
         "lodash": "^4.17.21",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0",
+        "react-router-dom": "^5 || ^6 || ^7",
         "use-resize-observer": "^9.0.0"
       }
     },

--- a/tracetable/package.json
+++ b/tracetable/package.json
@@ -16,7 +16,7 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@mui/x-data-grid": "^7.23.1"
+    "@mui/x-data-grid": "^7.20.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",


### PR DESCRIPTION
# Description

relax @mui/x-data-grid dependency requirement, because v7.21.0 introduced a bug: https://github.com/mui/mui-x/issues/17428

# Screenshots

no visible UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).