### PR TITLE
[IGNORE] Tempo: add limit and maxStaleValues params to SearchTags API

### DIFF
--- a/tempo/src/model/api-types.ts
+++ b/tempo/src/model/api-types.ts
@@ -94,6 +94,8 @@ export interface SearchTagsRequestParameters {
   q?: string;
   start?: number;
   end?: number;
+  limit?: number;
+  maxStaleValues?: number;
 }
 
 /**
@@ -118,6 +120,8 @@ export interface SearchTagValuesRequestParameters {
   q?: string;
   start?: number;
   end?: number;
+  limit?: number;
+  maxStaleValues?: number;
 }
 
 /**


### PR DESCRIPTION
# Description

The Tempo API got two new, optional parameters `limit` and `maxStaleValues`:
https://grafana.com/docs/tempo/latest/api_docs/#search-tag-values-v2

I'll make use of them in a follow-up PR for the auto-completion of the TraceQL editor.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).