### PR TITLE
[BUGFIX] Tempo: cleanup search params in API calls

### DIFF
--- a/tempo/src/model/tempo-client.test.ts
+++ b/tempo/src/model/tempo-client.test.ts
@@ -17,11 +17,15 @@ import {
   MOCK_SEARCH_RESPONSE_VPARQUET4,
   MOCK_TRACE_RESPONSE,
 } from '../test';
-import { searchWithFallback } from './tempo-client';
+import { searchTagValues, searchWithFallback } from './tempo-client';
 
 const fetchMock = (global.fetch = jest.fn());
 
 describe('tempo-client', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
   it('should return query results as-is when serviceStats are present', async () => {
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(MOCK_SEARCH_RESPONSE_VPARQUET4) });
 
@@ -54,5 +58,12 @@ describe('tempo-client', () => {
       postgres: { spanCount: 1 },
       'shop-backend': { spanCount: 4 },
     });
+  });
+
+  it('formats the search params and ignores undefined values', async () => {
+    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+
+    await searchTagValues({ tag:"name", q: '{}', start: 10, end: undefined }, { datasourceUrl: '' });
+    expect(fetchMock).toHaveBeenCalledWith("/api/v2/search/tag/name/values?q=%7B%7D&start=10", {"headers": {}, "method": "GET"});
   });
 });

--- a/tempo/src/model/tempo-client.test.ts
+++ b/tempo/src/model/tempo-client.test.ts
@@ -63,7 +63,10 @@ describe('tempo-client', () => {
   it('formats the search params and ignores undefined values', async () => {
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
 
-    await searchTagValues({ tag:"name", q: '{}', start: 10, end: undefined }, { datasourceUrl: '' });
-    expect(fetchMock).toHaveBeenCalledWith("/api/v2/search/tag/name/values?q=%7B%7D&start=10", {"headers": {}, "method": "GET"});
+    await searchTagValues({ tag: 'name', q: '{}', start: 10, end: undefined }, { datasourceUrl: '' });
+    expect(fetchMock).toHaveBeenCalledWith('/api/v2/search/tag/name/values?q=%7B%7D&start=10', {
+      headers: {},
+      method: 'GET',
+    });
   });
 });


### PR DESCRIPTION
# Description

Sanitize search params, i.e. do not send `?param=undefined` to the Tempo API.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).