### PR TITLE
[ENHANCEMENT] Tempo TraceQL Editor: account for selected time range for auto-completions

### DIFF
--- a/tempo/src/components/TraceQLEditor.tsx
+++ b/tempo/src/components/TraceQLEditor.tsx
@@ -18,16 +18,16 @@ import { isValidTraceId } from '@perses-dev/core';
 import { CompletionConfig, TraceQLExtension } from './TraceQLExtension';
 
 export interface TraceQLEditorProps extends Omit<ReactCodeMirrorProps, 'theme' | 'extensions'> {
-  completeConfig: CompletionConfig;
+  completionConfig: CompletionConfig;
 }
 
-export function TraceQLEditor({ completeConfig, ...rest }: TraceQLEditorProps): ReactElement {
+export function TraceQLEditor({ completionConfig, ...rest }: TraceQLEditorProps): ReactElement {
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
 
   const traceQLExtension = useMemo(() => {
-    return TraceQLExtension(completeConfig);
-  }, [completeConfig]);
+    return TraceQLExtension(completionConfig);
+  }, [completionConfig]);
 
   const codemirrorTheme = useMemo(() => {
     // https://github.com/mui/material-ui/blob/v5.16.7/packages/mui-material/src/OutlinedInput/OutlinedInput.js#L43

--- a/tempo/src/plugins/tempo-trace-query/TempoTraceQueryEditor.tsx
+++ b/tempo/src/plugins/tempo-trace-query/TempoTraceQueryEditor.tsx
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DatasourceSelect, DatasourceSelectProps, useDatasourceClient } from '@perses-dev/plugin-system';
+import { DatasourceSelect, DatasourceSelectProps, useDatasourceClient, useTimeRange } from '@perses-dev/plugin-system';
 import { useId } from '@perses-dev/components';
 import { produce } from 'immer';
 import { FormControl, InputLabel, Stack, TextField } from '@mui/material';
-import { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 import {
   DEFAULT_TEMPO,
   isDefaultTempoSelector,
@@ -33,6 +33,10 @@ export function TempoTraceQueryEditor(props: TraceQueryEditorProps): ReactElemen
   const datasourceSelectLabelID = useId('tempo-datasource-label'); // for panels with multiple queries, this component is rendered multiple times on the same page
 
   const { data: client } = useDatasourceClient<TempoClient>(selectedDatasource);
+  const { timeRange } = useTimeRange();
+  const completionConfig = useMemo(() => {
+    return { client, timeRange };
+  }, [client, timeRange]);
 
   const { query, handleQueryChange, handleQueryBlur } = useQueryState(props);
   const { limit, handleLimitChange, handleLimitBlur, limitHasError } = useLimitState(props);
@@ -69,7 +73,7 @@ export function TempoTraceQueryEditor(props: TraceQueryEditorProps): ReactElemen
       </FormControl>
       <Stack direction="row" spacing={2}>
         <TraceQLEditor
-          completeConfig={{ client }}
+          completionConfig={completionConfig}
           value={query}
           onChange={handleQueryChange}
           onBlur={handleQueryBlur}


### PR DESCRIPTION
# Description

Tempo TraceQL Editor: account for selected time range for auto-completions.
Otherwise, by default, only tag values of the last 15 minutes or so are shown.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).