### PR TITLE
[IGNORE] bump to latest Perses, cleanup dependencies

### DIFF
--- a/barchart/package.json
+++ b/barchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/bar-chart-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -19,9 +19,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/datasourcevariable/package.json
+++ b/datasourcevariable/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perses-dev/datasource-variable-plugin",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",
@@ -9,16 +9,13 @@
     "test": "cross-env LC_ALL=C TZ=UTC jest --passWithNoTests",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "@module-federation/enhanced": "^0.8.9"
-  },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/gaugechart/package.json
+++ b/gaugechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/gauge-chart-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -12,13 +12,16 @@
     "test": "cross-env LC_ALL=C TZ=UTC jest",
     "type-check": "tsc --noEmit"
   },
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/histogramchart/package.json
+++ b/histogramchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/histogram-chart",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build",
@@ -8,16 +8,13 @@
     "test": "cross-env LC_ALL=C TZ=UTC jest",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "@module-federation/enhanced": "^0.8.9",
-    "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-    "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-    "@perses-dev/plugin-system": "0.0.0-snapshot-histogram-types-78c5104"
-  },
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "peerDependencies": {
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "echarts": "5.5.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2 || ^18.0.0",

--- a/markdown/package.json
+++ b/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/markdown-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -23,9 +23,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,14 +68,14 @@
     },
     "barchart": {
       "name": "@perses-dev/bar-chart-plugin",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -88,17 +88,14 @@
     },
     "datasourcevariable": {
       "name": "@perses-dev/datasource-variable-plugin",
-      "version": "0.1.0",
-      "dependencies": {
-        "@module-federation/enhanced": "^0.8.9"
-      },
+      "version": "0.1.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -110,14 +107,14 @@
     },
     "gaugechart": {
       "name": "@perses-dev/gauge-chart-plugin",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -130,101 +127,21 @@
     },
     "histogramchart": {
       "name": "@perses-dev/histogram-chart",
-      "version": "0.7.1",
-      "dependencies": {
-        "@module-federation/enhanced": "^0.8.9",
-        "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/plugin-system": "0.0.0-snapshot-histogram-types-78c5104"
-      },
+      "version": "0.7.2",
       "peerDependencies": {
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "echarts": "5.5.0",
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "histogramchart/node_modules/@perses-dev/components": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-9Yz9v/3nedQE4iuH381qENzn6xzndO0fDyzcDRL6KO+l1We72t/l4y3++JGIF0FNleg2ofd4jA26OsUlNauztA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
-        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
-        "@codemirror/lang-json": "^6.0.1",
-        "@fontsource/lato": "^4.5.10",
-        "@mui/x-date-pickers": "^7.23.1",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "@tanstack/react-table": "^8.20.5",
-        "@uiw/react-codemirror": "^4.19.1",
-        "date-fns": "^4.1.0",
-        "date-fns-tz": "^3.2.0",
-        "echarts": "5.5.0",
-        "lodash": "^4.17.21",
-        "mathjs": "^10.6.4",
-        "mdi-material-ui": "^7.9.2",
-        "notistack": "^3.0.2",
-        "react-colorful": "^5.6.1",
-        "react-error-boundary": "^3.1.4",
-        "react-hook-form": "^7.51.3",
-        "react-virtuoso": "^4.12.2",
-        "zod": "^3.21.4"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.1.10",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "histogramchart/node_modules/@perses-dev/core": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-8S+cudUxQdz0SQdup0TV0K2VgJnl0ICEA1vBE9LLWw5U5vChp0hWYPv2TbONwuRjrBxALHRGJyNrJzu8yq/9og==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-fns": "^4.1.0",
-        "lodash": "^4.17.21",
-        "mathjs": "^10.6.4",
-        "numbro": "^2.3.6",
-        "zod": "^3.21.4"
-      },
-      "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "histogramchart/node_modules/@perses-dev/plugin-system": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-aFG1ZqFlZjJVsMVCFVlLQO35xg+aX/yTnXpz3WW6tBPBXKIRa8csfWLXQffmyk1HCiOsYT8/4SmQ4WWlHFAZ5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@module-federation/enhanced": "^0.8.9",
-        "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "date-fns": "^4.1.0",
-        "date-fns-tz": "^3.2.0",
-        "immer": "^10.1.1",
-        "react-hook-form": "^7.46.1",
-        "use-immer": "^0.11.0",
-        "use-query-params": "^2.1.2",
-        "zod": "^3.22.2"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.1.10",
-        "@tanstack/react-query": "^5.64.2",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "markdown": {
       "name": "@perses-dev/markdown-plugin",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "dompurify": "^3.2.3",
         "marked": "^15.0.6"
@@ -233,9 +150,9 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -435,6 +352,7 @@
       "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.5.2.tgz",
       "integrity": "sha512-fDuTwlDD11r3ev5tLJ6JnzQUiG9v77c8zGcNdO7RRNtZZbOHam8CFhmyFGY4E/mLjvgYng0UkcyCrSBc4FXYZw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "bind-event-listener": "^3.0.0",
@@ -446,6 +364,7 @@
       "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.0.3.tgz",
       "integrity": "sha512-/Sbu/HqN2VGLYBhnsG7SbRNg98XKkbF6L7XDdBi+izRybfaK1FeMfodPpm/xnBHPJzwYMdkE0qtLyv6afhgMUA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.1.0",
         "@babel/runtime": "^7.0.0"
@@ -986,6 +905,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.0.tgz",
       "integrity": "sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.4.0",
@@ -998,6 +918,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
       "integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
@@ -1022,6 +943,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.4.tgz",
       "integrity": "sha512-u4q7PnZlJUojeRe8FJa/njJcMctISGgPQ4PnWsd9268R4ZTtU+tfFYmwkBvgcrK2+QQ8tYFVALVb5fVJykKc5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
@@ -1033,6 +955,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.10.tgz",
       "integrity": "sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1053,6 +976,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.2.tgz",
       "integrity": "sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -1787,7 +1711,8 @@
       "version": "4.5.10",
       "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
       "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@grafana/lezer-traceql": {
       "version": "0.0.20",
@@ -2379,7 +2304,8 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@lezer/common": {
       "version": "1.2.3",
@@ -2401,6 +2327,7 @@
       "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
       "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -2857,6 +2784,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.8.12.tgz",
       "integrity": "sha512-fiSf9Df4RqdKiL1WtS7eCqAWqDnLNwMZ9qU7ZMjXSAhI3wOLzycFflpVx7PWOxSoTJPtc61hwD5lkEpNoHezkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/sdk": "0.8.12",
         "@types/semver": "7.5.8",
@@ -2868,6 +2796,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
       "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
@@ -2877,6 +2806,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.17.6"
       }
@@ -2886,6 +2816,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3100,6 +3031,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.8.12.tgz",
       "integrity": "sha512-YjCk6KPBQ4Ml2/2aIKQt11I4jBKOTvK3xHyAQMKPpX5aBbMEwonDhkpTitygUw3SMBdi3CP1KMRDJ3suj3O6Mg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.8.12",
         "@module-federation/sdk": "0.8.12",
@@ -3114,13 +3046,15 @@
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.12.tgz",
       "integrity": "sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/runtime": {
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.12.tgz",
       "integrity": "sha512-eYohRfambj/qzxz6tEakDn459ROcixWO4zL5gmTEOmwG+jCDnxGR14j1guopyrrpjb6EKFNrPVWtYZTPPfGdQQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.8.12",
         "@module-federation/runtime-core": "0.6.20",
@@ -3132,6 +3066,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
       "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
@@ -3141,6 +3076,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.17.6"
       }
@@ -3150,6 +3086,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.8.12.tgz",
       "integrity": "sha512-BhRZsG68XtGzKM0N02/3ldiW+PTc+QaHCMNyiZnk3GcxS0qe6USu7fTQwRIPCC2GONIdoHD+GVYPN/NJWjbTFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.8.12",
         "@module-federation/managers": "0.8.12",
@@ -3182,13 +3119,15 @@
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.12.tgz",
       "integrity": "sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@module-federation/dts-plugin/node_modules/@module-federation/sdk": {
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
       "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
@@ -3198,6 +3137,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3211,6 +3151,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.17.6"
       }
@@ -3220,6 +3161,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3241,6 +3183,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.8.12.tgz",
       "integrity": "sha512-uJODfWqL3C87LUu1E0ZLPRqE0sUt6QFH97bMFoCWYhkf8JS7J+wMc4KSc31ApaJs7CeQICXR1CYBAZDSdxkrOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "0.8.12",
         "@module-federation/data-prefetch": "0.8.12",
@@ -3276,13 +3219,15 @@
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.12.tgz",
       "integrity": "sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@module-federation/enhanced/node_modules/@module-federation/inject-external-runtime-core-plugin": {
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.8.12.tgz",
       "integrity": "sha512-/vFW+eiBiqXOKkDYVKl5JXGI0H4Whj10P8JadowxuHcEuR+R7kkXXauYuGYKaxIFqG4zbN3r9su2qxIEEqOsOw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@module-federation/runtime-tools": "0.8.12"
       }
@@ -3292,6 +3237,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.8.12.tgz",
       "integrity": "sha512-G73Cq7VwKdpFZwMd9hEBsE2HLF7mNQEIvLSiW6HOZG/+iWRRED1opiVkrjOmkcg770rChYSqTBiLvUS7HDT5Ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "0.8.12",
         "@module-federation/dts-plugin": "0.8.12",
@@ -3320,6 +3266,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.12.tgz",
       "integrity": "sha512-eYohRfambj/qzxz6tEakDn459ROcixWO4zL5gmTEOmwG+jCDnxGR14j1guopyrrpjb6EKFNrPVWtYZTPPfGdQQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.8.12",
         "@module-federation/runtime-core": "0.6.20",
@@ -3331,6 +3278,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.12.tgz",
       "integrity": "sha512-H97wR/toSU9+UO9S0VHLmPg/7QgohMI52EZlR0Kh0F4PD6fbiWuO4kBIp7R6g0dMI9D4NVKWTKV8xA9ASU+k7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.8.12",
         "@module-federation/webpack-bundler-runtime": "0.8.12"
@@ -3341,6 +3289,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
       "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
@@ -3350,6 +3299,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.12.tgz",
       "integrity": "sha512-zd343RO7/R7Xjh5ym5KdnYQ70z4LBmMxWsa44FS0nyNv04sOq6V1eZSCGKbEhbfqqhbS5Wfj8OzJyedeVvV/OQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.8.12",
         "@module-federation/sdk": "0.8.12"
@@ -3360,6 +3310,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.17.6"
       }
@@ -3384,6 +3335,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.8.12.tgz",
       "integrity": "sha512-+BBdBMptHiiT2ZsfPovQuHYkse6R1+dmDS6bAinw3UGpb418W8ERp5I4jHeyhEtr3t3mb/dh4sAsYM14/EWJ9Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/sdk": "0.8.12",
         "find-pkg": "2.0.0",
@@ -3395,6 +3347,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
       "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
@@ -3404,6 +3357,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.17.6"
       }
@@ -3413,6 +3367,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.8.12.tgz",
       "integrity": "sha512-UwC6/QK37x7Xr5K+89iKxOy/uQHqFMd49axOhgDmFSrWQOULFQd51EpTOxFXgwZfiq/h0uVBYq/c0GB3Tdu8GA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/dts-plugin": "0.8.12",
         "@module-federation/managers": "0.8.12",
@@ -3426,6 +3381,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
       "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
@@ -3435,6 +3391,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3448,6 +3405,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.17.6"
       }
@@ -4011,6 +3969,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.20.tgz",
       "integrity": "sha512-rX7sd/i7tpkAbfMD4TtFt/57SWNC/iv7UYS8g+ad7mnCJggWE1YEKsKSFgcvp4zU3thwR+j2y+kOCwd1sQvxEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.8.12",
         "@module-federation/sdk": "0.8.12"
@@ -4020,13 +3979,15 @@
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.12.tgz",
       "integrity": "sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@module-federation/runtime-core/node_modules/@module-federation/sdk": {
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
       "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
@@ -4036,6 +3997,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.7.tgz",
       "integrity": "sha512-n6/XnKnZ5eLEj6VllG4XmamXG7/F69nls8dcynHyhcTpsPUYgcgx4ifEaCo4lQJ2uzwfmIT+F0KBGwBcMKmt5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.17.6"
       }
@@ -4071,6 +4033,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.8.12.tgz",
       "integrity": "sha512-+ZO5XpBwEhP9v/Tqk51YgswwbAzj4TXKZ54++uVDsLnOh9yydVGJ/b5pQcSrc8B1C55+498tsDEcNsFgZODgMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-pkg": "2.0.0",
         "fs-extra": "9.1.0",
@@ -4082,6 +4045,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -4369,6 +4333,7 @@
       "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.28.0.tgz",
       "integrity": "sha512-m1bfkZLOw3cMogeh6q92SjykVmLzfptnz3ZTgAlFKV7UBnVFuGUITvmwbgTZ1Mz3FmLVnGUQYUpZWw0ZnoghNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
@@ -4787,10 +4752,9 @@
       "link": true
     },
     "node_modules/@perses-dev/components": {
-      "version": "0.51.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.51.0-beta.1.tgz",
-      "integrity": "sha512-J9/T3WJM+f17aA87AE1UakfyUDkXOlM9DT0hmSLgaxC+4xShnzkR6EH7WFv8U6dJMjC7XBbnIaDmdGKxUTXLkA==",
-      "license": "Apache-2.0",
+      "version": "0.51.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.51.0-rc.0.tgz",
+      "integrity": "sha512-rHg4t+gf9ZwrlJXglhYMSBC9iigYjmFOOjptL6CDzC3prEJp6J4W+M97qmCFWWsZksGmjBJhEn6IgFHrN2Oy+Q==",
       "peer": true,
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
@@ -4798,7 +4762,7 @@
         "@codemirror/lang-json": "^6.0.1",
         "@fontsource/lato": "^4.5.10",
         "@mui/x-date-pickers": "^7.23.1",
-        "@perses-dev/core": "0.51.0-beta.1",
+        "@perses-dev/core": "0.51.0-rc.0",
         "@tanstack/react-table": "^8.20.5",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^4.1.0",
@@ -4821,10 +4785,9 @@
       }
     },
     "node_modules/@perses-dev/core": {
-      "version": "0.51.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.51.0-beta.1.tgz",
-      "integrity": "sha512-XukFiD1A+gzV1Lpyi4jUQubtuoEXgBdU2B8VOwE6p7r4qg7gsIczd7/ubEZGetK6KApAzYPm3CFMng8FWMYRzA==",
-      "license": "Apache-2.0",
+      "version": "0.51.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.51.0-rc.0.tgz",
+      "integrity": "sha512-RKb5faHrx1RAEW5NziStiemPkfJzBiglSmX6IkcNr4IcMa2IDfDX968Ey92i0/DeRop8gu5VE8vc292wA0p64Q==",
       "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
@@ -4839,15 +4802,14 @@
       }
     },
     "node_modules/@perses-dev/dashboards": {
-      "version": "0.51.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.51.0-beta.1.tgz",
-      "integrity": "sha512-eHeRMkg6hRJYZEDngZwjD4r2c9Qk6hNCwk0XOeThGe5s4lSksCqq4dbGi8GSPD0q99KjVD/jaa4ZhevDufx7rQ==",
-      "license": "Apache-2.0",
+      "version": "0.51.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.51.0-rc.0.tgz",
+      "integrity": "sha512-uulxQGRpOH4cbMPPMa5xQMb6+Zz9D+6LnpHwxyT6coAi05dlmIB+RJLY1gPd+TxzMbQ75qvKjrU9I2zOgpgjXQ==",
       "peer": true,
       "dependencies": {
-        "@perses-dev/components": "0.51.0-beta.1",
-        "@perses-dev/core": "0.51.0-beta.1",
-        "@perses-dev/plugin-system": "0.51.0-beta.1",
+        "@perses-dev/components": "0.51.0-rc.0",
+        "@perses-dev/core": "0.51.0-rc.0",
+        "@perses-dev/plugin-system": "0.51.0-rc.0",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^4.1.0",
         "immer": "^10.1.1",
@@ -4873,17 +4835,16 @@
       "link": true
     },
     "node_modules/@perses-dev/explore": {
-      "version": "0.51.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.51.0-beta.1.tgz",
-      "integrity": "sha512-XpPOgtp74Q/I8eUFIubzlDYMLRX/axjd1LSvkhwsH/CtnSu6+4sYwAfwTqRCOXUFMDuC9PDYcsONYe+HYsWuWQ==",
-      "license": "Apache-2.0",
+      "version": "0.51.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.51.0-rc.0.tgz",
+      "integrity": "sha512-0dcy3lqFNEfYi+j9W7zgWea/Q9Ob4hXY+V2wp9034xa21wN0xdINnk+uZwwv/zUQr1Bg7wPlvlAyDj4tG638jw==",
       "peer": true,
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
-        "@perses-dev/components": "0.51.0-beta.1",
-        "@perses-dev/core": "0.51.0-beta.1",
-        "@perses-dev/dashboards": "0.51.0-beta.1",
-        "@perses-dev/plugin-system": "0.51.0-beta.1",
+        "@perses-dev/components": "0.51.0-rc.0",
+        "@perses-dev/core": "0.51.0-rc.0",
+        "@perses-dev/dashboards": "0.51.0-rc.0",
+        "@perses-dev/plugin-system": "0.51.0-rc.0",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^4.1.0",
         "immer": "^10.1.1",
@@ -4922,15 +4883,14 @@
       "link": true
     },
     "node_modules/@perses-dev/plugin-system": {
-      "version": "0.51.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.51.0-beta.1.tgz",
-      "integrity": "sha512-dsWBl7bE8uG0ZHRTxyvf/IVzPEh8ggGJ1u2GiFIzPTcIGvNh/+3mTBBzvKeQQG0Mgm8ZyrX6Bx7oX9phvmRaLA==",
-      "license": "Apache-2.0",
+      "version": "0.51.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.51.0-rc.0.tgz",
+      "integrity": "sha512-ox2VZWx46ekczDaG9aopSnixUnhIi1dRKrJbBLl0Y+1/WrM77B01vZ3SsF3u3Nvx0onNqIG9t01mafi6vWG14A==",
       "peer": true,
       "dependencies": {
         "@module-federation/enhanced": "^0.8.9",
-        "@perses-dev/components": "0.51.0-beta.1",
-        "@perses-dev/core": "0.51.0-beta.1",
+        "@perses-dev/components": "0.51.0-rc.0",
+        "@perses-dev/core": "0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "immer": "^10.1.1",
@@ -5961,6 +5921,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.2.tgz",
       "integrity": "sha512-11tNlEDTdIhMJba2RBH+ecJ9l1zgS2kjmexDPAraulc8jeNA4xocSNeyzextT0XJyASil4XsCYlJmf5jEWAtYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/table-core": "8.21.2"
       },
@@ -5981,6 +5942,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.2.tgz",
       "integrity": "sha512-uvXk/U4cBiFMxt+p9/G7yUWI/UbHYbyghLCjlpWZ3mLeIZiUBSKcUnw9UnKkdRz7Z/N4UBuFLWQdJCjUe7HjvA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6416,6 +6378,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6436,6 +6399,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.5.tgz",
       "integrity": "sha512-WH/po1gcEcoR6y857yAnPGug+ZhkF4PaTUxgAbwfeSH/QOgVSakKHBXoPGad/sEznmkiaK3pqHk+etdWisoeBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -6445,6 +6409,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*"
       }
@@ -6715,6 +6680,7 @@
       "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.23.10.tgz",
       "integrity": "sha512-zpbmSeNs3OU/f/Eyd6brFnjsBUYwv2mFjWxlAsIRSwTlW+skIT60rQHFBSfsj/5UVSxSLWVeUYczN7AyXvgTGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -6742,6 +6708,7 @@
       "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.23.10.tgz",
       "integrity": "sha512-AbN4eVHOL4ckRuIXpZxkzEqL/1ChVA+BSdEnAKjIB68pLQvKsVoYbiFP8zkXkYc4+Fcgq5KbAjvYqdo4ewemKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
@@ -7577,6 +7544,7 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -7618,7 +7586,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
       "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -8006,6 +7975,7 @@
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
       "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -8073,6 +8043,7 @@
       "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
       "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       },
@@ -8258,7 +8229,8 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",
@@ -8344,7 +8316,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8427,6 +8400,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -8437,6 +8411,7 @@
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
       "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "date-fns": "^3.0.0 || ^4.0.0"
       }
@@ -8694,6 +8669,7 @@
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -8741,6 +8717,7 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
       "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "5.5.0"
@@ -8750,7 +8727,8 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -9058,7 +9036,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
       "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -9822,7 +9801,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
       "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -10188,6 +10168,7 @@
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       },
@@ -10541,6 +10522,7 @@
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
       "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "csstype": "^3.0.10"
       }
@@ -10921,6 +10903,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -11613,7 +11596,8 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest": {
       "version": "29.7.0",
@@ -12758,6 +12742,7 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.3.tgz",
       "integrity": "sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
@@ -12811,6 +12796,7 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -12820,6 +12806,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -12836,6 +12823,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12845,6 +12833,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13078,6 +13067,7 @@
       "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.6.4.tgz",
       "integrity": "sha512-omQyvRE1jIy+3k2qsqkWASOcd45aZguXZDckr3HtnTYyXk5+2xpVfC3kATgbO2Srjxlqww3TVdhD0oUdZ/hiFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "complex.js": "^2.1.1",
@@ -13101,6 +13091,7 @@
       "resolved": "https://registry.npmjs.org/mdi-material-ui/-/mdi-material-ui-7.9.3.tgz",
       "integrity": "sha512-l56RUX0tnxY+U1z6hE3cHKXwGUIGpHJLiW2papfvTB1qTegpn3iYU6sX+XBPtl+KG7Ww2RqCLAT03CNzOqeoIg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@mui/material": "^5.0.0 || ^6.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -13335,6 +13326,7 @@
       "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
       "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clsx": "^1.1.0",
         "goober": "^2.0.33"
@@ -13357,6 +13349,7 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13379,6 +13372,7 @@
       "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.5.0.tgz",
       "integrity": "sha512-xDcctDimhzko/e+y+Q2/8i3qNC9Svw1QgOkSkQoO0kIPI473tR9QRbo2KP88Ty9p8WbPy+3OpTaAIzehtuHq+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bignumber.js": "^8 || ^9"
       },
@@ -14112,7 +14106,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rambda": {
       "version": "9.4.2",
@@ -14164,6 +14159,7 @@
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
@@ -14188,6 +14184,7 @@
       "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
       "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clsx": "^1.1.1",
         "prop-types": "^15.8.1"
@@ -14202,6 +14199,7 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14211,6 +14209,7 @@
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
       "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -14227,6 +14226,7 @@
       "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.1.tgz",
       "integrity": "sha512-4Fr+kKMk0+m1HL/BWfHxi/lRuaOmDNNKQDcu7m12+NEYcen20wIuZFo789u3qWCyvUsNUxCiyf0eKq4WiJSNYw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0",
         "fast-equals": "^4.0.3",
@@ -14245,6 +14245,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14261,6 +14262,7 @@
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
       "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -14293,6 +14295,7 @@
       "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.5.tgz",
       "integrity": "sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prop-types": "15.x",
         "react-draggable": "^4.0.3"
@@ -14340,6 +14343,7 @@
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -14452,7 +14456,8 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -14798,7 +14803,8 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/seek-bzip": {
       "version": "2.0.0",
@@ -14918,7 +14924,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
       "integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
@@ -15651,7 +15658,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.12",
@@ -16144,6 +16152,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.1.0.tgz",
       "integrity": "sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ==",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -16296,6 +16305,7 @@
       "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.11.0.tgz",
       "integrity": "sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "immer": ">=8.0.0",
         "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
@@ -16306,6 +16316,7 @@
       "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.2.1.tgz",
       "integrity": "sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "serialize-query-params": "^2.0.2"
       },
@@ -16329,6 +16340,7 @@
       "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
       "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1"
       },
@@ -16690,6 +16702,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16776,6 +16789,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -16785,6 +16799,7 @@
       "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
       "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -16793,13 +16808,15 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/zustand": {
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.6.tgz",
       "integrity": "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "use-sync-external-store": "^1.2.2"
       },
@@ -16825,14 +16842,14 @@
     },
     "piechart": {
       "name": "@perses-dev/pie-chart-plugin",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -16845,12 +16862,13 @@
     },
     "prometheus": {
       "name": "@perses-dev/prometheus-plugin",
-      "version": "0.51.0-rc.0",
+      "version": "0.51.0-rc.1",
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
         "@prometheus-io/codemirror-promql": "^0.45.6",
         "color-hash": "^2.0.2",
-        "qs": "^6.13.0"
+        "qs": "^6.13.0",
+        "react-virtuoso": "^4.12.2"
       },
       "devDependencies": {
         "@types/qs": "^6.9.18"
@@ -16859,11 +16877,11 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/dashboards": "^0.51.0-beta.1",
-        "@perses-dev/explore": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/dashboards": "^0.51.0-rc.0",
+        "@perses-dev/explore": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "@tanstack/react-query": "^5.64.2",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
@@ -16953,17 +16971,17 @@
     },
     "scatterchart": {
       "name": "@perses-dev/scatter-chart-plugin",
-      "version": "0.6.0",
-      "devDependencies": {
+      "version": "0.6.1",
+      "dependencies": {
         "react-virtuoso": "^4.12.2"
       },
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -16975,14 +16993,14 @@
     },
     "statchart": {
       "name": "@perses-dev/stat-chart-plugin",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -16995,7 +17013,7 @@
     },
     "staticlistvariable": {
       "name": "@perses-dev/static-list-variable-plugin",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "color-hash": "^2.0.2"
       },
@@ -17003,9 +17021,9 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -17017,14 +17035,14 @@
     },
     "statushistorychart": {
       "name": "@perses-dev/status-history-chart-plugin",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -17037,20 +17055,15 @@
     },
     "table": {
       "name": "@perses-dev/table-plugin",
-      "version": "0.6.0",
-      "dependencies": {
-        "@perses-dev/components": "^0.51.0-rc.0",
-        "@perses-dev/dashboards": "^0.51.0-rc.0",
-        "@perses-dev/plugin-system": "^0.51.0-rc.0"
-      },
+      "version": "0.6.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/dashboards": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/dashboards": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -17064,6 +17077,7 @@
       "version": "0.51.0-rc.0",
       "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.51.0-rc.0.tgz",
       "integrity": "sha512-rHg4t+gf9ZwrlJXglhYMSBC9iigYjmFOOjptL6CDzC3prEJp6J4W+M97qmCFWWsZksGmjBJhEn6IgFHrN2Oy+Q==",
+      "peer": true,
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
@@ -17096,6 +17110,7 @@
       "version": "0.51.0-rc.0",
       "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.51.0-rc.0.tgz",
       "integrity": "sha512-RKb5faHrx1RAEW5NziStiemPkfJzBiglSmX6IkcNr4IcMa2IDfDX968Ey92i0/DeRop8gu5VE8vc292wA0p64Q==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "lodash": "^4.17.21",
@@ -17112,6 +17127,7 @@
       "version": "0.51.0-rc.0",
       "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.51.0-rc.0.tgz",
       "integrity": "sha512-uulxQGRpOH4cbMPPMa5xQMb6+Zz9D+6LnpHwxyT6coAi05dlmIB+RJLY1gPd+TxzMbQ75qvKjrU9I2zOgpgjXQ==",
+      "peer": true,
       "dependencies": {
         "@perses-dev/components": "0.51.0-rc.0",
         "@perses-dev/core": "0.51.0-rc.0",
@@ -17140,6 +17156,7 @@
       "version": "0.51.0-rc.0",
       "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.51.0-rc.0.tgz",
       "integrity": "sha512-ox2VZWx46ekczDaG9aopSnixUnhIi1dRKrJbBLl0Y+1/WrM77B01vZ3SsF3u3Nvx0onNqIG9t01mafi6vWG14A==",
+      "peer": true,
       "dependencies": {
         "@module-federation/enhanced": "^0.8.9",
         "@perses-dev/components": "0.51.0-rc.0",
@@ -17161,23 +17178,21 @@
     },
     "tempo": {
       "name": "@perses-dev/tempo-plugin",
-      "version": "0.51.0-beta.2",
+      "version": "0.51.0-rc.1",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
         "@grafana/lezer-traceql": "^0.0.20",
-        "@lezer/highlight": "^1.2.1x",
-        "@perses-dev/core": "^0.51.0-rc.0",
-        "@perses-dev/plugin-system": "^0.51.0-rc.0"
+        "@lezer/highlight": "^1.2.1x"
       },
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/dashboards": "^0.51.0-beta.1",
-        "@perses-dev/explore": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/dashboards": "^0.51.0-rc.0",
+        "@perses-dev/explore": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "@tanstack/react-query": "^5.64.2",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^4.1.0",
@@ -17195,6 +17210,7 @@
       "version": "0.51.0-rc.0",
       "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.51.0-rc.0.tgz",
       "integrity": "sha512-RKb5faHrx1RAEW5NziStiemPkfJzBiglSmX6IkcNr4IcMa2IDfDX968Ey92i0/DeRop8gu5VE8vc292wA0p64Q==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "lodash": "^4.17.21",
@@ -17211,6 +17227,7 @@
       "version": "0.51.0-rc.0",
       "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.51.0-rc.0.tgz",
       "integrity": "sha512-ox2VZWx46ekczDaG9aopSnixUnhIi1dRKrJbBLl0Y+1/WrM77B01vZ3SsF3u3Nvx0onNqIG9t01mafi6vWG14A==",
+      "peer": true,
       "dependencies": {
         "@module-federation/enhanced": "^0.8.9",
         "@perses-dev/components": "0.51.0-rc.0",
@@ -17234,6 +17251,7 @@
       "version": "0.51.0-rc.0",
       "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.51.0-rc.0.tgz",
       "integrity": "sha512-rHg4t+gf9ZwrlJXglhYMSBC9iigYjmFOOjptL6CDzC3prEJp6J4W+M97qmCFWWsZksGmjBJhEn6IgFHrN2Oy+Q==",
+      "peer": true,
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
@@ -17264,18 +17282,17 @@
     },
     "timeserieschart": {
       "name": "@perses-dev/timeseries-chart-plugin",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
-        "@module-federation/enhanced": "^0.8.9",
         "color-hash": "^2.0.2"
       },
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -17288,21 +17305,15 @@
     },
     "timeseriestable": {
       "name": "@perses-dev/timeseries-table-plugin",
-      "version": "0.7.0",
-      "dependencies": {
-        "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/dashboards": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/plugin-system": "0.0.0-snapshot-histogram-types-78c5104"
-      },
+      "version": "0.7.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/dashboards": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/dashboards": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -17312,111 +17323,9 @@
         "use-resize-observer": "^9.0.0"
       }
     },
-    "timeseriestable/node_modules/@perses-dev/components": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-9Yz9v/3nedQE4iuH381qENzn6xzndO0fDyzcDRL6KO+l1We72t/l4y3++JGIF0FNleg2ofd4jA26OsUlNauztA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
-        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
-        "@codemirror/lang-json": "^6.0.1",
-        "@fontsource/lato": "^4.5.10",
-        "@mui/x-date-pickers": "^7.23.1",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "@tanstack/react-table": "^8.20.5",
-        "@uiw/react-codemirror": "^4.19.1",
-        "date-fns": "^4.1.0",
-        "date-fns-tz": "^3.2.0",
-        "echarts": "5.5.0",
-        "lodash": "^4.17.21",
-        "mathjs": "^10.6.4",
-        "mdi-material-ui": "^7.9.2",
-        "notistack": "^3.0.2",
-        "react-colorful": "^5.6.1",
-        "react-error-boundary": "^3.1.4",
-        "react-hook-form": "^7.51.3",
-        "react-virtuoso": "^4.12.2",
-        "zod": "^3.21.4"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.1.10",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "timeseriestable/node_modules/@perses-dev/core": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-8S+cudUxQdz0SQdup0TV0K2VgJnl0ICEA1vBE9LLWw5U5vChp0hWYPv2TbONwuRjrBxALHRGJyNrJzu8yq/9og==",
-      "dependencies": {
-        "date-fns": "^4.1.0",
-        "lodash": "^4.17.21",
-        "mathjs": "^10.6.4",
-        "numbro": "^2.3.6",
-        "zod": "^3.21.4"
-      },
-      "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "timeseriestable/node_modules/@perses-dev/dashboards": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-YJjF2VIwAox9xoBY81pXbFYSs/XCq/R642C8p6+OHzdw7KpR2ouJUI1W/O70TMYalc9RZAiKobU69FlvvpejxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/plugin-system": "0.0.0-snapshot-histogram-types-78c5104",
-        "@types/react-grid-layout": "^1.3.2",
-        "date-fns": "^4.1.0",
-        "immer": "^10.1.1",
-        "mdi-material-ui": "^7.9.2",
-        "react-grid-layout": "^1.3.4",
-        "react-hook-form": "^7.46.1",
-        "react-intersection-observer": "^9.4.0",
-        "use-immer": "^0.11.0",
-        "use-query-params": "^2.1.1",
-        "use-resize-observer": "^9.0.0",
-        "yaml": "^2.7.0",
-        "zustand": "^4.3.3"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.1.10",
-        "@tanstack/react-query": "^5.64.2",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "timeseriestable/node_modules/@perses-dev/plugin-system": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-aFG1ZqFlZjJVsMVCFVlLQO35xg+aX/yTnXpz3WW6tBPBXKIRa8csfWLXQffmyk1HCiOsYT8/4SmQ4WWlHFAZ5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@module-federation/enhanced": "^0.8.9",
-        "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "date-fns": "^4.1.0",
-        "date-fns-tz": "^3.2.0",
-        "immer": "^10.1.1",
-        "react-hook-form": "^7.46.1",
-        "use-immer": "^0.11.0",
-        "use-query-params": "^2.1.2",
-        "zod": "^3.22.2"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.1.10",
-        "@tanstack/react-query": "^5.64.2",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
     "tracetable": {
       "name": "@perses-dev/trace-table-plugin",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@mui/x-data-grid": "^7.20.0"
       },
@@ -17424,9 +17333,9 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -17439,20 +17348,17 @@
     },
     "tracingganttchart": {
       "name": "@perses-dev/tracing-gantt-chart-plugin",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
-        "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/plugin-system": "0.0.0-snapshot-histogram-types-78c5104",
         "color-hash": "^2.0.2"
       },
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-beta.1",
-        "@perses-dev/core": "^0.51.0-beta.1",
-        "@perses-dev/plugin-system": "^0.51.0-beta.1",
+        "@perses-dev/components": "^0.51.0-rc.0",
+        "@perses-dev/core": "^0.51.0-rc.0",
+        "@perses-dev/plugin-system": "^0.51.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -17461,80 +17367,6 @@
         "react-dom": "^17.0.2 || ^18.0.0",
         "react-router-dom": "^5 || ^6 || ^7",
         "use-resize-observer": "^9.0.0"
-      }
-    },
-    "tracingganttchart/node_modules/@perses-dev/components": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-9Yz9v/3nedQE4iuH381qENzn6xzndO0fDyzcDRL6KO+l1We72t/l4y3++JGIF0FNleg2ofd4jA26OsUlNauztA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
-        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
-        "@codemirror/lang-json": "^6.0.1",
-        "@fontsource/lato": "^4.5.10",
-        "@mui/x-date-pickers": "^7.23.1",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "@tanstack/react-table": "^8.20.5",
-        "@uiw/react-codemirror": "^4.19.1",
-        "date-fns": "^4.1.0",
-        "date-fns-tz": "^3.2.0",
-        "echarts": "5.5.0",
-        "lodash": "^4.17.21",
-        "mathjs": "^10.6.4",
-        "mdi-material-ui": "^7.9.2",
-        "notistack": "^3.0.2",
-        "react-colorful": "^5.6.1",
-        "react-error-boundary": "^3.1.4",
-        "react-hook-form": "^7.51.3",
-        "react-virtuoso": "^4.12.2",
-        "zod": "^3.21.4"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.1.10",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "tracingganttchart/node_modules/@perses-dev/core": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-8S+cudUxQdz0SQdup0TV0K2VgJnl0ICEA1vBE9LLWw5U5vChp0hWYPv2TbONwuRjrBxALHRGJyNrJzu8yq/9og==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-fns": "^4.1.0",
-        "lodash": "^4.17.21",
-        "mathjs": "^10.6.4",
-        "numbro": "^2.3.6",
-        "zod": "^3.21.4"
-      },
-      "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
-      }
-    },
-    "tracingganttchart/node_modules/@perses-dev/plugin-system": {
-      "version": "0.0.0-snapshot-histogram-types-78c5104",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.0.0-snapshot-histogram-types-78c5104.tgz",
-      "integrity": "sha512-aFG1ZqFlZjJVsMVCFVlLQO35xg+aX/yTnXpz3WW6tBPBXKIRa8csfWLXQffmyk1HCiOsYT8/4SmQ4WWlHFAZ5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@module-federation/enhanced": "^0.8.9",
-        "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-        "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-        "date-fns": "^4.1.0",
-        "date-fns-tz": "^3.2.0",
-        "immer": "^10.1.1",
-        "react-hook-form": "^7.46.1",
-        "use-immer": "^0.11.0",
-        "use-query-params": "^2.1.2",
-        "zod": "^3.22.2"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.1.10",
-        "@tanstack/react-query": "^5.64.2",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
       }
     }
   }

--- a/piechart/package.json
+++ b/piechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/pie-chart-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -19,9 +19,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/prometheus-plugin",
-  "version": "0.51.0-rc.0",
+  "version": "0.51.0-rc.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -19,17 +19,18 @@
     "@nexucis/fuzzy": "^0.5.1",
     "@prometheus-io/codemirror-promql": "^0.45.6",
     "color-hash": "^2.0.2",
-    "qs": "^6.13.0"
+    "qs": "^6.13.0",
+    "react-virtuoso": "^4.12.2"
   },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/dashboards": "^0.51.0-beta.1",
-    "@perses-dev/explore": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/dashboards": "^0.51.0-rc.0",
+    "@perses-dev/explore": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "@tanstack/react-query": "^5.64.2",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",

--- a/scatterchart/package.json
+++ b/scatterchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/scatter-chart-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -15,16 +15,16 @@
   "main": "lib/cjs/index.js",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
-  "devDependencies": {
+  "dependencies": {
     "react-virtuoso": "^4.12.2"
   },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/statchart/package.json
+++ b/statchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/stat-chart-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -19,9 +19,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/statchart/src/StatChartBase.tsx
+++ b/statchart/src/StatChartBase.tsx
@@ -167,7 +167,6 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
           sx={{
             width: '100%',
           }}
-          // @ts-expect-error: Perses need to be released
           style={{
             // ECharts rounds the height to the nearest integer by default.
             // This can cause unneccessary scrollbars when the total height of this chart exceeds the 'height' prop.

--- a/staticlistvariable/package.json
+++ b/staticlistvariable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/static-list-variable-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -22,9 +22,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/statushistorychart/package.json
+++ b/statushistorychart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/status-history-chart-plugin",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -19,9 +19,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/table/package.json
+++ b/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/table-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -12,11 +12,6 @@
     "test": "cross-env LC_ALL=C TZ=UTC jest",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "@perses-dev/plugin-system": "^0.51.0-rc.0",
-    "@perses-dev/components": "^0.51.0-rc.0",
-    "@perses-dev/dashboards": "^0.51.0-rc.0"
-  },
   "main": "lib/cjs/index.js",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -24,10 +19,10 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
-    "@perses-dev/dashboards": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
+    "@perses-dev/dashboards": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/tempo/package.json
+++ b/tempo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tempo-plugin",
-  "version": "0.51.0-beta.2",
+  "version": "0.51.0-rc.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -18,19 +18,17 @@
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.4",
     "@lezer/highlight": "^1.2.1x",
-    "@grafana/lezer-traceql": "^0.0.20",
-    "@perses-dev/core": "^0.51.0-rc.0",
-    "@perses-dev/plugin-system": "^0.51.0-rc.0"
+    "@grafana/lezer-traceql": "^0.0.20"
   },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/dashboards": "^0.51.0-beta.1",
-    "@perses-dev/explore": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/dashboards": "^0.51.0-rc.0",
+    "@perses-dev/explore": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "@tanstack/react-query": "^5.64.2",
     "@uiw/react-codemirror": "^4.19.1",
     "date-fns": "^4.1.0",

--- a/timeserieschart/package.json
+++ b/timeserieschart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/timeseries-chart-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -16,16 +16,15 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@module-federation/enhanced": "^0.8.9",
     "color-hash": "^2.0.2"
   },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/timeseriestable/package.json
+++ b/timeseriestable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/timeseries-table-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -15,20 +15,14 @@
   "main": "lib/cjs/index.js",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
-  "dependencies": {
-    "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-    "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-    "@perses-dev/plugin-system": "0.0.0-snapshot-histogram-types-78c5104",
-    "@perses-dev/dashboards": "0.0.0-snapshot-histogram-types-78c5104"
-  },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
-    "@perses-dev/dashboards": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
+    "@perses-dev/dashboards": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/tracetable/package.json
+++ b/tracetable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/trace-table-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -22,9 +22,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",

--- a/tracingganttchart/package.json
+++ b/tracingganttchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tracing-gantt-chart-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -16,18 +16,15 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@perses-dev/components": "0.0.0-snapshot-histogram-types-78c5104",
-    "@perses-dev/core": "0.0.0-snapshot-histogram-types-78c5104",
-    "@perses-dev/plugin-system": "0.0.0-snapshot-histogram-types-78c5104",
     "color-hash": "^2.0.2"
   },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@hookform/resolvers": "^3.2.0",
-    "@perses-dev/components": "^0.51.0-beta.1",
-    "@perses-dev/core": "^0.51.0-beta.1",
-    "@perses-dev/plugin-system": "^0.51.0-beta.1",
+    "@perses-dev/components": "^0.51.0-rc.0",
+    "@perses-dev/core": "^0.51.0-rc.0",
+    "@perses-dev/plugin-system": "^0.51.0-rc.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",


### PR DESCRIPTION
# Description

- bump to latest Perses
- cleanup dependencies (remove @perses-dev dependencies in dependencies section; some plugins had them as a workaround to use features from a snapshot release)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

supersedes https://github.com/perses/plugins/pull/131