### PR TITLE
[IGNORE] datasourcevariable: change default port

### DIFF
--- a/datasourcevariable/rsbuild.config.ts
+++ b/datasourcevariable/rsbuild.config.ts
@@ -17,7 +17,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   server: {
-    port: 3012,
+    port: 3022,
   },
   dev: {
     assetPrefix: '/plugins/DatasourceVariable/',


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Port 3012 already used by staticlistvariable plugin


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
