### PR TITLE
[BUGFIX] make Format field a pointer to keep optional

### DIFF
--- a/table/sdk/go/table.go
+++ b/table/sdk/go/table.go
@@ -47,16 +47,16 @@ const (
 )
 
 type ColumnSettings struct {
-	Name              string        `json:"name" yaml:"name"`
-	Header            string        `json:"header,omitempty" yaml:"header,omitempty"`
-	HeaderDescription string        `json:"headerDescription,omitempty" yaml:"headerDescription,omitempty"`
-	CellDescription   string        `json:"cellDescription,omitempty" yaml:"cellDescription,omitempty"`
-	Format            common.Format `json:"format,omitempty" yaml:"format,omitempty"`
-	Align             Align         `json:"align,omitempty" yaml:"align,omitempty"`
-	EnableSorting     bool          `json:"enableSorting,omitempty" yaml:"enableSorting,omitempty"`
-	Sort              Sort          `json:"sort,omitempty" yaml:"sort,omitempty"`
-	Width             float64       `json:"width,omitempty" yaml:"width,omitempty"`
-	Hide              bool          `json:"hide,omitempty" yaml:"hide,omitempty"`
+	Name              string         `json:"name" yaml:"name"`
+	Header            string         `json:"header,omitempty" yaml:"header,omitempty"`
+	HeaderDescription string         `json:"headerDescription,omitempty" yaml:"headerDescription,omitempty"`
+	CellDescription   string         `json:"cellDescription,omitempty" yaml:"cellDescription,omitempty"`
+	Format            *common.Format `json:"format,omitempty" yaml:"format,omitempty"`
+	Align             Align          `json:"align,omitempty" yaml:"align,omitempty"`
+	EnableSorting     bool           `json:"enableSorting,omitempty" yaml:"enableSorting,omitempty"`
+	Sort              Sort           `json:"sort,omitempty" yaml:"sort,omitempty"`
+	Width             float64        `json:"width,omitempty" yaml:"width,omitempty"`
+	Hide              bool           `json:"hide,omitempty" yaml:"hide,omitempty"`
 }
 
 type ValueConditionSpec struct {


### PR DESCRIPTION
Importing JSON for table panel kind with empty format for the columns throws invalid panel error
```
              "columnSettings": [
                {
                  "name": "cluster",
                  "header": "Cluster",
                  "format": {
                    "unit": ""
                  },
                  "align": "right"
                },
```

`bad request: invalid panel 0_0: spec.columnSettings.0.format: 11 errors in empty disjunction: spec.columnSettings.0.format.unit: 8 errors in empty disjunction: spec.columnSettings.0.format.unit: conflicting values "bytes" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:35:18 spec.columnSettings.0.format.unit: conflicting values "days" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:19:69 spec.columnSettings.0.format.unit: conflicting values "decimal" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:29:18 spec.columnSettings.0.format.unit: conflicting values "hours" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:19:59 spec.columnSettings.0.format.unit: conflicting values "milliseconds" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:19:18 spec.columnSettings.0.format.unit: conflicting values "minutes" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:19:47 spec.columnSettings.0.format.unit: conflicting values "months" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:19:88 spec.columnSettings.0.format.unit: conflicting values "seconds" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:19:35 spec.columnSettings.0.format.unit: conflicting values "weeks" and "": 1:77 ../plugins/Table-0.7.1/cue.mod/pkg/github.com/perses/perses/cue/common/format.cue:19:78 spec.columnSettings.0.format.unit: conflicting values "years" and "": 1:77 ../plugins/Table-`

