### PR TITLE
[IGNORE] fix location of heatmapchart types generation

### DIFF
--- a/heatmapchart/tsconfig.json
+++ b/heatmapchart/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../tsconfig.base.json"
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/lib",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
# Description

Fix the tsconfig to generate the types in the correct location

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).