### PR TITLE
[BUGFIX] move PromQL Expression label higher to avoid overlap with editor

### DIFF
--- a/prometheus/src/components/PromQLEditor.tsx
+++ b/prometheus/src/components/PromQLEditor.tsx
@@ -64,7 +64,7 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
         shrink
         sx={{
           position: 'absolute',
-          top: '-8px',
+          top: '-12px',
           left: '10px',
           padding: '0 4px',
           color: theme.palette.text.primary,


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Before: Label appeared too close to or partially inside the editor input area.
After: Adjusts the positioning of the PromQL Expression label in the PromQL editor component to prevent it from overlapping with the editor content.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).