### PR TITLE
[FEATURE] flamechart: Add Responsive to FlameChart and Profiling Explorer

### DIFF
--- a/flamechart/src/components/FlameChartPanel.tsx
+++ b/flamechart/src/components/FlameChartPanel.tsx
@@ -13,7 +13,7 @@
 
 import { TitleComponentOption } from 'echarts';
 import { useChartsTheme } from '@perses-dev/components';
-import { Stack, Typography, SxProps } from '@mui/material';
+import { Stack, Typography, SxProps, useMediaQuery, useTheme } from '@mui/material';
 import { FC, useState, useEffect } from 'react';
 import { ProfileData } from '@perses-dev/core';
 import { PanelProps } from '@perses-dev/plugin-system';
@@ -30,6 +30,8 @@ export type FlameChartPanelProps = PanelProps<FlameChartOptions, ProfileData>;
 
 export const FlameChartPanel: FC<FlameChartPanelProps> = (props) => {
   const { contentDimensions, queryResults, spec } = props;
+
+  const isMobileSize = useMediaQuery(useTheme().breakpoints.down('sm'));
 
   // selectedId equals 0 => Flame Graph is not zoomed in
   // selectedId different from 0 => Flame Graph is zoomed in
@@ -85,6 +87,18 @@ export const FlameChartPanel: FC<FlameChartPanelProps> = (props) => {
     contentDimensions.height -
     (contentDimensions.height > LARGE_PANEL_TRESHOLD ? SERIES_CHART_HEIGHT + SETTINGS_HEIGHT + PADDING : 0);
 
+  const TABLE_CHART_WIDTH = isMobileSize
+    ? contentDimensions.width
+    : liveSpec.showFlameGraph
+      ? 0.4 * contentDimensions.width
+      : contentDimensions.width;
+
+  const FLAME_CHART_WIDTH = isMobileSize
+    ? contentDimensions.width
+    : liveSpec.showTable
+      ? 0.6 * contentDimensions.width
+      : contentDimensions.width;
+
   return (
     <Stack
       height={contentDimensions.height}
@@ -114,10 +128,10 @@ export const FlameChartPanel: FC<FlameChartPanelProps> = (props) => {
               selectedId={selectedId}
             />
           )}
-          <Stack direction="row" justifyContent="center" alignItems="top">
+          <Stack direction={isMobileSize ? 'column' : 'row'} justifyContent="center" alignItems="top">
             {liveSpec.showTable && (
               <TableChart
-                width={liveSpec.showFlameGraph ? 0.4 * contentDimensions.width : contentDimensions.width}
+                width={TABLE_CHART_WIDTH}
                 height={TABLE_FLAME_CHART_HEIGHT}
                 data={flameChartData.data}
                 searchValue={searchValue}
@@ -127,7 +141,7 @@ export const FlameChartPanel: FC<FlameChartPanelProps> = (props) => {
             )}
             {liveSpec.showFlameGraph && (
               <FlameChart
-                width={liveSpec.showTable ? 0.6 * contentDimensions.width : contentDimensions.width}
+                width={FLAME_CHART_WIDTH}
                 height={TABLE_FLAME_CHART_HEIGHT}
                 data={flameChartData.data}
                 palette={liveSpec.palette}

--- a/pyroscope/src/components/FilterItem.tsx
+++ b/pyroscope/src/components/FilterItem.tsx
@@ -47,7 +47,7 @@ export function FilterItem(props: FilterItemProps): ReactElement {
   };
 
   return (
-    <Stack direction="row" spacing={0}>
+    <Stack direction="row" spacing={0} sx={{ flexWrap: 'wrap', maxWidth: '100%' }}>
       <LabelName datasource={datasource} value={value.labelName} onChange={handleLabelNameChange} />
       <Operator value={value.operator} onChange={handleOperatorChange} />
       <LabelValue

--- a/pyroscope/src/components/ProfileType.tsx
+++ b/pyroscope/src/components/ProfileType.tsx
@@ -28,7 +28,7 @@ export function ProfileType(props: ProfileTypeProps): ReactElement {
   const { data: profileTypesOptions, isLoading: isProfileTypesOptionsLoading } = useProfileTypes(datasource);
 
   return (
-    <Stack position="relative" sx={{ flexGrow: 1 }}>
+    <Stack position="relative" sx={{ flexGrow: 1, maxWidth: '100%' }}>
       <TextField
         select
         label="Profile Type"

--- a/pyroscope/src/components/Service.tsx
+++ b/pyroscope/src/components/Service.tsx
@@ -28,7 +28,7 @@ export function Service(props: ServiceProps): ReactElement {
   const { data: servicesOptions, isLoading: isServicesOptionsLoading } = useServices(datasource);
 
   return (
-    <Stack position="relative" sx={{ flexGrow: 1 }}>
+    <Stack position="relative" sx={{ flexGrow: 1, maxWidth: '100%' }}>
       <TextField select label="Service" value={value} size="small" onChange={(event) => onChange?.(event.target.value)}>
         {isServicesOptionsLoading ? (
           <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>

--- a/pyroscope/src/plugins/pyroscope-profile-query/PyroscopeProfileQueryEditor.tsx
+++ b/pyroscope/src/plugins/pyroscope-profile-query/PyroscopeProfileQueryEditor.tsx
@@ -75,7 +75,15 @@ export function PyroscopeProfileQueryEditor(props: ProfileQueryEditorProps): Rea
           notched
         />
       </FormControl>
-      <Stack direction="row" spacing={2}>
+      <Stack
+        direction="row"
+        spacing={0}
+        sx={{
+          flexWrap: 'wrap',
+          rowGap: 1,
+          gap: 2,
+        }}
+      >
         <Service datasource={selectedDatasource} value={service} onChange={handleServiceChange} />
         <ProfileType datasource={selectedDatasource} value={profileType} onChange={handleProfileTypeChange} />
         <TextField


### PR DESCRIPTION
# Description

The purpose of this feature is to make sure that Profiling Explorer and FlameChart Panel are responsive and will be rendered well on small screens (tablets, smartphones, etc.). 

# Screenshots
## On smartphones:

<img width="467" height="833" alt="image" src="https://github.com/user-attachments/assets/46b6419a-7b8e-4905-8184-d50337d8bab0" />

---

<img width="474" height="804" alt="image" src="https://github.com/user-attachments/assets/ac00d2ec-e20a-447a-9161-08bb7c05a7a3" />

---

<img width="473" height="839" alt="image" src="https://github.com/user-attachments/assets/f2b0b432-2c31-41ee-b078-050adba4be93" />

## On tablets:

<img width="727" height="966" alt="image" src="https://github.com/user-attachments/assets/a56d3874-2bfd-41c5-9a95-516e62032659" />

## On laptops:

<img width="1648" height="918" alt="image" src="https://github.com/user-attachments/assets/09c966c3-b0be-4ae1-869d-3d4fe41184f4" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).