### PR TITLE
[ENHANCEMENT] Tempo: convert base64-encoded trace IDs and span IDs to hex-encoding

### DIFF
--- a/tempo/src/plugins/plugin.test.ts
+++ b/tempo/src/plugins/plugin.test.ts
@@ -70,4 +70,11 @@ describe('TempoTraceQuery', () => {
     );
     expect(results).toEqual(MOCK_TRACE_DATA_SEARCHRESULT);
   });
+
+  it('should convert base64-encoded trace IDs and span IDs in the response to hex format', async () => {
+    const results = await TempoTraceQuery.getTraceData({ query: 'fbd37845209d43cdccd418dc5f9ff021' }, stubTempoContext);
+    expect(results.trace?.resourceSpans[0]?.scopeSpans[0]?.spans[1]?.traceId).toEqual('fbd37845209d43cdccd418dc5f9ff021');
+    expect(results.trace?.resourceSpans[0]?.scopeSpans[0]?.spans[1]?.spanId).toEqual('8467bca11377c166');
+    expect(results.trace?.resourceSpans[0]?.scopeSpans[0]?.spans[1]?.parentSpanId).toEqual('9c22eb77cb5c14c7');
+  });
 });


### PR DESCRIPTION
# Description

Tempo: convert base64-encoded trace IDs and span IDs to hex-encoding

Tempo returns Trace ID and Span ID base64-encoded. The OTLP spec defines the encoding in the hex format: Spec: https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding Example: https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/examples/trace.json

# Screenshots

no UI changes (the traceid and spanid is not visible in the UI yet)

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).