### PR TITLE
[ENHANCEMENT] TracingGanttChart: show span metadata in attribute pane

### DIFF
--- a/tracingganttchart/src/TracingGanttChart/DetailPane/Attributes.test.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/Attributes.test.tsx
@@ -14,11 +14,22 @@
 import { render, RenderResult } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
 import { MemoryRouter } from 'react-router-dom';
-import { otlpcommonv1 } from '@perses-dev/core';
-import { AttributeLinks, AttributeList, AttributeListProps } from './Attributes';
+import { otlpcommonv1, otlptracev1 } from '@perses-dev/core';
+import * as exampleTrace from '../../test/traces/example_otlp.json';
+import { getTraceModel } from '../trace';
+import { AttributeLinks, AttributeList, AttributeListProps, TraceAttributes, TraceAttributesProps } from './Attributes';
 
 describe('Attributes', () => {
-  const renderComponent = (props: AttributeListProps): RenderResult => {
+  const trace = getTraceModel(exampleTrace as otlptracev1.TracesData);
+  const renderTraceAttributes = (props: TraceAttributesProps): RenderResult => {
+    return render(
+      <MemoryRouter>
+        <TraceAttributes {...props} />
+      </MemoryRouter>
+    );
+  };
+
+  const renderAttributeList = (props: AttributeListProps): RenderResult => {
     return render(
       <MemoryRouter>
         <AttributeList {...props} />
@@ -28,20 +39,20 @@ describe('Attributes', () => {
 
   it('render stringValues', () => {
     const attributes = [{ key: 'attrkey', value: { stringValue: 'str' } }];
-    renderComponent({ attributes });
+    renderAttributeList({ attributes });
     expect(screen.getByText('attrkey')).toBeInTheDocument();
     expect(screen.getByText('str')).toBeInTheDocument();
   });
 
   it('render intValue', () => {
     const attributes = [{ key: 'attrkey', value: { intValue: '123' } }];
-    renderComponent({ attributes });
+    renderAttributeList({ attributes });
     expect(screen.getByText('123')).toBeInTheDocument();
   });
 
   it('render boolValue', () => {
     const attributes = [{ key: 'attrkey', value: { boolValue: false } }];
-    renderComponent({ attributes });
+    renderAttributeList({ attributes });
     expect(screen.getByText('false')).toBeInTheDocument();
   });
 
@@ -49,7 +60,7 @@ describe('Attributes', () => {
     const attributes = [
       { key: 'attrkey', value: { arrayValue: { values: [{ stringValue: 'abc' }, { boolValue: true }] } } },
     ];
-    renderComponent({ attributes });
+    renderAttributeList({ attributes });
     expect(screen.getByText('abc, true')).toBeInTheDocument();
   });
 
@@ -64,11 +75,18 @@ describe('Attributes', () => {
       { key: 'k8s.pod.name', value: { stringValue: 'hotrod' } },
     ];
 
-    renderComponent({ attributeLinks, attributes });
+    renderAttributeList({ attributeLinks, attributes });
     expect(screen.getByText('testing')).not.toHaveAttribute('href');
     expect(screen.getByRole('link', { name: 'hotrod' })).toHaveAttribute(
       'href',
       '/console/ns/testing/pod/hotrod/detail'
     );
+  });
+
+  it('render span id and duration', () => {
+    renderTraceAttributes({ trace, span: trace.rootSpans[0]!.childSpans[0]!.childSpans[0]! });
+    expect(screen.getByText('sid3')).toBeInTheDocument();
+    expect(screen.getByText('300ms')).toBeInTheDocument(); // start
+    expect(screen.getByText('150ms')).toBeInTheDocument(); // duration
   });
 });

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/Attributes.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/Attributes.tsx
@@ -12,11 +12,41 @@
 // limitations under the License.
 
 import { ReactElement, useMemo } from 'react';
-import { Link, List, ListItem, ListItemText } from '@mui/material';
+import { Divider, Link, List, ListItem, ListItemText } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { otlpcommonv1 } from '@perses-dev/core';
+import { Span, Trace } from '../trace';
+import { formatDuration } from '../utils';
 
 export type AttributeLinks = Record<string, (attributes: Record<string, otlpcommonv1.AnyValue>) => string>;
+
+export interface TraceAttributesProps {
+  trace: Trace;
+  span: Span;
+  attributeLinks?: AttributeLinks;
+}
+
+export function TraceAttributes(props: TraceAttributesProps) {
+  const { trace, span, attributeLinks } = props;
+
+  return (
+    <>
+      <List>
+        <AttributeItem name="span ID" value={span.spanId} />
+        <AttributeItem name="start" value={formatDuration(span.startTimeUnixMs - trace.startTimeUnixMs)} />
+        <AttributeItem name="duration" value={formatDuration(span.endTimeUnixMs - span.startTimeUnixMs)} />
+      </List>
+      <Divider />
+      {span.attributes.length > 0 && (
+        <>
+          <AttributeList attributeLinks={attributeLinks} attributes={span.attributes} />
+          <Divider />
+        </>
+      )}
+      <AttributeList attributeLinks={attributeLinks} attributes={span.resource.attributes} />
+    </>
+  );
+}
 
 export interface AttributeListProps {
   attributeLinks?: AttributeLinks;
@@ -31,41 +61,47 @@ export function AttributeList(props: AttributeListProps): ReactElement {
   );
 
   return (
-    <>
-      <List>
-        {attributes
-          .sort((a, b) => a.key.localeCompare(b.key))
-          .map((attribute, i) => (
-            <AttributeItem key={i} attribute={attribute} linkTo={attributeLinks?.[attribute.key]?.(attributesMap)} />
-          ))}
-      </List>
-    </>
+    <List>
+      {attributes
+        .sort((a, b) => a.key.localeCompare(b.key))
+        .map((attribute, i) => (
+          <AttributeItem
+            key={i}
+            name={attribute.key}
+            value={renderAttributeValue(attribute.value)}
+            link={attributeLinks?.[attribute.key]?.(attributesMap)}
+          />
+        ))}
+    </List>
   );
 }
 
 interface AttributeItemProps {
-  attribute: otlpcommonv1.KeyValue;
-  linkTo?: string;
+  name: string;
+  value: string;
+  link?: string;
 }
 
 function AttributeItem(props: AttributeItemProps): ReactElement {
-  const { attribute, linkTo } = props;
+  const { name, value, link } = props;
 
-  const value = linkTo ? (
-    <Link component={RouterLink} to={linkTo}>
-      {renderAttributeValue(attribute.value)}
+  const valueComponent = link ? (
+    <Link component={RouterLink} to={link}>
+      {value}
     </Link>
   ) : (
-    renderAttributeValue(attribute.value)
+    value
   );
 
   return (
     <ListItem disablePadding>
       <ListItemText
-        primary={attribute.key}
-        secondary={value}
-        primaryTypographyProps={{ variant: 'h5' }}
-        secondaryTypographyProps={{ variant: 'body1', sx: { wordBreak: 'break-word' } }}
+        primary={name}
+        secondary={valueComponent}
+        slotProps={{
+          primary: { variant: 'h5' },
+          secondary: { variant: 'body1', sx: { wordBreak: 'break-word' } },
+        }}
       />
     </ListItem>
   );

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Divider, IconButton, Tab, Tabs, Typography } from '@mui/material';
+import { Box, IconButton, Tab, Tabs, Typography } from '@mui/material';
 import { ReactElement, useState } from 'react';
 import CloseIcon from 'mdi-material-ui/Close';
 import { Span, Trace } from '../trace';
-import { AttributeLinks, AttributeList } from './Attributes';
+import { AttributeLinks, TraceAttributes } from './Attributes';
 import { SpanEventList } from './SpanEvents';
 
 export interface DetailPaneProps {
@@ -53,13 +53,7 @@ export function DetailPane(props: DetailPaneProps): ReactElement {
           {span.events.length > 0 && <Tab value="events" label="Events" />}
         </Tabs>
       </Box>
-      {tab === 'attributes' && (
-        <>
-          {span.attributes.length > 0 && <AttributeList attributeLinks={attributeLinks} attributes={span.attributes} />}
-          {span.attributes.length > 0 && <Divider />}
-          <AttributeList attributeLinks={attributeLinks} attributes={span.resource.attributes} />
-        </>
-      )}
+      {tab === 'attributes' && <TraceAttributes trace={trace} span={span} attributeLinks={attributeLinks} />}
       {tab === 'events' && <SpanEventList trace={trace} span={span} />}
     </Box>
   );


### PR DESCRIPTION
# Description

Show span metadata (span id, start, duration) in attribute pane (right side)

# Screenshots

<img width="3376" height="718" alt="Bildschirmfoto vom 2025-07-16 16-46-12" src="https://github.com/user-attachments/assets/13fc2a2a-bb67-484f-a350-fcfcd8bd9f3e" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).