### PR TITLE
[ENHANCEMENT] TracingGanttChart: show trace metadata on top of chart

### DIFF
--- a/tracingganttchart/src/TracingGanttChart/TraceDetails.test.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TraceDetails.test.tsx
@@ -1,0 +1,37 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, RenderResult } from '@testing-library/react';
+import { screen } from '@testing-library/dom';
+import { MemoryRouter } from 'react-router-dom';
+import { otlptracev1 } from '@perses-dev/core';
+import * as exampleTrace from '../test/traces/example_otlp.json';
+import { getTraceModel } from './trace';
+import { TraceDetails, TraceDetailsProps } from './TraceDetails';
+
+describe('TraceDetails', () => {
+  const trace = getTraceModel(exampleTrace as otlptracev1.TracesData);
+  const renderComponent = (props: TraceDetailsProps): RenderResult => {
+    return render(
+      <MemoryRouter>
+        <TraceDetails {...props} />
+      </MemoryRouter>
+    );
+  };
+
+  it('render trace details', () => {
+    renderComponent({ trace });
+    expect(screen.getByRole('heading', { name: 'shop-backend: testRootSpan (1s)' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Trace ID: tid1/ })).toBeInTheDocument();
+  });
+});

--- a/tracingganttchart/src/TracingGanttChart/TraceDetails.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TraceDetails.tsx
@@ -1,0 +1,62 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Stack, Typography } from '@mui/material';
+import { ReactElement } from 'react';
+import { useTimeZone } from '@perses-dev/components';
+import { formatDuration } from './utils';
+import { Trace } from './trace';
+
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  fractionalSecondDigits: 3,
+  timeZoneName: 'short',
+};
+
+export interface TraceDetailsProps {
+  trace: Trace;
+}
+
+export function TraceDetails(props: TraceDetailsProps): ReactElement {
+  const { trace } = props;
+
+  const { dateFormatOptionsWithUserTimeZone } = useTimeZone();
+  const dateFormatOptions = dateFormatOptionsWithUserTimeZone(DATE_FORMAT_OPTIONS);
+  const dateFormatter = new Intl.DateTimeFormat(undefined, dateFormatOptions);
+
+  const rootSpan = trace.rootSpans[0];
+  if (!rootSpan) {
+    return <Typography>Trace contains no spans.</Typography>;
+  }
+
+  return (
+    <Stack direction="row" sx={{ justifyContent: 'space-between' }}>
+      <Typography variant="h3">
+        {rootSpan.resource.serviceName}: {rootSpan.name} ({formatDuration(trace.endTimeUnixMs - trace.startTimeUnixMs)})
+      </Typography>
+      <Typography variant="h4">
+        <Typography component="span" sx={{ px: 1 }}>
+          <strong>Start:</strong> {dateFormatter.format(trace.startTimeUnixMs)}
+        </Typography>
+        <Typography component="span" sx={{ px: 1 }}>
+          <strong>Trace ID:</strong> {rootSpan.traceId}
+        </Typography>
+      </Typography>
+    </Stack>
+  );
+}

--- a/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
@@ -23,6 +23,7 @@ import { GanttTableProvider } from './GanttTable/GanttTableProvider';
 import { ResizableDivider } from './GanttTable/ResizableDivider';
 import { AttributeLinks } from './DetailPane/Attributes';
 import { getTraceModel, Span } from './trace';
+import { TraceDetails } from './TraceDetails';
 
 export interface TracingGanttChartProps {
   options: TracingGanttChartOptions;
@@ -62,6 +63,7 @@ export function TracingGanttChart(props: TracingGanttChartProps): ReactElement {
   return (
     <Stack ref={ganttChart} direction="row" sx={{ height: '100%', minHeight: '240px', gap }}>
       <Stack sx={{ flexGrow: 1, gap }}>
+        <TraceDetails trace={trace} />
         <MiniGanttChart options={options} trace={trace} viewport={viewport} setViewport={setViewport} />
         <GanttTableProvider>
           <GanttTable


### PR DESCRIPTION
# Description

show trace metadata (name, duration, start time, trace ID) on top of chart

# Screenshots

<img width="3376" height="718" alt="Bildschirmfoto vom 2025-07-16 16-46-12" src="https://github.com/user-attachments/assets/3f43d93f-be12-43d6-9c0c-3f7b255429bf" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).