### PR TITLE
[ENHANCEMENT] Explore view -> Finder tab datasource dropdown

### DIFF
--- a/prometheus/src/explore/PrometheusMetricsFinder/filter/FinderFilters.tsx
+++ b/prometheus/src/explore/PrometheusMetricsFinder/filter/FinderFilters.tsx
@@ -49,7 +49,7 @@ export function FinderFilters({
 
   return (
     <Stack {...props} direction="row" alignItems="center" flexWrap="wrap" gap={1} sx={{ width: '100%' }}>
-      <FormControl sx={{ width: 250 }}>
+      <FormControl sx={{ width: 500 }}>
         <DatasourceSelect
           size="medium"
           datasourcePluginKind={PROM_DATASOURCE_KIND}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Perses Explorer -> Finder tab allows to search for metrics while specifying a datasource but the dropdown is no wide enough for good UX

# Screenshots

Current
<img width="288" height="413" alt="Screenshot 2025-07-23 at 2 32 49 PM" src="https://github.com/user-attachments/assets/a3378b6b-a729-4c20-a017-6d53d89d14e4" />
Expected
<img width="516" height="400" alt="Screenshot 2025-07-23 at 2 32 33 PM" src="https://github.com/user-attachments/assets/e9478997-ea24-477f-a635-8a6378224628" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).