### PR TITLE
[IGNORE] TracingGanttChart: improve span attributes and events styling

### DIFF
--- a/tracingganttchart/src/TracingGanttChart/DetailPane/Attributes.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/Attributes.tsx
@@ -39,21 +39,42 @@ export function TraceAttributes(props: TraceAttributesProps) {
       <Divider />
       {span.attributes.length > 0 && (
         <>
-          <AttributeList attributeLinks={attributeLinks} attributes={span.attributes} />
+          <AttributeList
+            attributes={span.attributes.toSorted((a, b) => a.key.localeCompare(b.key))}
+            attributeLinks={attributeLinks}
+          />
           <Divider />
         </>
       )}
-      <AttributeList attributeLinks={attributeLinks} attributes={span.resource.attributes} />
+      <AttributeList
+        attributes={span.resource.attributes.toSorted((a, b) => a.key.localeCompare(b.key))}
+        attributeLinks={attributeLinks}
+      />
     </>
   );
 }
 
 export interface AttributeListProps {
+  attributes: otlpcommonv1.KeyValue[];
+  attributeLinks?: AttributeLinks;
+}
+
+export function AttributeList(props: AttributeListProps): ReactElement {
+  const { attributes, attributeLinks } = props;
+
+  return (
+    <List>
+      <AttributeItems attributes={attributes} attributeLinks={attributeLinks} />
+    </List>
+  );
+}
+
+interface AttributeItemsProps {
   attributeLinks?: AttributeLinks;
   attributes: otlpcommonv1.KeyValue[];
 }
 
-export function AttributeList(props: AttributeListProps): ReactElement {
+export function AttributeItems(props: AttributeItemsProps): ReactElement {
   const { attributeLinks, attributes } = props;
   const attributesMap = useMemo(
     () => Object.fromEntries(attributes.map((attr) => [attr.key, attr.value])),
@@ -61,18 +82,16 @@ export function AttributeList(props: AttributeListProps): ReactElement {
   );
 
   return (
-    <List>
-      {attributes
-        .sort((a, b) => a.key.localeCompare(b.key))
-        .map((attribute, i) => (
-          <AttributeItem
-            key={i}
-            name={attribute.key}
-            value={renderAttributeValue(attribute.value)}
-            link={attributeLinks?.[attribute.key]?.(attributesMap)}
-          />
-        ))}
-    </List>
+    <>
+      {attributes.map((attribute, i) => (
+        <AttributeItem
+          key={i}
+          name={attribute.key}
+          value={renderAttributeValue(attribute.value)}
+          link={attributeLinks?.[attribute.key]?.(attributesMap)}
+        />
+      ))}
+    </>
   );
 }
 
@@ -82,7 +101,7 @@ interface AttributeItemProps {
   link?: string;
 }
 
-function AttributeItem(props: AttributeItemProps): ReactElement {
+export function AttributeItem(props: AttributeItemProps): ReactElement {
   const { name, value, link } = props;
 
   const valueComponent = link ? (
@@ -94,7 +113,7 @@ function AttributeItem(props: AttributeItemProps): ReactElement {
   );
 
   return (
-    <ListItem disablePadding>
+    <ListItem sx={{ px: 1, py: 0 }}>
       <ListItemText
         primary={name}
         secondary={valueComponent}

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
@@ -54,7 +54,7 @@ export function DetailPane(props: DetailPaneProps): ReactElement {
         </Tabs>
       </Box>
       {tab === 'attributes' && <TraceAttributes trace={trace} span={span} attributeLinks={attributeLinks} />}
-      {tab === 'events' && <SpanEventList trace={trace} span={span} />}
+      {tab === 'events' && <SpanEventList trace={trace} span={span} attributeLinks={attributeLinks} />}
     </Box>
   );
 }

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/SpanEvents.test.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/SpanEvents.test.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { screen } from '@testing-library/dom';
+import { fireEvent, screen } from '@testing-library/dom';
 import { render, RenderResult } from '@testing-library/react';
 import { otlptracev1 } from '@perses-dev/core';
 import * as exampleTrace from '../../test/traces/example_otlp.json';
@@ -27,8 +27,12 @@ describe('SpanEvents', () => {
   it('render', () => {
     renderComponent({ trace, span: trace.rootSpans[0]!.childSpans[0]! });
 
+    // open event details
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
     expect(screen.getByText('150ms')).toBeInTheDocument();
-    expect(screen.getByText('event1_name')).toBeInTheDocument();
+    expect(screen.getAllByText('event1_name')).toHaveLength(2);
     expect(screen.getByText('event1_key')).toBeInTheDocument();
     expect(screen.getByText('event1_value')).toBeInTheDocument();
   });


### PR DESCRIPTION
# Description

* add padding
* span events: use collapsible list instead of accordion

# Screenshots

before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/6139549a-08cf-4d01-8971-ce8f8101ee13" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/fd27ebf3-6716-4844-b9ab-9c2833ba44f0" />

after
<img width="300" alt="image" src="https://github.com/user-attachments/assets/5306ce1c-baea-4195-9784-c16dd3066951" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/78532c97-2bd7-44fd-92af-60899bf01cfc" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).