### PR TITLE
[IGNORE] prometheus: Fix min step uncontrolled input

### DIFF
--- a/prometheus/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/prometheus/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -115,8 +115,8 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
           label="Min Step"
           placeholder={minStepPlaceholder}
           helperText="Lower bound for the step. If not provided, the scrape interval of the datasource is used."
-          value={minStep}
-          onChange={(e) => handleMinStepChange(e.target.value as DurationString)}
+          value={minStep ?? ''}
+          onChange={(e) => handleMinStepChange(e.target.value ? (e.target.value as DurationString) : undefined)}
           onBlur={handleMinStepBlur}
           sx={{ width: '250px' }}
         />

--- a/prometheus/src/plugins/prometheus-time-series-query/query-editor-model.ts
+++ b/prometheus/src/plugins/prometheus-time-series-query/query-editor-model.ts
@@ -103,7 +103,7 @@ export function useFormatState(props: PrometheusTimeSeriesQueryEditorProps): {
  */
 export function useMinStepState(props: PrometheusTimeSeriesQueryEditorProps): {
   minStep: string | undefined;
-  handleMinStepChange: (e: DurationString) => void;
+  handleMinStepChange: (e: DurationString | undefined) => void;
   handleMinStepBlur: () => void;
 } {
   const { onChange, value } = props;
@@ -117,7 +117,7 @@ export function useMinStepState(props: PrometheusTimeSeriesQueryEditorProps): {
   }
 
   // Update our local state as the user types
-  const handleMinStepChange = (e: DurationString): void => {
+  const handleMinStepChange = (e: DurationString | undefined): void => {
     setMinStep(e);
   };
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fixing uncontrolled input. That could fail e2e tests.

# Screenshots

<!-- If there are UI changes -->
Before:

`MUI: A component is changing the controlled value state of Autocomplete to be uncontrolled.
Elements should not switch from uncontrolled to controlled (or vice versa).
Decide between using a controlled or uncontrolled Autocomplete element for the lifetime of the component.
The nature of the state is determined during the first render. It's considered controlled if the value is not `undefined`.
More info: https://fb.me/react-controlled-components`


After:

Nothing :)

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).