### PR TITLE
[FEATURE] prometheus: Round the promql response time

### DIFF
--- a/prometheus/src/components/TreeNode.tsx
+++ b/prometheus/src/components/TreeNode.tsx
@@ -383,7 +383,7 @@ function QueryStatus({
       <Typography variant="body2" component="span" sx={{ color: (theme) => theme.palette.grey[500] }}>
         {resultStats.numSeries} result{resultStats.numSeries !== 1 && 's'}
         &nbsp;&nbsp;–&nbsp;&nbsp;
-        {responseTime}ms
+        {responseTime ? `${Math.round(responseTime)}ms` : '? ms'}
         {resultStats.sortedLabelCards.length > 0 && <>&nbsp;&nbsp;–</>}
       </Typography>
       {resultStats.sortedLabelCards.slice(0, maxLabelNames).map(([ln, cnt]) => (


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3133

# Description

As suggested here (https://github.com/perses/perses/issues/3133), the response time is simply rounded using `Math.round` function. 

# Test

To test this you need to run the Perses/Plugin localy

- Clone the Repo
- Swith to this branch
- Have the Perses CLI ready on your machine, and then:
-  ./percli.exe plugin start ../../../projects/plugins/prometheus/
- You also need to run the server and client of Perses itself


# Screenshots

<img width="2296" height="336" alt="image" src="https://github.com/user-attachments/assets/47981bcc-6473-4b96-abbe-9d17d6cb174f" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).