### PR TITLE
[BUGFIX] piechart: Remove the static text Access from from the tooltip

### DIFF
--- a/piechart/src/PieChartBase.tsx
+++ b/piechart/src/PieChartBase.tsx
@@ -53,7 +53,7 @@ export function PieChartBase(props: PieChartBaseProps): ReactElement {
     },
     tooltip: {
       trigger: 'item',
-      formatter: '{a} <br/>{b} : {c} ({d}%)',
+      formatter: '{b} : {c} ({d}%)',
     },
     axisLabel: {
       overflow: 'truncate',
@@ -61,7 +61,6 @@ export function PieChartBase(props: PieChartBaseProps): ReactElement {
     },
     series: [
       {
-        name: 'Access From',
         type: 'pie',
         radius: '55%',
         label: false,


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3135

Simply removes the static text `Access From` from the Piechart tooltip. The tooltip text and the legend should be identical. 


<img width="2252" height="377" alt="image" src="https://github.com/user-attachments/assets/68a54331-a532-4b4d-bb00-17f2f14adbf7" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).