### PR TITLE
[BREAKINGCHANGE] TracingGanttChart: configure attribute links in panel spec instead of panel props

### DIFF
--- a/tempo/src/explore/TempoExplorer.tsx
+++ b/tempo/src/explore/TempoExplorer.tsx
@@ -27,6 +27,34 @@ interface SearchResultsPanelProps {
   queries: QueryDefinition[];
 }
 
+const linkToTraceParams = new URLSearchParams({
+  explorer: 'Tempo-TempoExplorer',
+  data: JSON.stringify({
+    queries: [
+      {
+        kind: 'TraceQuery',
+        spec: {
+          plugin: {
+            kind: 'TempoTraceQuery',
+            spec: {
+              query: 'TRACEID',
+              datasource: {
+                kind: 'TempoDatasource',
+                name: 'DATASOURCENAME',
+              },
+            },
+          },
+        },
+      },
+    ],
+  }),
+});
+
+// add ${...} syntax after the URL is URL-encoded, because the characters ${} must not be URL-encoded
+const linkToTrace = `/explore?${linkToTraceParams}`
+  .replace('TRACEID', '${traceId}')
+  .replace('DATASOURCENAME', '${datasourceName}');
+
 function SearchResultsPanel({ queries }: SearchResultsPanelProps): ReactElement {
   const { isFetching, isLoading, queryResults } = useDataQueries('TraceQuery');
 
@@ -84,7 +112,18 @@ function TracingGanttChartPanel({ queries }: { queries: QueryDefinition[] }): Re
       }}
       definition={{
         kind: 'Panel',
-        spec: { queries, display: { name: '' }, plugin: { kind: 'TracingGanttChart', spec: {} } },
+        spec: {
+          queries,
+          display: { name: '' },
+          plugin: {
+            kind: 'TracingGanttChart',
+            spec: {
+              links: {
+                trace: linkToTrace,
+              },
+            },
+          },
+        },
       }}
     />
   );

--- a/tracingganttchart/schemas/tracing-gantt-chart.cue
+++ b/tracingganttchart/schemas/tracing-gantt-chart.cue
@@ -21,7 +21,18 @@ package model
 	palette?: #palette
 }
 
+#links: {
+	trace?: string
+	attributes?: [...#attributeLink]
+}
+
+#attributeLink: {
+	name: string
+	link: string
+}
+
 kind: "TracingGanttChart"
 spec: close({
 	visual?: #visual
+	links?:  #links
 })

--- a/tracingganttchart/schemas/tracing-gantt-chart.json
+++ b/tracingganttchart/schemas/tracing-gantt-chart.json
@@ -1,4 +1,16 @@
 {
   "kind": "TracingGanttChart",
-  "spec": {}
+  "spec": {
+    "visual": {
+      "palette": {
+        "mode": "auto"
+      }
+    },
+    "links": {
+      "trace": "/datasource/${datasourceName}/trace/${traceId}",
+      "attributes": [
+        { "name": "k8s.pod.name", "link": "/namespace/${k8s_namespace_name}/pod/${k8s_pod_name}" }
+      ]
+    }
+  }
 }

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/Attributes.test.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/Attributes.test.tsx
@@ -13,18 +13,25 @@
 
 import { render, RenderResult } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import { MemoryRouter } from 'react-router-dom';
-import { otlpcommonv1, otlptracev1 } from '@perses-dev/core';
+import { MemoryRouter, Link as RouterLink } from 'react-router-dom';
+import { otlptracev1 } from '@perses-dev/core';
+import { VariableProvider } from '@perses-dev/dashboards';
+import { TimeRangeProvider } from '@perses-dev/plugin-system';
 import * as exampleTrace from '../../test/traces/example_otlp.json';
 import { getTraceModel } from '../trace';
-import { AttributeLinks, AttributeList, AttributeListProps, TraceAttributes, TraceAttributesProps } from './Attributes';
+import { CustomLinks } from '../../gantt-chart-model';
+import { AttributeList, AttributeListProps, TraceAttributes, TraceAttributesProps } from './Attributes';
 
 describe('Attributes', () => {
   const trace = getTraceModel(exampleTrace as otlptracev1.TracesData);
   const renderTraceAttributes = (props: TraceAttributesProps): RenderResult => {
     return render(
       <MemoryRouter>
-        <TraceAttributes {...props} />
+        <TimeRangeProvider timeRange={{ pastDuration: '1m' }}>
+          <VariableProvider>
+            <TraceAttributes {...props} />
+          </VariableProvider>
+        </TimeRangeProvider>
       </MemoryRouter>
     );
   };
@@ -32,7 +39,11 @@ describe('Attributes', () => {
   const renderAttributeList = (props: AttributeListProps): RenderResult => {
     return render(
       <MemoryRouter>
-        <AttributeList {...props} />
+        <TimeRangeProvider timeRange={{ pastDuration: '1m' }}>
+          <VariableProvider>
+            <AttributeList {...props} />
+          </VariableProvider>
+        </TimeRangeProvider>
       </MemoryRouter>
     );
   };
@@ -65,17 +76,19 @@ describe('Attributes', () => {
   });
 
   it('render an attribute with a link', () => {
-    const stringValue = (val?: otlpcommonv1.AnyValue): string => (val && 'stringValue' in val ? val.stringValue : '');
-    const attributeLinks: AttributeLinks = {
-      'k8s.pod.name': (attrs) =>
-        `/console/ns/${stringValue(attrs['k8s.namespace.name'])}/pod/${stringValue(attrs['k8s.pod.name'])}/detail`,
+    const customLinks: CustomLinks = {
+      RouterComponent: RouterLink,
+      links: {
+        attributes: [{ name: 'k8s.pod.name', link: '/console/ns/${k8s_namespace_name}/pod/${k8s_pod_name}/detail' }],
+      },
+      variables: {},
     };
     const attributes = [
       { key: 'k8s.namespace.name', value: { stringValue: 'testing' } },
       { key: 'k8s.pod.name', value: { stringValue: 'hotrod' } },
     ];
 
-    renderAttributeList({ attributeLinks, attributes });
+    renderAttributeList({ customLinks, attributes });
     expect(screen.getByText('testing')).not.toHaveAttribute('href');
     expect(screen.getByRole('link', { name: 'hotrod' })).toHaveAttribute(
       'href',

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
@@ -15,11 +15,12 @@ import { Box, IconButton, Tab, Tabs, Typography } from '@mui/material';
 import { ReactElement, useState } from 'react';
 import CloseIcon from 'mdi-material-ui/Close';
 import { Span, Trace } from '../trace';
-import { AttributeLinks, TraceAttributes } from './Attributes';
+import { CustomLinks } from '../../gantt-chart-model';
+import { TraceAttributes } from './Attributes';
 import { SpanEventList } from './SpanEvents';
 
 export interface DetailPaneProps {
-  attributeLinks?: AttributeLinks;
+  customLinks?: CustomLinks;
   trace: Trace;
   span: Span;
   onCloseBtnClick: () => void;
@@ -29,7 +30,7 @@ export interface DetailPaneProps {
  * DetailPane renders a sidebar showing the span attributes etc.
  */
 export function DetailPane(props: DetailPaneProps): ReactElement {
-  const { attributeLinks, trace, span, onCloseBtnClick } = props;
+  const { customLinks, trace, span, onCloseBtnClick } = props;
   const [tab, setTab] = useState<'attributes' | 'events'>('attributes');
 
   // if the events tab is selected, and then a span without events is clicked,
@@ -53,8 +54,8 @@ export function DetailPane(props: DetailPaneProps): ReactElement {
           {span.events.length > 0 && <Tab value="events" label="Events" />}
         </Tabs>
       </Box>
-      {tab === 'attributes' && <TraceAttributes trace={trace} span={span} attributeLinks={attributeLinks} />}
-      {tab === 'events' && <SpanEventList trace={trace} span={span} attributeLinks={attributeLinks} />}
+      {tab === 'attributes' && <TraceAttributes customLinks={customLinks} trace={trace} span={span} />}
+      {tab === 'events' && <SpanEventList customLinks={customLinks} trace={trace} span={span} />}
     </Box>
   );
 }

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/SpanEvents.test.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/SpanEvents.test.tsx
@@ -14,6 +14,9 @@
 import { fireEvent, screen } from '@testing-library/dom';
 import { render, RenderResult } from '@testing-library/react';
 import { otlptracev1 } from '@perses-dev/core';
+import { VariableProvider } from '@perses-dev/dashboards';
+import { TimeRangeProvider } from '@perses-dev/plugin-system';
+import { MemoryRouter } from 'react-router-dom';
 import * as exampleTrace from '../../test/traces/example_otlp.json';
 import { getTraceModel } from '../trace';
 import { SpanEventList, SpanEventListProps } from './SpanEvents';
@@ -21,7 +24,15 @@ import { SpanEventList, SpanEventListProps } from './SpanEvents';
 describe('SpanEvents', () => {
   const trace = getTraceModel(exampleTrace as otlptracev1.TracesData);
   const renderComponent = (props: SpanEventListProps): RenderResult => {
-    return render(<SpanEventList {...props} />);
+    return render(
+      <MemoryRouter>
+        <TimeRangeProvider timeRange={{ pastDuration: '1m' }}>
+          <VariableProvider>
+            <SpanEventList {...props} />
+          </VariableProvider>
+        </TimeRangeProvider>
+      </MemoryRouter>
+    );
   };
 
   it('render', () => {

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/SpanEvents.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/SpanEvents.tsx
@@ -17,16 +17,17 @@ import ChevronUp from 'mdi-material-ui/ChevronUp';
 import ChevronDown from 'mdi-material-ui/ChevronDown';
 import { formatDuration } from '../utils';
 import { Trace, Span, Event } from '../trace';
-import { AttributeItems, AttributeItem, AttributeLinks } from './Attributes';
+import { CustomLinks } from '../../gantt-chart-model';
+import { AttributeItems, AttributeItem } from './Attributes';
 
 export interface SpanEventListProps {
+  customLinks?: CustomLinks;
   trace: Trace;
   span: Span;
-  attributeLinks?: AttributeLinks;
 }
 
 export function SpanEventList(props: SpanEventListProps): ReactElement {
-  const { trace, span, attributeLinks } = props;
+  const { customLinks, trace, span } = props;
 
   return (
     <>
@@ -35,7 +36,7 @@ export function SpanEventList(props: SpanEventListProps): ReactElement {
         .map((event, i) => (
           <Fragment key={i}>
             {i > 0 && <Divider />}
-            <SpanEventItem trace={trace} event={event} attributeLinks={attributeLinks} />
+            <SpanEventItem customLinks={customLinks} trace={trace} event={event} />
           </Fragment>
         ))}
     </>
@@ -43,13 +44,13 @@ export function SpanEventList(props: SpanEventListProps): ReactElement {
 }
 
 interface SpanEventItemProps {
+  customLinks?: CustomLinks;
   trace: Trace;
   event: Event;
-  attributeLinks?: AttributeLinks;
 }
 
 function SpanEventItem(props: SpanEventItemProps): ReactElement {
-  const { trace, event, attributeLinks } = props;
+  const { customLinks, trace, event } = props;
   const relativeTime = event.timeUnixMs - trace.startTimeUnixMs;
 
   const [open, setOpen] = useState(false);
@@ -74,7 +75,7 @@ function SpanEventItem(props: SpanEventItemProps): ReactElement {
         <List sx={{ px: 1 }}>
           <AttributeItem name="name" value={event.name} />
           <AttributeItem name="time" value={formatDuration(relativeTime)} />
-          <AttributeItems attributes={event.attributes} attributeLinks={attributeLinks} />
+          <AttributeItems customLinks={customLinks} attributes={event.attributes} />
         </List>
       </Collapse>
     </List>

--- a/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
@@ -14,20 +14,19 @@
 import { ReactElement, useMemo, useRef, useState } from 'react';
 import { Box, Stack, useTheme } from '@mui/material';
 import { otlptracev1 } from '@perses-dev/core';
-import { TracingGanttChartOptions } from '../gantt-chart-model';
+import { CustomLinks, TracingGanttChartOptions } from '../gantt-chart-model';
 import { MiniGanttChart } from './MiniGanttChart/MiniGanttChart';
 import { DetailPane } from './DetailPane/DetailPane';
 import { Viewport } from './utils';
 import { GanttTable } from './GanttTable/GanttTable';
 import { GanttTableProvider } from './GanttTable/GanttTableProvider';
 import { ResizableDivider } from './GanttTable/ResizableDivider';
-import { AttributeLinks } from './DetailPane/Attributes';
 import { getTraceModel, Span } from './trace';
 import { TraceDetails } from './TraceDetails';
 
 export interface TracingGanttChartProps {
   options: TracingGanttChartOptions;
-  attributeLinks?: AttributeLinks;
+  customLinks?: CustomLinks;
   trace: otlptracev1.TracesData;
 }
 
@@ -38,7 +37,7 @@ export interface TracingGanttChartProps {
  * https://github.com/jaegertracing/jaeger-ui
  */
 export function TracingGanttChart(props: TracingGanttChartProps): ReactElement {
-  const { options, attributeLinks, trace: otlpTrace } = props;
+  const { options, customLinks, trace: otlpTrace } = props;
 
   const theme = useTheme();
   const trace = useMemo(() => {
@@ -80,7 +79,7 @@ export function TracingGanttChart(props: TracingGanttChartProps): ReactElement {
           <ResizableDivider parentRef={ganttChart} spacing={parseInt(theme.spacing(gap))} onMove={setTableWidth} />
           <Box sx={{ width: `${(1 - tableWidth) * 100}%`, overflow: 'auto' }}>
             <DetailPane
-              attributeLinks={attributeLinks}
+              customLinks={customLinks}
               trace={trace}
               span={selectedSpan}
               onCloseBtnClick={() => setSelectedSpan(undefined)}

--- a/tracingganttchart/src/TracingGanttChart/utils.ts
+++ b/tracingganttchart/src/TracingGanttChart/utils.ts
@@ -14,6 +14,7 @@
 import { PersesChartsTheme } from '@perses-dev/components';
 import { Theme } from '@mui/material';
 import { otlptracev1 } from '@perses-dev/core';
+import { replaceVariables, VariableStateMap } from '@perses-dev/plugin-system';
 import { getConsistentCategoricalColor, getConsistentColor } from './palette';
 import { Span } from './trace';
 
@@ -67,4 +68,16 @@ export function formatDuration(timeMs: number): string {
     return `${+timeMs.toFixed(2)}ms`;
   }
   return `${+(timeMs / 1000).toFixed(2)}s`;
+}
+
+export function renderTemplate(
+  template: string | undefined,
+  variableValues: VariableStateMap,
+  extraVariables?: Record<string, string>
+): string | undefined {
+  if (!template) return undefined;
+  for (const [key, value] of Object.entries(extraVariables ?? {})) {
+    variableValues[key] = { value, loading: false };
+  }
+  return replaceVariables(template, variableValues);
 }

--- a/tracingganttchart/src/gantt-chart-model.ts
+++ b/tracingganttchart/src/gantt-chart-model.ts
@@ -11,12 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { ReactNode, MouseEvent } from 'react';
+
 /**
  * The Options object type supported by the TracingGanttChart panel plugin.
  */
-// Note: The interface attributes must match cue/schemas/panels/tracing-gantt-chart/tracing-gantt-chart.cue
+// Note: The interface attributes must match schemas/tracing-gantt-chart.cue
 export interface TracingGanttChartOptions {
   visual?: TracingGanttChartVisualOptions;
+  links?: TracingGanttChartCustomLinks;
 }
 
 export interface TracingGanttChartVisualOptions {
@@ -25,6 +28,22 @@ export interface TracingGanttChartVisualOptions {
 
 export interface TracingGanttChartPaletteOptions {
   mode: 'auto' | 'categorical';
+}
+
+export interface TracingGanttChartCustomLinks {
+  trace?: string;
+  attributes?: TracingGanttChartCustomAttributeLink[];
+}
+
+export interface TracingGanttChartCustomAttributeLink {
+  name: string;
+  link: string;
+}
+
+export interface CustomLinks {
+  RouterComponent: (props: { to: string; onClick?: (event: MouseEvent) => void }) => ReactNode;
+  variables: Record<string, string>;
+  links: TracingGanttChartCustomLinks;
 }
 
 /**


### PR DESCRIPTION
# Description

Previously, the attribute links (linking from span attributes to custom pages) were configured via panel props. However, this works only if the panel is embedded directly, i.e. `<TracingGanttChart.PanelComponent .../>` and doesn't work when included via `<Panel definition={{...}} />`.

This was a problem, because the TempoExplorer in the Tempo plugin includes the panel via the plugin system (via `<Panel ... />`) and therefore cannot pass custom props to the panel plugin.

This change moves the attribute link configuration to the panel spec.

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).