### PR TITLE
[BUGFIX] Set the end of the time range according to the start and step

### DIFF
--- a/prometheus/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/prometheus/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -77,12 +77,23 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
 
   // Align the time range so that it's a multiple of the step
   let { start, end } = timeRange;
+
   const utcOffsetSec = new Date().getTimezoneOffset() * 60;
 
   const alignedEnd = Math.floor((end + utcOffsetSec) / step) * step - utcOffsetSec;
   const alignedStart = Math.floor((start + utcOffsetSec) / step) * step - utcOffsetSec;
   start = alignedStart;
   end = alignedEnd;
+
+  /* Ensure end is always greater than start:
+     If the step is greater than equal to the diff of end and start,
+     both start, and end will eventually be rounded to the same value,
+     Consequently, the time range will be zero, which does not return any valid value
+  */
+  if (end === start) {
+    end = start + step;
+    console.warn(`Step (${step}) was larger than the time range! end of time range was set accordingly.`);
+  }
 
   // Replace variable placeholders in PromQL query
   const intervalMs = step * 1000;


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/2362

# Description

If the selected range of the time-series is shorter than the step, 
The `start` and `end` would be rounded to the same value. Consequently, the time range would be zero.
If the time range is set to zero, the X-Axis scale would not show the proper information. The query also would not be correct, because the range is zero.

This change set the end accordingly to make sure there would be always a valid time range.

<img width="988" height="850" alt="image" src="https://github.com/user-attachments/assets/2b402b1c-c424-4e77-8c3f-491d96b19b28" />



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).