### PR TITLE
[FEATURE] TracingGanttChart: show span links

### DIFF
--- a/tempo/src/plugins/tempo-trace-query/get-trace-data.ts
+++ b/tempo/src/plugins/tempo-trace-query/get-trace-data.ts
@@ -103,13 +103,20 @@ function parseTraceResponse(response: QueryResponse): otlptracev1.TracesData {
         if (span.traceId.length != 32) {
           span.traceId = base64ToHex(span.traceId);
         }
-
         if (span.spanId.length != 16) {
           span.spanId = base64ToHex(span.spanId);
         }
-
         if (span.parentSpanId && span.parentSpanId.length != 16) {
           span.parentSpanId = base64ToHex(span.parentSpanId);
+        }
+
+        for (const link of span.links ?? []) {
+          if (link.traceId.length != 32) {
+            link.traceId = base64ToHex(link.traceId);
+          }
+          if (link.spanId.length != 16) {
+            link.spanId = base64ToHex(link.spanId);
+          }
         }
       }
     }

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
@@ -18,6 +18,7 @@ import { Span, Trace } from '../trace';
 import { CustomLinks } from '../../gantt-chart-model';
 import { TraceAttributes } from './Attributes';
 import { SpanEventList } from './SpanEvents';
+import { SpanLinkList } from './SpanLinks';
 
 export interface DetailPaneProps {
   customLinks?: CustomLinks;
@@ -31,11 +32,15 @@ export interface DetailPaneProps {
  */
 export function DetailPane(props: DetailPaneProps): ReactElement {
   const { customLinks, trace, span, onCloseBtnClick } = props;
-  const [tab, setTab] = useState<'attributes' | 'events'>('attributes');
+  const [tab, setTab] = useState<'attributes' | 'events' | 'links'>('attributes');
 
   // if the events tab is selected, and then a span without events is clicked,
   // we need to switch the current selected tab back to the attributes tab.
   if (tab === 'events' && span.events.length === 0) {
+    setTab('attributes');
+  }
+  // same as above, but for span links
+  if (tab === 'links' && span.links.length === 0) {
     setTab('attributes');
   }
 
@@ -52,10 +57,12 @@ export function DetailPane(props: DetailPaneProps): ReactElement {
         <Tabs value={tab} onChange={(_, tab) => setTab(tab)}>
           <Tab sx={{ p: 0 }} value="attributes" label="Attributes" />
           {span.events.length > 0 && <Tab value="events" label="Events" />}
+          {span.links.length > 0 && <Tab value="links" label="Links" />}
         </Tabs>
       </Box>
       {tab === 'attributes' && <TraceAttributes customLinks={customLinks} trace={trace} span={span} />}
       {tab === 'events' && <SpanEventList customLinks={customLinks} trace={trace} span={span} />}
+      {tab === 'links' && <SpanLinkList customLinks={customLinks} span={span} />}
     </Box>
   );
 }

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/SpanLinks.test.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/SpanLinks.test.tsx
@@ -1,0 +1,64 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { screen } from '@testing-library/dom';
+import { render, RenderResult } from '@testing-library/react';
+import { otlptracev1 } from '@perses-dev/core';
+import { MemoryRouter } from 'react-router-dom';
+import { VariableProvider } from '@perses-dev/dashboards';
+import { ReactRouterProvider, TimeRangeProvider } from '@perses-dev/plugin-system';
+import { CustomLinks } from '../../gantt-chart-model';
+import { getTraceModel } from '../trace';
+import * as exampleTrace from '../../test/traces/example_otlp.json';
+import { SpanLinkList, SpanLinkListProps } from './SpanLinks';
+
+describe('SpanLinks', () => {
+  const trace = getTraceModel(exampleTrace as otlptracev1.TracesData);
+  const renderComponent = (props: SpanLinkListProps): RenderResult => {
+    return render(
+      <MemoryRouter>
+        <ReactRouterProvider>
+          <TimeRangeProvider timeRange={{ pastDuration: '1m' }}>
+            <VariableProvider>
+              <SpanLinkList {...props} />
+            </VariableProvider>
+          </TimeRangeProvider>
+        </ReactRouterProvider>
+      </MemoryRouter>
+    );
+  };
+
+  it('render', () => {
+    renderComponent({ span: trace.rootSpans[0]!.childSpans[0]!.childSpans[0]! });
+
+    expect(screen.getByText('tid1')).toBeInTheDocument();
+    expect(screen.getByText('sid1')).toBeInTheDocument();
+    expect(screen.getByText('link-key1')).toBeInTheDocument();
+    expect(screen.getByText('link-value1')).toBeInTheDocument();
+  });
+
+  it('render link to trace', () => {
+    const customLinks: CustomLinks = {
+      links: {
+        trace: '/datasource/${datasourceName}/trace/${traceId}',
+      },
+      variables: {
+        datasourceName: 'tempods',
+      },
+    };
+
+    renderComponent({ customLinks, span: trace.rootSpans[0]!.childSpans[0]!.childSpans[0]! });
+    expect(screen.getByRole('link', { name: 'tid1' })).toHaveAttribute('href', '/datasource/tempods/trace/tid1');
+    expect(screen.getByRole('link', { name: 'sid1' })).toHaveAttribute('href', '/datasource/tempods/trace/tid1');
+  });
+});

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/SpanLinks.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/SpanLinks.tsx
@@ -1,0 +1,63 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Divider, List } from '@mui/material';
+import { Fragment, ReactElement } from 'react';
+import { useAllVariableValues } from '@perses-dev/plugin-system';
+import { Span, Link } from '../trace';
+import { CustomLinks } from '../../gantt-chart-model';
+import { renderTemplate } from '../utils';
+import { AttributeItem, AttributeItems } from './Attributes';
+
+export interface SpanLinkListProps {
+  customLinks?: CustomLinks;
+  span: Span;
+}
+
+export function SpanLinkList(props: SpanLinkListProps): ReactElement {
+  const { customLinks, span } = props;
+
+  return (
+    <>
+      {span.links.map((link, i) => (
+        <Fragment key={i}>
+          {i > 0 && <Divider />}
+          <SpanLinkItem link={link} customLinks={customLinks} />
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+interface SpanLinkItemProps {
+  customLinks?: CustomLinks;
+  link: Link;
+}
+
+function SpanLinkItem(props: SpanLinkItemProps): ReactElement {
+  const { customLinks, link } = props;
+  const variableValues = useAllVariableValues();
+  const spanLink = renderTemplate(customLinks?.links.trace, variableValues, {
+    ...customLinks?.variables,
+    traceId: link.traceId,
+    spanId: link.spanId,
+  });
+
+  return (
+    <List>
+      <AttributeItem name="trace ID" value={link.traceId} link={spanLink} />
+      <AttributeItem name="span ID" value={link.spanId} link={spanLink} />
+      <AttributeItems customLinks={customLinks} attributes={link.attributes} />
+    </List>
+  );
+}

--- a/tracingganttchart/src/TracingGanttChart/GanttTable/GanttTable.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/GanttTable.tsx
@@ -15,7 +15,7 @@ import { Virtuoso, ListRange } from 'react-virtuoso';
 import { ReactElement, useMemo, useRef, useState } from 'react';
 import { Box, useTheme } from '@mui/material';
 import { Viewport } from '../utils';
-import { TracingGanttChartOptions } from '../../gantt-chart-model';
+import { CustomLinks, TracingGanttChartOptions } from '../../gantt-chart-model';
 import { Span, Trace } from '../trace';
 import { useGanttTableContext } from './GanttTableProvider';
 import { GanttTableRow } from './GanttTableRow';
@@ -24,6 +24,7 @@ import { ResizableDivider } from './ResizableDivider';
 
 export interface GanttTableProps {
   options: TracingGanttChartOptions;
+  customLinks?: CustomLinks;
   trace: Trace;
   viewport: Viewport;
   selectedSpan?: Span;
@@ -31,7 +32,7 @@ export interface GanttTableProps {
 }
 
 export function GanttTable(props: GanttTableProps): ReactElement {
-  const { options, trace, viewport, selectedSpan, onSpanClick } = props;
+  const { options, customLinks, trace, viewport, selectedSpan, onSpanClick } = props;
   const { collapsedSpans, setVisibleSpans } = useGanttTableContext();
   const [nameColumnWidth, setNameColumnWidth] = useState<number>(0.25);
   const tableRef = useRef<HTMLDivElement>(null);
@@ -73,6 +74,7 @@ export function GanttTable(props: GanttTableProps): ReactElement {
         itemContent={(_, span) => (
           <GanttTableRow
             options={options}
+            customLinks={customLinks}
             span={span}
             viewport={viewport}
             selected={span === selectedSpan}

--- a/tracingganttchart/src/TracingGanttChart/GanttTable/GanttTableRow.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/GanttTableRow.tsx
@@ -14,13 +14,14 @@
 import { Stack, styled, useTheme } from '@mui/material';
 import { memo } from 'react';
 import { Viewport, rowHeight } from '../utils';
-import { TracingGanttChartOptions } from '../../gantt-chart-model';
+import { CustomLinks, TracingGanttChartOptions } from '../../gantt-chart-model';
 import { Span } from '../trace';
 import { SpanName } from './SpanName';
 import { SpanDuration } from './SpanDuration';
 
 interface GanttTableRowProps {
   options: TracingGanttChartOptions;
+  customLinks?: CustomLinks;
   span: Span;
   viewport: Viewport;
   selected?: boolean;
@@ -30,7 +31,7 @@ interface GanttTableRowProps {
 }
 
 export const GanttTableRow = memo(function GanttTableRow(props: GanttTableRowProps) {
-  const { options, span, viewport, selected, nameColumnWidth, divider, onClick } = props;
+  const { options, customLinks, span, viewport, selected, nameColumnWidth, divider, onClick } = props;
   const theme = useTheme();
 
   const handleOnClick = (): void => {
@@ -46,7 +47,7 @@ export const GanttTableRow = memo(function GanttTableRow(props: GanttTableRowPro
       direction="row"
       onClick={handleOnClick}
     >
-      <SpanName span={span} nameColumnWidth={nameColumnWidth} />
+      <SpanName customLinks={customLinks} span={span} nameColumnWidth={nameColumnWidth} />
       {divider}
       <SpanDuration options={options} span={span} viewport={viewport} />
     </RowContainer>

--- a/tracingganttchart/src/TracingGanttChart/GanttTable/SpanLinksButton.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/SpanLinksButton.tsx
@@ -1,0 +1,109 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { IconButton, Menu, MenuItem } from '@mui/material';
+import { MouseEvent, useState } from 'react';
+import LaunchIcon from 'mdi-material-ui/Launch';
+import { InfoTooltip } from '@perses-dev/components';
+import { useAllVariableValues, useRouterContext } from '@perses-dev/plugin-system';
+import { Span } from '../trace';
+import { CustomLinks } from '../../gantt-chart-model';
+import { renderTemplate } from '../utils';
+
+export interface SpanLinksButtonProps {
+  customLinks: CustomLinks;
+  span: Span;
+}
+
+export function SpanLinksButton(props: SpanLinksButtonProps) {
+  const { customLinks, span } = props;
+  const variableValues = useAllVariableValues();
+  const { RouterComponent } = useRouterContext();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const isOpen = Boolean(anchorEl);
+
+  if (!RouterComponent || !customLinks.links.trace) {
+    return;
+  }
+
+  // if there is a single span link, render the button directly without a menu
+  if (span.links.length == 1 && span.links[0]) {
+    const link = span.links[0];
+    return (
+      <InfoTooltip description="open linked span">
+        <IconButton
+          size="small"
+          component={RouterComponent}
+          to={
+            renderTemplate(customLinks.links.trace, variableValues, {
+              ...customLinks.variables,
+              traceId: link.traceId,
+              spanId: link.spanId,
+            }) as string
+          }
+        >
+          <LaunchIcon fontSize="inherit" />
+        </IconButton>
+      </InfoTooltip>
+    );
+  }
+
+  const handleOpenMenu = (event: MouseEvent<HTMLButtonElement>) => {
+    // do not propagate onClick event to the table row (otherwise, the detail pane would open)
+    event.stopPropagation();
+
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (event: MouseEvent) => {
+    // Closing the menu, i.e. clicking on the fullscreen transparent MUI backdrop element, does trigger a click on the table row (which opens the detail pane).
+    // Therefore, stop propagating this event
+    event.stopPropagation();
+
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <InfoTooltip description={`${span.links.length} linked spans`}>
+        <IconButton
+          aria-label="span links"
+          aria-haspopup="true"
+          aria-expanded={isOpen ? 'true' : undefined}
+          size="small"
+          onClick={handleOpenMenu}
+        >
+          <LaunchIcon fontSize="inherit" />
+        </IconButton>
+      </InfoTooltip>
+      <Menu anchorEl={anchorEl} open={isOpen} onClose={handleClose}>
+        {span.links.map((link) => (
+          <MenuItem
+            key={link.spanId}
+            component={RouterComponent}
+            onClick={handleClose}
+            to={
+              renderTemplate(customLinks.links.trace, variableValues, {
+                ...customLinks.variables,
+                traceId: link.traceId,
+                spanId: link.spanId,
+              }) as string
+            }
+          >
+            Open linked span {link.spanId}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/tracingganttchart/src/TracingGanttChart/GanttTable/SpanName.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/SpanName.tsx
@@ -16,9 +16,12 @@ import AlertIcon from 'mdi-material-ui/AlertCircleOutline';
 import { ReactElement } from 'react';
 import { spanHasError } from '../utils';
 import { Span } from '../trace';
+import { CustomLinks } from '../../gantt-chart-model';
 import { SpanIndents } from './SpanIndents';
+import { SpanLinksButton } from './SpanLinksButton';
 
 export interface SpanNameProps {
+  customLinks?: CustomLinks;
   span: Span;
   nameColumnWidth: number;
 }
@@ -27,7 +30,7 @@ export interface SpanNameProps {
  * SpanName renders the entire left column of a SpanRow, i.e. the hierarchy and the service and span name
  */
 export function SpanName(props: SpanNameProps): ReactElement {
-  const { span, nameColumnWidth } = props;
+  const { customLinks, span, nameColumnWidth } = props;
 
   return (
     <Stack direction="row" sx={{ alignItems: 'center' }} style={{ width: `${nameColumnWidth * 100}%` }}>
@@ -36,6 +39,11 @@ export function SpanName(props: SpanNameProps): ReactElement {
       <Box sx={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>
         <strong>{span.resource.serviceName}:</strong> {span.name}
       </Box>
+      {customLinks && customLinks.links.trace && span.links.length > 0 && (
+        <Box sx={{ marginLeft: 'auto', px: 1 }}>
+          <SpanLinksButton customLinks={customLinks} span={span} />
+        </Box>
+      )}
     </Stack>
   );
 }

--- a/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
@@ -67,6 +67,7 @@ export function TracingGanttChart(props: TracingGanttChartProps): ReactElement {
         <GanttTableProvider>
           <GanttTable
             options={options}
+            customLinks={customLinks}
             trace={trace}
             viewport={viewport}
             selectedSpan={selectedSpan}

--- a/tracingganttchart/src/TracingGanttChart/trace.test.ts
+++ b/tracingganttchart/src/TracingGanttChart/trace.test.ts
@@ -80,6 +80,20 @@ const spanTree = {
           endTimeUnixMs: 1450,
           attributes: [{ key: 'http.method', value: { stringValue: 'PUT' } }],
           events: [],
+          links: [
+            {
+              traceId: 'tid1',
+              spanId: 'sid1',
+              attributes: [
+                {
+                  key: 'link-key1',
+                  value: {
+                    stringValue: 'link-value1',
+                  },
+                },
+              ],
+            },
+          ],
           status: {},
         },
       ],
@@ -98,6 +112,7 @@ const spanTree = {
           attributes: [{ key: 'event1_key', value: { stringValue: 'event1_value' } }],
         },
       ],
+      links: [],
       status: { message: 'Forbidden', code: 'STATUS_CODE_ERROR' as const },
     },
   ],
@@ -109,6 +124,7 @@ const spanTree = {
   endTimeUnixMs: 2000,
   attributes: [],
   events: [],
+  links: [],
   status: {},
 };
 

--- a/tracingganttchart/src/TracingGanttChart/trace.ts
+++ b/tracingganttchart/src/TracingGanttChart/trace.ts
@@ -43,6 +43,7 @@ export interface Span {
   endTimeUnixMs: number;
   attributes: otlpcommonv1.KeyValue[];
   events: Event[];
+  links: Link[];
   status: otlptracev1.Status;
 }
 
@@ -54,6 +55,12 @@ export interface Resource {
 export interface Event {
   timeUnixMs: number;
   name: string;
+  attributes: otlpcommonv1.KeyValue[];
+}
+
+export interface Link {
+  traceId: string;
+  spanId: string;
   attributes: otlpcommonv1.KeyValue[];
 }
 
@@ -149,6 +156,7 @@ function parseSpan(span: otlptracev1.Span): Omit<Span, 'resource' | 'scope' | 'c
     endTimeUnixMs: parseInt(span.endTimeUnixNano) * 1e-6,
     attributes: span.attributes ?? [],
     events: (span.events ?? []).map(parseEvent),
+    links: (span.links ?? []).map(parseLink),
     status: span.status ?? {},
   };
 }
@@ -158,5 +166,13 @@ function parseEvent(event: otlptracev1.Event): Event {
     timeUnixMs: parseInt(event.timeUnixNano) * 1e-6, // convert to milliseconds because JS cannot handle numbers larger than 9007199254740991
     name: event.name,
     attributes: event.attributes ?? [],
+  };
+}
+
+function parseLink(link: otlptracev1.Link): Link {
+  return {
+    traceId: link.traceId,
+    spanId: link.spanId,
+    attributes: link.attributes ?? [],
   };
 }

--- a/tracingganttchart/src/test/traces/example_otlp.json
+++ b/tracingganttchart/src/test/traces/example_otlp.json
@@ -75,6 +75,20 @@
                       "stringValue": "PUT"
                     }
                   }
+                ],
+                "links": [
+                  {
+                    "traceId": "tid1",
+                    "spanId": "sid1",
+                    "attributes": [
+                      {
+                        "key": "link-key1",
+                        "value": {
+                          "stringValue": "link-value1"
+                        }
+                      }
+                    ]
+                  }
                 ]
               }
             ]


### PR DESCRIPTION
# Description

Show span links next to the span name and in the detail pane.

# Screenshots

Link icon next to span name:
<img width="3388" height="666" alt="image" src="https://github.com/user-attachments/assets/2221b0fc-1bc0-4f30-9b77-74fbc0007436" />

If there are multiple links, show a menu:
<img width="3388" height="666" alt="image" src="https://github.com/user-attachments/assets/57fa5e65-8270-43c3-84f2-ae3dacea2ad2" />

Span link details in the attribute pane:
<img width="3390" height="948" alt="image" src="https://github.com/user-attachments/assets/bf888d07-fd54-4e28-a14c-77a5367469e1" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).