### PR TITLE
[BUGFIX] Fix statchar color for zero values

### DIFF
--- a/statchart/src/utils/get-color.ts
+++ b/statchart/src/utils/get-color.ts
@@ -27,7 +27,7 @@ export function getStatChartColor(
   // Determine the default color from thresholds or theme
   const defaultColor = thresholds?.defaultColor ?? chartsTheme.thresholds.defaultColor;
 
-  if (!value || (!thresholds?.steps && !mappings)) {
+  if (value === undefined || value === null || value === '' || (!thresholds?.steps && !mappings)) {
     return defaultColor;
   }
 
@@ -52,7 +52,7 @@ export function getStatChartColor(
 }
 
 function getColorFromMappings(value: StatChartValue, mappings: ValueMapping[]): string | null {
-  if (mappings?.length && value) {
+  if (mappings?.length && value !== undefined && value !== null) {
     const { color } = applyValueMapping(value, mappings);
     return color || null;
   }


### PR DESCRIPTION
@AntoineThebaud 

Closes https://github.com/perses/perses/issues/3142

## Bug Description 🐞 

Details of the bug can be found here https://github.com/perses/perses/issues/3142


## About the fix 🔧 

JS, the most lovely programming language in the world, equates `0` with `false`. Therefore, developers should be careful with their conditional statements. Since JS considers 0 to be false, if it makes sense for the given scenario, `typeof` should be used instead. 

For more information you can take a look at the following MDN link. 

https://developer.mozilla.org/en-US/docs/Glossary/Falsy

## Screenshots (After the fix)

<img width="887" height="460" alt="image" src="https://github.com/user-attachments/assets/df03cfed-7e99-49ae-bac6-0b052d65f4b6" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).