### PR TITLE
[ignore] bump prometheus and tempo to v0.52.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17178,7 +17178,7 @@
     },
     "prometheus": {
       "name": "@perses-dev/prometheus-plugin",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
         "@prometheus-io/codemirror-promql": "^0.45.6",
@@ -17481,7 +17481,7 @@
     },
     "tempo": {
       "name": "@perses-dev/tempo-plugin",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
         "@grafana/lezer-traceql": "^0.0.20",

--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/prometheus-plugin",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/tempo/package.json
+++ b/tempo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tempo-plugin",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
this bump will release the datasource that includes the fix related to the datasource variable.

See https://github.com/perses/perses/issues/3084 for more info about the bug and https://github.com/perses/perses/pull/3111 for the fix in the cuelang common package