### PR TITLE
[IGNORE] fix build configuration for plugins

### DIFF
--- a/barchart/rsbuild.config.ts
+++ b/barchart/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export const assetPrefix = '/plugins/BarChart/';
+const assetPrefix = '/plugins/BarChart/';
 
 export default defineConfig({
   server: { port: 3005 },

--- a/datasourcevariable/rsbuild.config.ts
+++ b/datasourcevariable/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,49 +11,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+const assetPrefix = '/plugins/DatasourceVariable/';
+
 export default defineConfig({
-  server: {
-    port: 3022,
-  },
-  dev: {
-    assetPrefix: '/plugins/DatasourceVariable/',
-  },
+  server: { port: 3022 },
+  dev: { assetPrefix },
+  source: { entry: { main: './src/index-federation.ts' } },
   output: {
-    assetPrefix: '/plugins/DatasourceVariable/',
-    copy: [{ from: './package.json' }, { from: 'README.md' }],
+    assetPrefix,
+    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
+    distPath: {
+      root: 'dist',
+      js: '__mf/js',
+      css: '__mf/css',
+      font: '__mf/font',
+    },
   },
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginModuleFederation({
+      name: 'DatasourceVariable',
+      exposes: {
+        './DatasourceVariable': './src/DatasourceVariable.tsx',
+      },
+      shared: {
+        react: { requiredVersion: '18.2.0', singleton: true },
+        'react-dom': { requiredVersion: '18.2.0', singleton: true },
+        echarts: { singleton: true },
+        'date-fns': { singleton: true },
+        'date-fns-tz': { singleton: true },
+        lodash: { singleton: true },
+        '@perses-dev/components': { singleton: true },
+        '@perses-dev/plugin-system': { singleton: true },
+        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+        '@emotion/styled': { singleton: true },
+        '@hookform/resolvers': { singleton: true },
+      },
+      dts: false,
+      runtime: false,
+    }),
+  ],
   tools: {
     htmlPlugin: false,
-    rspack: (config, { appendPlugins }) => {
-      config.output!.uniqueName = 'DatasourceVariable';
-      appendPlugins([
-        new ModuleFederationPlugin({
-          name: 'DatasourceVariable',
-          exposes: {
-            './DatasourceVariable': './src/DatasourceVariable.tsx',
-          },
-          shared: {
-            react: { requiredVersion: '18.2.0', singleton: true },
-            'react-dom': { requiredVersion: '18.2.0', singleton: true },
-            echarts: { singleton: true },
-            'date-fns': { singleton: true },
-            'date-fns-tz': { singleton: true },
-            lodash: { singleton: true },
-            '@perses-dev/components': { singleton: true },
-            '@perses-dev/plugin-system': { singleton: true },
-            '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-            '@emotion/styled': { singleton: true },
-            '@hookform/resolvers': { singleton: true },
-          },
-          dts: false,
-          runtime: false,
-        }),
-      ]);
-    },
   },
 });

--- a/datasourcevariable/src/DatasourceVariable.tsx
+++ b/datasourcevariable/src/DatasourceVariable.tsx
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,7 +21,7 @@ type StaticListVariableOptions = {
 
 const EMPTY_SELECTED_KIND = { label: '', value: '' };
 
-const DatasourceVariableOptionEditor = (props: OptionsEditorProps<StaticListVariableOptions>) => {
+export const DatasourceVariableOptionEditor = (props: OptionsEditorProps<StaticListVariableOptions>) => {
   const { onChange, value } = props;
   const { datasourcePluginKind } = value;
   const { data: datasourcePlugins } = useListPluginMetadata(['Datasource']);

--- a/datasourcevariable/src/getPluginModule.ts
+++ b/datasourcevariable/src/getPluginModule.ts
@@ -11,5 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+import { PluginModuleResource, PluginModuleSpec } from '@perses-dev/plugin-system';
+import packageJson from '../package.json';
+
+/**
+ * Returns the plugin module information from package.json
+ */
+export function getPluginModule(): PluginModuleResource {
+  const { name, version, perses } = packageJson;
+  return {
+    kind: 'PluginModule',
+    metadata: {
+      name,
+      version,
+    },
+    spec: perses as PluginModuleSpec,
+  };
+}

--- a/datasourcevariable/src/index-federation.ts
+++ b/datasourcevariable/src/index-federation.ts
@@ -11,5 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+import('./bootstrap');

--- a/datasourcevariable/src/index.tsx
+++ b/datasourcevariable/src/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -10,5 +10,5 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-import('./bootstrap');
+export * from './DatasourceVariable';
+export { getPluginModule } from './getPluginModule';

--- a/flamechart/package.json
+++ b/flamechart/package.json
@@ -1,6 +1,14 @@
 {
-  "name": "@perses-dev/flame-chart",
+  "name": "@perses-dev/flame-chart-plugin",
   "version": "0.1.0",
+  "homepage": "https://github.com/perses/plugins/blob/main/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/perses/plugins.git"
+  },
+  "bugs": {
+    "url": "https://github.com/perses/plugins/issues"
+  },
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",
@@ -12,6 +20,9 @@
     "test": "cross-env LC_ALL=C TZ=UTC jest",
     "type-check": "tsc --noEmit"
   },
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "devDependencies": {
     "@types/color-hash": "^2.0.0"
   },

--- a/flamechart/rsbuild.config.ts
+++ b/flamechart/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,49 +11,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+const assetPrefix = '/plugins/FlameChart/';
+
 export default defineConfig({
-  server: {
-    port: 3021,
-  },
-  dev: {
-    assetPrefix: '/plugins/FlameChart/',
-  },
+  server: { port: 3021 },
+  dev: { assetPrefix },
+  source: { entry: { main: './src/index-federation.ts' } },
   output: {
-    assetPrefix: '/plugins/FlameChart/',
-    copy: [{ from: './package.json' }, { from: 'README.md' }],
+    assetPrefix,
+    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
+    distPath: {
+      root: 'dist',
+      js: '__mf/js',
+      css: '__mf/css',
+      font: '__mf/font',
+    },
   },
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginModuleFederation({
+      name: 'FlameChart',
+      exposes: {
+        './FlameChart': './src/FlameChart.ts',
+      },
+      shared: {
+        react: { requiredVersion: '18.2.0', singleton: true },
+        'react-dom': { requiredVersion: '18.2.0', singleton: true },
+        echarts: { singleton: true },
+        'date-fns': { singleton: true },
+        'date-fns-tz': { singleton: true },
+        lodash: { singleton: true },
+        '@perses-dev/components': { singleton: true },
+        '@perses-dev/plugin-system': { singleton: true },
+        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+        '@emotion/styled': { singleton: true },
+        '@hookform/resolvers': { singleton: true },
+      },
+      dts: false,
+      runtime: false,
+    }),
+  ],
   tools: {
     htmlPlugin: false,
-    rspack: (config, { appendPlugins }) => {
-      config.output!.uniqueName = 'FlameChart';
-      appendPlugins([
-        new ModuleFederationPlugin({
-          name: 'FlameChart',
-          exposes: {
-            './FlameChart': './src/FlameChart.ts',
-          },
-          shared: {
-            react: { requiredVersion: '18.2.0', singleton: true },
-            'react-dom': { requiredVersion: '18.2.0', singleton: true },
-            echarts: { singleton: true },
-            'date-fns': { singleton: true },
-            'date-fns-tz': { singleton: true },
-            lodash: { singleton: true },
-            '@perses-dev/components': { singleton: true },
-            '@perses-dev/plugin-system': { singleton: true },
-            '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-            '@emotion/styled': { singleton: true },
-            '@hookform/resolvers': { singleton: true },
-          },
-          dts: false,
-          runtime: false,
-        }),
-      ]);
-    },
   },
 });

--- a/flamechart/src/components/index.ts
+++ b/flamechart/src/components/index.ts
@@ -11,5 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+export * from './CustomBreadcrumb';
+export * from './FlameChart';
+export * from './FlameChartOptionsEditorSettings';
+export * from './FlameChartPanel';
+export * from './PaletteSelector';
+export * from './SearchBar';
+export * from './SeriesChart';
+export * from './Settings';
+export * from './SwitchSelector';
+export * from './TableChart';

--- a/flamechart/src/getPluginModule.ts
+++ b/flamechart/src/getPluginModule.ts
@@ -11,5 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+import { PluginModuleResource, PluginModuleSpec } from '@perses-dev/plugin-system';
+import packageJson from '../package.json';
+
+/**
+ * Returns the plugin module information from package.json
+ */
+export function getPluginModule(): PluginModuleResource {
+  const { name, version, perses } = packageJson;
+  return {
+    kind: 'PluginModule',
+    metadata: {
+      name,
+      version,
+    },
+    spec: perses as PluginModuleSpec,
+  };
+}

--- a/flamechart/src/index-federation.ts
+++ b/flamechart/src/index-federation.ts
@@ -11,5 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+import('./bootstrap');

--- a/flamechart/tsconfig.json
+++ b/flamechart/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../tsconfig.base.json"
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/lib",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
 }

--- a/gaugechart/rsbuild.config.ts
+++ b/gaugechart/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export const assetPrefix = '/plugins/GaugeChart/';
+const assetPrefix = '/plugins/GaugeChart/';
 
 export default defineConfig({
   server: { port: 3006 },

--- a/heatmapchart/package.json
+++ b/heatmapchart/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@perses-dev/heatmap-chart",
+  "name": "@perses-dev/heatmap-chart-plugin",
   "version": "0.1.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/histogramchart/package.json
+++ b/histogramchart/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@perses-dev/histogram-chart",
+  "name": "@perses-dev/histogram-chart-plugin",
   "version": "0.8.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/markdown/rsbuild.config.ts
+++ b/markdown/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export const assetPrefix = '/plugins/Markdown/';
+const assetPrefix = '/plugins/Markdown/';
 
 export default defineConfig({
   server: { port: 3007 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
       }
     },
     "flamechart": {
-      "name": "@perses-dev/flame-chart",
+      "name": "@perses-dev/flame-chart-plugin",
       "version": "0.1.0",
       "devDependencies": {
         "@types/color-hash": "^2.0.0"
@@ -157,7 +157,7 @@
       }
     },
     "heatmapchart": {
-      "name": "@perses-dev/heatmap-chart",
+      "name": "@perses-dev/heatmap-chart-plugin",
       "version": "0.1.0",
       "peerDependencies": {
         "@perses-dev/components": "^0.52.0-beta.3",
@@ -171,7 +171,7 @@
       }
     },
     "histogramchart": {
-      "name": "@perses-dev/histogram-chart",
+      "name": "@perses-dev/histogram-chart-plugin",
       "version": "0.8.0",
       "peerDependencies": {
         "@perses-dev/components": "^0.52.0-beta.3",
@@ -3648,7 +3648,7 @@
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
-    "node_modules/@perses-dev/flame-chart": {
+    "node_modules/@perses-dev/flame-chart-plugin": {
       "resolved": "flamechart",
       "link": true
     },
@@ -3656,11 +3656,11 @@
       "resolved": "gaugechart",
       "link": true
     },
-    "node_modules/@perses-dev/heatmap-chart": {
+    "node_modules/@perses-dev/heatmap-chart-plugin": {
       "resolved": "heatmapchart",
       "link": true
     },
-    "node_modules/@perses-dev/histogram-chart": {
+    "node_modules/@perses-dev/histogram-chart-plugin": {
       "resolved": "histogramchart",
       "link": true
     },
@@ -3700,7 +3700,7 @@
       "resolved": "prometheus",
       "link": true
     },
-    "node_modules/@perses-dev/pyroscope": {
+    "node_modules/@perses-dev/pyroscope-plugin": {
       "resolved": "pyroscope",
       "link": true
     },
@@ -16129,7 +16129,7 @@
       }
     },
     "pyroscope": {
-      "name": "@perses-dev/pyroscope",
+      "name": "@perses-dev/pyroscope-plugin",
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",

--- a/piechart/rsbuild.config.ts
+++ b/piechart/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export const assetPrefix = '/plugins/PieChart/';
+const assetPrefix = '/plugins/PieChart/';
 
 export default defineConfig({
   server: { port: 3008 },

--- a/prometheus/rsbuild.config.ts
+++ b/prometheus/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export const assetPrefix = '/plugins/Prometheus/';
+const assetPrefix = '/plugins/Prometheus/';
 
 export default defineConfig({
   server: { port: 3009 },

--- a/pyroscope/package.json
+++ b/pyroscope/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@perses-dev/pyroscope",
+  "name": "@perses-dev/pyroscope-plugin",
   "version": "0.1.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/pyroscope/rsbuild.config.ts
+++ b/pyroscope/rsbuild.config.ts
@@ -11,56 +11,58 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+const assetPrefix = '/plugins/Pyroscope/';
+
 export default defineConfig({
-  server: {
-    port: 3020,
-  },
-  dev: {
-    assetPrefix: '/plugins/Pyroscope/',
-  },
+  server: { port: 3020 },
+  dev: { assetPrefix },
+  source: { entry: { main: './src/index-federation.ts' } },
   output: {
-    assetPrefix: '/plugins/Pyroscope/',
-    copy: [{ from: './package.json' }, { from: 'README.md' }],
+    assetPrefix,
+    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
+    distPath: {
+      root: 'dist',
+      js: '__mf/js',
+      css: '__mf/css',
+      font: '__mf/font',
+    },
   },
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginModuleFederation({
+      name: 'Pyroscope',
+      exposes: {
+        './PyroscopeDatasource': './src/plugins/pyroscope-datasource.tsx',
+        './PyroscopeProfileQuery': './src/plugins/pyroscope-profile-query/PyroscopeProfileQuery.ts',
+        './PyroscopeExplorer': './src/explore/PyroscopeExplorer.tsx',
+      },
+      shared: {
+        react: { requiredVersion: '18.2.0', singleton: true },
+        'react-dom': { requiredVersion: '18.2.0', singleton: true },
+        echarts: { singleton: true },
+        'date-fns': { singleton: true },
+        'date-fns-tz': { singleton: true },
+        lodash: { singleton: true },
+        '@perses-dev/components': { singleton: true },
+        '@perses-dev/plugin-system': { singleton: true },
+        '@perses-dev/explore': { singleton: true },
+        '@perses-dev/dashboards': { singleton: true },
+        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+        '@emotion/styled': { singleton: true },
+        '@hookform/resolvers': { singleton: true },
+        '@tanstack/react-query': { singleton: true },
+        'react-hook-form': { singleton: true },
+        'react-router-dom': { singleton: true },
+      },
+      dts: false,
+      runtime: false,
+    }),
+  ],
   tools: {
     htmlPlugin: false,
-    rspack: (config, { appendPlugins }) => {
-      config.output!.uniqueName = 'Pyroscope';
-      appendPlugins([
-        new ModuleFederationPlugin({
-          name: 'Pyroscope',
-          exposes: {
-            './PyroscopeDatasource': './src/plugins/pyroscope-datasource.tsx',
-            './PyroscopeProfileQuery': './src/plugins/pyroscope-profile-query/PyroscopeProfileQuery.ts',
-            './PyroscopeExplorer': './src/explore/PyroscopeExplorer.tsx',
-          },
-          shared: {
-            react: { requiredVersion: '18.2.0', singleton: true },
-            'react-dom': { requiredVersion: '18.2.0', singleton: true },
-            echarts: { singleton: true },
-            'date-fns': { singleton: true },
-            'date-fns-tz': { singleton: true },
-            lodash: { singleton: true },
-            '@perses-dev/components': { singleton: true },
-            '@perses-dev/plugin-system': { singleton: true },
-            '@perses-dev/explore': { singleton: true },
-            '@perses-dev/dashboards': { singleton: true },
-            '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-            '@emotion/styled': { singleton: true },
-            '@hookform/resolvers': { singleton: true },
-            '@tanstack/react-query': { singleton: true },
-            'react-hook-form': { singleton: true },
-            'react-router-dom': { singleton: true },
-          },
-          dts: false,
-          runtime: false,
-        }),
-      ]);
-    },
   },
 });

--- a/pyroscope/src/components/ProfileTypeSelector.tsx
+++ b/pyroscope/src/components/ProfileTypeSelector.tsx
@@ -16,13 +16,13 @@ import { Stack, TextField, MenuItem, CircularProgress } from '@mui/material';
 import { PyroscopeDatasourceSelector } from '../model';
 import { useProfileTypes } from '../utils/use-query';
 
-export interface ProfileTypeProps {
+export interface ProfileTypeSelectorProps {
   datasource: PyroscopeDatasourceSelector;
   value: string;
   onChange?(value: string): void;
 }
 
-export function ProfileType(props: ProfileTypeProps): ReactElement {
+export function ProfileTypeSelector(props: ProfileTypeSelectorProps): ReactElement {
   const { datasource, value, onChange } = props;
 
   const { data: profileTypesOptions, isLoading: isProfileTypesOptionsLoading } = useProfileTypes(datasource);

--- a/pyroscope/src/components/index.ts
+++ b/pyroscope/src/components/index.ts
@@ -11,6 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './ProfileType';
+export * from './ProfileTypeSelector';
 export * from './Service';
 export * from './Filters';

--- a/pyroscope/src/explore/index.ts
+++ b/pyroscope/src/explore/index.ts
@@ -11,5 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+export * from './PyroscopeExplorer';

--- a/pyroscope/src/getPluginModule.ts
+++ b/pyroscope/src/getPluginModule.ts
@@ -11,5 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+import { PluginModuleResource, PluginModuleSpec } from '@perses-dev/plugin-system';
+import packageJson from '../package.json';
+
+/**
+ * Returns the plugin module information from package.json
+ */
+export function getPluginModule(): PluginModuleResource {
+  const { name, version, perses } = packageJson;
+  return {
+    kind: 'PluginModule',
+    metadata: {
+      name,
+      version,
+    },
+    spec: perses as PluginModuleSpec,
+  };
+}

--- a/pyroscope/src/index-federation.ts
+++ b/pyroscope/src/index-federation.ts
@@ -11,5 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+import('./bootstrap');

--- a/pyroscope/src/index.tsx
+++ b/pyroscope/src/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,4 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import('./bootstrap');
+export * from './components';
+export * from './explore';
+export { getPluginModule } from './getPluginModule';
+export * from './model';
+export * from './plugins';

--- a/pyroscope/src/plugins/index.ts
+++ b/pyroscope/src/plugins/index.ts
@@ -11,5 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+export * from './pyroscope-profile-query';
+export * from './pyroscope-datasource-types';
+export * from './pyroscope-datasource';
+export * from './PyroscopeDatasourceEditor';

--- a/pyroscope/src/plugins/pyroscope-profile-query/PyroscopeProfileQueryEditor.tsx
+++ b/pyroscope/src/plugins/pyroscope-profile-query/PyroscopeProfileQueryEditor.tsx
@@ -22,7 +22,7 @@ import {
   isPyroscopeDatasourceSelector,
   PYROSCOPE_DATASOURCE_KIND,
 } from '../../model/pyroscope-selectors';
-import { ProfileType, Service, Filters } from '../../components';
+import { ProfileTypeSelector, Service, Filters } from '../../components';
 import {
   ProfileQueryEditorProps,
   useMaxNodesState,
@@ -85,7 +85,7 @@ export function PyroscopeProfileQueryEditor(props: ProfileQueryEditorProps): Rea
         }}
       >
         <Service datasource={selectedDatasource} value={service} onChange={handleServiceChange} />
-        <ProfileType datasource={selectedDatasource} value={profileType} onChange={handleProfileTypeChange} />
+        <ProfileTypeSelector datasource={selectedDatasource} value={profileType} onChange={handleProfileTypeChange} />
         <TextField
           size="small"
           label="Max Nodes"

--- a/pyroscope/src/plugins/pyroscope-profile-query/index.ts
+++ b/pyroscope/src/plugins/pyroscope-profile-query/index.ts
@@ -11,5 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './components';
-export { getPluginModule } from './getPluginModule';
+export * from './get-profile-data';
+export * from './PyroscopeProfileQuery';
+export * from './PyroscopeProfileQueryEditor';
+export * from './query-editor-model';

--- a/pyroscope/tsconfig.json
+++ b/pyroscope/tsconfig.json
@@ -1,15 +1,8 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
-    "module": "ESNext",
-    "jsx": "react-jsx",
-    "strict": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "outDir": "./dist/lib",
+    "rootDir": "./src"
   },
   "include": ["src"]
 }

--- a/scatterchart/rsbuild.config.ts
+++ b/scatterchart/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export const assetPrefix = '/plugins/ScatterChart/';
+const assetPrefix = '/plugins/ScatterChart/';
 
 export default defineConfig({
   server: { port: 3010 },

--- a/statchart/rsbuild.config.ts
+++ b/statchart/rsbuild.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Perses Authors
+// Copyright 2025 The Perses Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export const assetPrefix = '/plugins/StatChart/';
+const assetPrefix = '/plugins/StatChart/';
 
 export default defineConfig({
   server: { port: 3011 },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
# Description

- fix configuration for building plugins, make older configuration consistent to use the new `@module-federation/rsbuild-plugin` package
- add index-federation.ts to the plugins that missed it
- Fixes the validation in `pyroscope/src/plugins/pyroscope-profile-query/get-profile-data.ts` this was not reported before as the typescript configuration was different.


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).