### PR TITLE
[BUGFIX] Handle long text in promql tree view tooltip

### DIFF
--- a/prometheus/src/components/TreeNode.tsx
+++ b/prometheus/src/components/TreeNode.tsx
@@ -412,11 +412,22 @@ function QueryStatus({
                             ? theme.palette.warning.dark
                             : theme.palette.warning.main,
                         fontFamily: 'monospace',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        flexGrow: 1,
                       }}
                     >
                       {escapeString(value)}
                     </Typography>
-                    <Typography variant="body2" component="span">
+                    <Typography
+                      variant="body2"
+                      component="span"
+                      sx={{
+                        whiteSpace: 'nowrap',
+                        flexShrink: 0,
+                      }}
+                    >
                       ({count}x)
                     </Typography>
                   </ListItem>


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3219

## Description

Simply manages very long text in PromQl tree tooltip

<!-- Context useful to a reviewer -->

## Screenshots


<img width="2265" height="1226" alt="image" src="https://github.com/user-attachments/assets/e072e003-ba1f-48c9-bca1-a8e0bd3fa03f" />


## Test 🧪 

Do the following trick 

```typescript
  {escapeString(value)+'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'}
```

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).