### PR TITLE
[ENHANCEMENT] TimeSeriesChart: Grafana migration: migrate byName-based fixedColor overrides

### DIFF
--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -135,4 +135,18 @@ spec: {
 	if #stacking != "none" {
 		visual: stack: "all"
 	}
+
+	// migrate byName-based fixedColor overrides to querySettings when applicable
+	querySettings: [
+		for override in (*#panel.fieldConfig.overrides | [])
+			if override.matcher.id == "byName" && override.matcher.options != _|_
+				for property in override.properties
+					if (*property.value.fixedColor | null) != null
+						for i, target in (*#panel.targets | [])
+							if target.legendFormat == override.matcher.options {
+								queryIndex: i
+								colorMode: "fixed"
+								colorValue: property.value.fixedColor
+							}
+	]
 }

--- a/timeserieschart/schemas/migrate/tests/basic-2/expected.json
+++ b/timeserieschart/schemas/migrate/tests/basic-2/expected.json
@@ -15,6 +15,7 @@
         "sum"
       ]
     },
+    "querySettings": [],
     "visual": {
       "areaOpacity": 0,
       "connectNulls": true,

--- a/timeserieschart/schemas/migrate/tests/basic/expected.json
+++ b/timeserieschart/schemas/migrate/tests/basic/expected.json
@@ -6,6 +6,7 @@
       "position": "bottom",
       "values": []
     },
+    "querySettings": [],
     "visual": {
       "areaOpacity": 0.1,
       "connectNulls": false,

--- a/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/expected.json
+++ b/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/expected.json
@@ -1,0 +1,50 @@
+{
+  "kind": "TimeSeriesChart",
+  "spec": {
+    "legend": {
+      "mode": "list",
+      "position": "bottom",
+      "values": []
+    },
+    "querySettings": [
+      {
+        "queryIndex": 2,
+        "colorMode": "fixed",
+        "colorValue": "#890F02"
+      },
+      {
+        "queryIndex": 5,
+        "colorMode": "fixed",
+        "colorValue": "#052B51"
+      },
+      {
+        "queryIndex": 0,
+        "colorMode": "fixed",
+        "colorValue": "#EAB839"
+      },
+      {
+        "queryIndex": 1,
+        "colorMode": "fixed",
+        "colorValue": "#0A437C"
+      },
+      {
+        "queryIndex": 4,
+        "colorMode": "fixed",
+        "colorValue": "#6D1F62"
+      }
+    ],
+    "visual": {
+      "areaOpacity": 0.4,
+      "connectNulls": false,
+      "display": "line",
+      "lineWidth": 1,
+      "stack": "all"
+    },
+    "yAxis": {
+      "format": {
+        "unit": "percent-decimal"
+      },
+      "min": 0
+    }
+  }
+}

--- a/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/input.json
+++ b/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/input.json
@@ -1,0 +1,227 @@
+{
+  "id": 77,
+  "type": "timeseries",
+  "title": "CPU Basic",
+  "description": "CPU time spent busy vs idle, split by activity type",
+  "gridPos": {
+    "x": 0,
+    "y": 6,
+    "h": 7,
+    "w": 12
+  },
+  "fieldConfig": {
+    "defaults": {
+      "custom": {
+        "drawStyle": "line",
+        "lineInterpolation": "smooth",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "lineWidth": 1,
+        "fillOpacity": 40,
+        "gradientMode": "none",
+        "spanNulls": false,
+        "insertNulls": false,
+        "showPoints": "never",
+        "pointSize": 5,
+        "stacking": {
+          "mode": "percent",
+          "group": "A"
+        },
+        "axisPlacement": "auto",
+        "axisLabel": "",
+        "axisColorMode": "text",
+        "axisBorderShow": false,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "axisCenteredZero": false,
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "color": {
+        "mode": "palette-classic"
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "links": [],
+      "min": 0,
+      "unit": "percentunit"
+    },
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Busy Iowait"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "#890F02",
+              "mode": "fixed"
+            }
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Idle"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "#052B51",
+              "mode": "fixed"
+            }
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Busy System"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "#EAB839",
+              "mode": "fixed"
+            }
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Busy User"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "#0A437C",
+              "mode": "fixed"
+            }
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Busy Other"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "#6D1F62",
+              "mode": "fixed"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "pluginVersion": "11.6.3",
+  "targets": [
+    {
+      "editorMode": "code",
+      "exemplar": false,
+      "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=\"system\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "intervalFactor": 1,
+      "legendFormat": "Busy System",
+      "range": true,
+      "refId": "A",
+      "step": 240
+    },
+    {
+      "editorMode": "code",
+      "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=\"user\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
+      "format": "time_series",
+      "hide": false,
+      "intervalFactor": 1,
+      "legendFormat": "Busy User",
+      "range": true,
+      "refId": "B",
+      "step": 240
+    },
+    {
+      "editorMode": "code",
+      "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=\"iowait\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Busy Iowait",
+      "range": true,
+      "refId": "C",
+      "step": 240
+    },
+    {
+      "editorMode": "code",
+      "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=~\".*irq\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Busy IRQs",
+      "range": true,
+      "refId": "D",
+      "step": 240
+    },
+    {
+      "editorMode": "code",
+      "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\",  mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq'}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Busy Other",
+      "range": true,
+      "refId": "E",
+      "step": 240
+    },
+    {
+      "editorMode": "code",
+      "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=\"idle\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "Idle",
+      "range": true,
+      "refId": "F",
+      "step": 240
+    }
+  ],
+  "datasource": {
+    "type": "prometheus",
+    "uid": "argos-world"
+  },
+  "options": {
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc",
+      "hideZeros": false
+    },
+    "legend": {
+      "showLegend": true,
+      "displayMode": "list",
+      "placement": "bottom",
+      "calcs": [],
+      "width": 250
+    }
+  }
+}

--- a/timeserieschart/schemas/migrate/tests/legacy-panel/expected.json
+++ b/timeserieschart/schemas/migrate/tests/legacy-panel/expected.json
@@ -1,4 +1,6 @@
 {
   "kind": "TimeSeriesChart",
-  "spec": {}
+  "spec": {
+    "querySettings": []
+  }
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Enriches the migration of the `timeseries` panel from Grafana to migrate byName-based fixedColor overrides into `querySettings`.

# Screenshots

When importing the Node Exporter Full dashboard, the "CPU basic" timeseries panel now properly has color overrides defined as in the original:

<img width="283" height="365" alt="image" src="https://github.com/user-attachments/assets/c459fcb1-15dc-4146-a085-0fbdb61f66e7" />

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).