### PR TITLE
[BUGFIX] Tempo TraceQL editor: escape label values and support backticks

### DIFF
--- a/tempo/src/components/complete.test.ts
+++ b/tempo/src/components/complete.test.ts
@@ -11,15 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { EditorState } from '@uiw/react-codemirror';
+import { EditorState, EditorView } from '@uiw/react-codemirror';
 import { parser } from '@grafana/lezer-traceql';
 import { LRLanguage, ensureSyntaxTree } from '@codemirror/language';
-import { Completions, identifyCompletions } from './complete';
+import { identifyCompletions, applyQuotedCompletion } from './complete';
 
 const traceQLExtension = LRLanguage.define({ parser: parser });
 
 describe('complete', () => {
-  const tests: Array<{ expr: string; pos?: number; expected: Completions | undefined }> = [
+  it.each([
     // start
     {
       expr: '',
@@ -188,9 +188,7 @@ describe('complete', () => {
       expr: '{ status=e',
       expected: { scopes: [{ kind: 'TagValue', tag: 'status' }], from: 9 },
     },
-  ];
-
-  it.each(tests)('retrieve completions for $expr', ({ expr, pos, expected }) => {
+  ])('retrieve completions for $expr', ({ expr, pos, expected }) => {
     if (pos === undefined) pos = expr.length;
     if (pos < 0) pos = expr.length + pos;
 
@@ -199,5 +197,27 @@ describe('complete', () => {
     expect(tree).not.toBeNull();
     const completions = identifyCompletions(state, pos, tree!);
     expect(completions).toEqual(expected);
+  });
+
+  it.each([
+    { doc: '{ .http.method=', completion: 'GET', from: 15, expected: '{ .http.method="GET"' },
+    { doc: '{ .http.method="', completion: 'GET', from: 16, expected: '{ .http.method="GET"' },
+    // cursor before "
+    { doc: '{ .http.method="', completion: 'GET', from: 15, expected: '{ .http.method="GET"' },
+    { doc: '{ .http.method=""', completion: 'GET', from: 16, expected: '{ .http.method="GET"' },
+    { doc: '{ .http.method=', completion: 'GE"T', from: 15, expected: '{ .http.method="GE\\"T"' },
+
+    { doc: '{ .http.method=GE', completion: 'GET', from: 15, to: 17, expected: '{ .http.method="GET"' },
+    { doc: '{ .http.method="GE"', completion: 'GET', from: 16, to: 18, expected: '{ .http.method="GET"' },
+
+    { doc: '{ .http.method=`', completion: 'GET', from: 16, expected: '{ .http.method=`GET`' },
+    // cursor before `
+    { doc: '{ .http.method=`', completion: 'GET', from: 15, expected: '{ .http.method=`GET`' },
+    { doc: '{ .http.method=`', completion: 'GE"T', from: 16, expected: '{ .http.method=`GE"T`' },
+  ])('quote completion $completion at $doc pos $pos', ({ doc, completion, from, to, expected }) => {
+    const state = EditorState.create({ doc });
+    const view = new EditorView({ state });
+    applyQuotedCompletion(view, { label: completion }, from, to ?? from);
+    expect(view.state.doc.toString()).toBe(expected);
   });
 });

--- a/tempo/src/components/complete.ts
+++ b/tempo/src/components/complete.ts
@@ -45,6 +45,9 @@ export interface Completions {
   to?: number;
 }
 
+const quoteChars = ['"', '`'];
+const defaultQuoteChar = '"';
+
 export async function complete(
   completionCfg: CompletionConfig,
   { state, pos }: CompletionContext
@@ -179,7 +182,7 @@ export function identifyCompletions(state: EditorState, pos: number, tree: Tree)
         const fieldExpr = node.parent.firstChild;
         const attribute = state.sliceDoc(fieldExpr.from, fieldExpr.to);
         // ignore leading " in { name="HT
-        const from = state.sliceDoc(node.from, node.from + 1) === '"' ? node.from + 1 : node.from;
+        const from = quoteChars.includes(state.sliceDoc(node.from, node.from + 1)) ? node.from + 1 : node.from;
         return { scopes: [{ kind: 'TagValue', tag: attribute }], from };
       }
 
@@ -256,13 +259,21 @@ async function completeTagName(
  * { name="x
  * { name="x" where cursor is after the 'x'
  */
-function applyQuotedCompletion(view: EditorView, completion: Completion, from: number, to: number): void {
-  let insertText = completion.label;
-  if (view.state.sliceDoc(from - 1, from) !== '"') {
-    insertText = '"' + insertText;
+export function applyQuotedCompletion(view: EditorView, completion: Completion, from: number, to: number): void {
+  let quoteChar = defaultQuoteChar;
+  if (quoteChars.includes(view.state.sliceDoc(from - 1, from))) {
+    quoteChar = view.state.sliceDoc(from - 1, from);
+  } else if (quoteChars.includes(view.state.sliceDoc(to, to + 1))) {
+    quoteChar = view.state.sliceDoc(to, to + 1);
   }
-  if (view.state.sliceDoc(to, to + 1) !== '"') {
-    insertText = insertText + '"';
+
+  let insertText = quoteChar == '"' ? completion.label.replaceAll('"', '\\"') : completion.label;
+
+  if (view.state.sliceDoc(from - 1, from) !== quoteChar) {
+    insertText = quoteChar + insertText;
+  }
+  if (view.state.sliceDoc(to, to + 1) !== quoteChar) {
+    insertText = insertText + quoteChar;
   }
   view.dispatch(insertCompletionText(view.state, insertText, from, to));
 }


### PR DESCRIPTION
# Description

In the TraceQL auto-completion:
* escape label values which contain `"` when using `"` as quotation character
* support backtick as quotation character

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).