### PR TITLE
[BUGFIX] Tempo filter bar: escape backslash

### DIFF
--- a/tempo/src/components/filter/filter_to_traceql.ts
+++ b/tempo/src/components/filter/filter_to_traceql.ts
@@ -24,7 +24,7 @@ export function filterToTraceQL(filter: Filter) {
 }
 
 function escape(q: string) {
-  return q.replace(/"/g, '\\"');
+  return q.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 }
 
 function stringMatcher(attribute: string, values: string[]) {

--- a/tempo/src/components/filter/traceql.test.ts
+++ b/tempo/src/components/filter/traceql.test.ts
@@ -52,6 +52,19 @@ describe('TraceQL query', () => {
         customMatchers: ['span.http.status_code=200', 'span.http.method="GET"', 'event:name="test"'],
       },
     },
+    {
+      query: '{ name = "service \\\\ \\" end" && span.http.route="/some/regex \\\\ \\" end" }',
+      expected: {
+        serviceName: [],
+        spanName: ['service \\ " end'],
+        namespace: [],
+        status: [],
+        spanDuration: {},
+        traceDuration: {},
+        // custom matcher values are not escaped
+        customMatchers: ['span.http.route="/some/regex \\\\ \\" end"'],
+      },
+    },
   ])('parse $query', ({ query, expected }) => {
     const filter = traceQLToFilter(query);
     expect(filter).toEqual(expected);

--- a/tempo/src/components/filter/traceql_to_filter.ts
+++ b/tempo/src/components/filter/traceql_to_filter.ts
@@ -65,7 +65,7 @@ function parseQuery(query: string) {
 }
 
 function unescape(q: string) {
-  return q.replace(/\\"/g, '"');
+  return q.replaceAll('\\"', '"').replaceAll('\\\\', '\\');
 }
 
 function reverseStringMatcher(matches?: Matcher[]) {


### PR DESCRIPTION
# Description

Tempo filter bar: escape backslash

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).