### PR TITLE
[ENHANCEMENT] TracingGanttChart: support linking to Gantt Chart with …

### DIFF
--- a/scatterchart/src/scatter-chart-model.ts
+++ b/scatterchart/src/scatter-chart-model.ts
@@ -26,7 +26,10 @@ export interface ScatterChartOptions {
   /** range of the circles diameter */
   sizeRange?: [number, number];
 
-  /** where to navigate after clicking on a bubble */
+  /**
+   * Where to navigate after clicking on a bubble.
+   * Supported variables: datasourceName, traceId
+   */
   link?: string;
 }
 

--- a/tempo/src/explore/links.ts
+++ b/tempo/src/explore/links.ts
@@ -1,0 +1,70 @@
+// Copyright 2025 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const linkToTraceParams = new URLSearchParams({
+  explorer: 'Tempo-TempoExplorer',
+  data: JSON.stringify({
+    queries: [
+      {
+        kind: 'TraceQuery',
+        spec: {
+          plugin: {
+            kind: 'TempoTraceQuery',
+            spec: {
+              query: 'TRACEID',
+              datasource: {
+                kind: 'TempoDatasource',
+                name: 'DATASOURCENAME',
+              },
+            },
+          },
+        },
+      },
+    ],
+  }),
+});
+
+const linkToSpanParams = new URLSearchParams({
+  explorer: 'Tempo-TempoExplorer',
+  data: JSON.stringify({
+    queries: [
+      {
+        kind: 'TraceQuery',
+        spec: {
+          plugin: {
+            kind: 'TempoTraceQuery',
+            spec: {
+              query: 'TRACEID',
+              datasource: {
+                kind: 'TempoDatasource',
+                name: 'DATASOURCENAME',
+              },
+            },
+          },
+        },
+      },
+    ],
+    spanId: 'SPANID',
+  }),
+});
+
+// add ${...} syntax after the URL is URL-encoded, because the characters ${} must not be URL-encoded
+export const linkToTrace = `/explore?${linkToTraceParams}`
+  .replace('DATASOURCENAME', '${datasourceName}')
+  .replace('TRACEID', '${traceId}');
+
+// add ${...} syntax after the URL is URL-encoded, because the characters ${} must not be URL-encoded
+export const linkToSpan = `/explore?${linkToSpanParams}`
+  .replace('DATASOURCENAME', '${datasourceName}')
+  .replace('TRACEID', '${traceId}')
+  .replace('SPANID', '${spanId}');

--- a/tracetable/src/trace-table-model.ts
+++ b/tracetable/src/trace-table-model.ts
@@ -29,6 +29,10 @@ export interface TraceTablePaletteOptions {
 }
 
 export interface TraceTableCustomLinks {
+  /**
+   * Link to a trace.
+   * Supported variables: datasourceName, traceId
+   */
   trace?: string;
 }
 

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/SpanLinks.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/SpanLinks.tsx
@@ -46,8 +46,14 @@ interface SpanLinkItemProps {
 function SpanLinkItem(props: SpanLinkItemProps): ReactElement {
   const { customLinks, link } = props;
   const variableValues = useAllVariableValues();
-  const spanLink = customLinks?.links.trace
+  const traceLink = customLinks?.links.trace
     ? replaceVariablesInString(customLinks.links.trace, variableValues, {
+        ...customLinks?.variables,
+        traceId: link.traceId,
+      })
+    : undefined;
+  const spanLink = customLinks?.links.span
+    ? replaceVariablesInString(customLinks.links.span, variableValues, {
         ...customLinks?.variables,
         traceId: link.traceId,
         spanId: link.spanId,
@@ -56,7 +62,7 @@ function SpanLinkItem(props: SpanLinkItemProps): ReactElement {
 
   return (
     <List>
-      <AttributeItem name="trace ID" value={link.traceId} link={spanLink} />
+      <AttributeItem name="trace ID" value={link.traceId} link={traceLink} />
       <AttributeItem name="span ID" value={link.spanId} link={spanLink} />
       <AttributeItems customLinks={customLinks} attributes={link.attributes} />
     </List>

--- a/tracingganttchart/src/TracingGanttChart/GanttTable/GanttTable.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/GanttTable.tsx
@@ -46,6 +46,17 @@ export function GanttTable(props: GanttTableProps): ReactElement {
     return rows;
   }, [trace.rootSpans, collapsedSpans]);
 
+  const selectedSpanIndex = useMemo(() => {
+    if (!selectedSpan) return undefined;
+
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i]?.spanId === selectedSpan.spanId) {
+        return i;
+      }
+    }
+    return undefined;
+  }, [rows, selectedSpan]);
+
   const divider = <ResizableDivider parentRef={tableRef} onMove={setNameColumnWidth} />;
 
   // update currently visible spans
@@ -71,6 +82,7 @@ export function GanttTable(props: GanttTableProps): ReactElement {
       <GanttTableHeader trace={trace} viewport={viewport} nameColumnWidth={nameColumnWidth} divider={divider} />
       <Virtuoso
         data={rows}
+        initialTopMostItemIndex={selectedSpanIndex ?? 0}
         itemContent={(_, span) => (
           <GanttTableRow
             options={options}

--- a/tracingganttchart/src/TracingGanttChart/GanttTable/SpanLinksButton.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/SpanLinksButton.tsx
@@ -31,7 +31,7 @@ export function SpanLinksButton(props: SpanLinksButtonProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const isOpen = Boolean(anchorEl);
 
-  if (!RouterComponent || !customLinks.links.trace) {
+  if (!RouterComponent || !customLinks.links.span) {
     return;
   }
 
@@ -43,7 +43,7 @@ export function SpanLinksButton(props: SpanLinksButtonProps) {
         <IconButton
           size="small"
           component={RouterComponent}
-          to={replaceVariablesInString(customLinks.links.trace, variableValues, {
+          to={replaceVariablesInString(customLinks.links.span, variableValues, {
             ...customLinks.variables,
             traceId: link.traceId,
             spanId: link.spanId,
@@ -89,7 +89,7 @@ export function SpanLinksButton(props: SpanLinksButtonProps) {
             key={link.spanId}
             component={RouterComponent}
             onClick={handleClose}
-            to={replaceVariablesInString(customLinks.links.trace!, variableValues, {
+            to={replaceVariablesInString(customLinks.links.span!, variableValues, {
               ...customLinks.variables,
               traceId: link.traceId,
               spanId: link.spanId,

--- a/tracingganttchart/src/TracingGanttChart/GanttTable/SpanName.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/SpanName.tsx
@@ -39,7 +39,7 @@ export function SpanName(props: SpanNameProps): ReactElement {
       <Box sx={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>
         <strong>{span.resource.serviceName}:</strong> {span.name}
       </Box>
-      {customLinks && customLinks.links.trace && span.links.length > 0 && (
+      {customLinks && customLinks.links.span && span.links.length > 0 && (
         <Box sx={{ marginLeft: 'auto', px: 1 }}>
           <SpanLinksButton customLinks={customLinks} span={span} />
         </Box>

--- a/tracingganttchart/src/TracingGanttChart/MiniGanttChart/draw.ts
+++ b/tracingganttchart/src/TracingGanttChart/MiniGanttChart/draw.ts
@@ -17,14 +17,6 @@ import { minSpanWidthPx } from '../utils';
 const MIN_BAR_HEIGHT = 1;
 const MAX_BAR_HEIGHT = 7;
 
-function countSpans(span: Span): number {
-  let n = 1;
-  for (const childSpan of span.childSpans) {
-    n += countSpans(childSpan);
-  }
-  return n;
-}
-
 export function drawSpans(
   ctx: CanvasRenderingContext2D,
   width: number,
@@ -33,7 +25,7 @@ export function drawSpans(
   spanColorGenerator: (span: Span) => string
 ): void {
   // calculate optimal height, enforce min and max bar height and finally round to an integer
-  const numSpans = trace.rootSpans.map(countSpans).reduce((acc, n) => acc + n, 0);
+  const numSpans = trace.spanById.size;
   const barHeight = Math.round(Math.min(Math.max(height / numSpans, MIN_BAR_HEIGHT), MAX_BAR_HEIGHT));
 
   const traceDuration = trace.endTimeUnixMs - trace.startTimeUnixMs;

--- a/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
@@ -51,7 +51,9 @@ export function TracingGanttChart(props: TracingGanttChartProps): ReactElement {
     startTimeUnixMs: trace.startTimeUnixMs,
     endTimeUnixMs: trace.endTimeUnixMs,
   });
-  const [selectedSpan, setSelectedSpan] = useState<Span | undefined>(undefined);
+  const [selectedSpan, setSelectedSpan] = useState<Span | undefined>(() =>
+    options.selectedSpanId ? trace.spanById.get(options.selectedSpanId) : undefined
+  );
 
   const ganttChart = useRef<HTMLDivElement>(null);
   // tableWidth only comes to effect if the detail pane is visible.

--- a/tracingganttchart/src/gantt-chart-model.ts
+++ b/tracingganttchart/src/gantt-chart-model.ts
@@ -18,6 +18,11 @@
 export interface TracingGanttChartOptions {
   visual?: TracingGanttChartVisualOptions;
   links?: TracingGanttChartCustomLinks;
+  /**
+   * Span ID of the initially selected span.
+   * This property is used in the explore view when clicking on span links, and is intentionally not exposed in the Cue schema.
+   */
+  selectedSpanId?: string;
 }
 
 export interface TracingGanttChartVisualOptions {
@@ -29,12 +34,26 @@ export interface TracingGanttChartPaletteOptions {
 }
 
 export interface TracingGanttChartCustomLinks {
+  /**
+   * Link to a trace.
+   * Supported variables: datasourceName, traceId
+   */
   trace?: string;
+
+  /**
+   * Link to a trace, with the span selected.
+   * Supported variables: datasourceName, traceId, spanId
+   */
+  span?: string;
   attributes?: TracingGanttChartCustomAttributeLink[];
 }
 
 export interface TracingGanttChartCustomAttributeLink {
   name: string;
+  /**
+   * Link to an arbitrary attribute value.
+   * Supported variables: datasourceName and all other attributes
+   */
   link: string;
 }
 


### PR DESCRIPTION
# Description

TracingGanttChart: support linking to Gantt Chart with a span selected.

This change adds a `selectedSpanId` property to the Gantt Chart. When this property is set, the referenced span is visible (i.e. on top of the current viewport) and selected (highlighted and the detail pane is open).

This is mainly used to highlight the referenced span when clicking on a span link.

# Screenshots

https://github.com/user-attachments/assets/3f5cffe6-3cfd-49fa-b2d9-f779512ce81d

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).