### PR TITLE
[ENHANCEMENT] GaugeChart: Add show legend flag

### DIFF
--- a/gaugechart/schemas/gauge.cue
+++ b/gaugechart/schemas/gauge.cue
@@ -23,4 +23,9 @@ spec: close({
 	format?:     common.#format
 	thresholds?: common.#thresholds
 	max?:        number // determines end value of last threshold color segment when unit is not a percent
+	legend?: #legend
 })
+
+#legend: {
+	show?: bool | *true
+}

--- a/gaugechart/src/GaugeChartOptionsEditorSettings.tsx
+++ b/gaugechart/src/GaugeChartOptionsEditorSettings.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TextField } from '@mui/material';
+import { Switch, TextField } from '@mui/material';
 import {
   FormatControls,
   FormatControlsProps,
@@ -36,6 +36,10 @@ import {
 
 export function GaugeChartOptionsEditorSettings(props: GaugeChartOptionsEditorProps): ReactElement {
   const { onChange, value } = props;
+  /* If legend setting doesn't exist (because it is optional), the legend should show by default 
+     This is for the records before the legend option was added
+  */
+  const showLegend = value?.legend?.show ?? true;
 
   const handleCalculationChange: CalculationSelectorProps['onChange'] = (newCalculation) => {
     onChange(
@@ -101,6 +105,21 @@ export function GaugeChartOptionsEditorSettings(props: GaugeChartOptionsEditorPr
       </OptionsEditorColumn>
       <OptionsEditorColumn>
         <ThresholdsEditor thresholds={value.thresholds} onChange={handleThresholdsChange} />
+        <OptionsEditorControl
+          label="Show legend"
+          control={
+            <Switch
+              onChange={(): void => {
+                onChange(
+                  produce(value, (draft: GaugeChartOptions) => {
+                    draft.legend = { ...draft.legend, show: !showLegend };
+                  })
+                );
+              }}
+              checked={showLegend}
+            />
+          }
+        />
       </OptionsEditorColumn>
     </OptionsEditorGrid>
   );

--- a/gaugechart/src/gauge-chart-model.ts
+++ b/gaugechart/src/gauge-chart-model.ts
@@ -33,6 +33,7 @@ export interface GaugeChartOptions {
   format?: FormatOptions;
   thresholds?: ThresholdOptions;
   max?: number;
+  legend?: { show?: boolean };
 }
 
 export type GaugeChartOptionsEditorProps = OptionsEditorProps<GaugeChartOptions>;


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3252 

## Description 🖊️ 

This change adds a bool switch option to the Gauge Spec Settings panel by which the users can choose to show or hide the legend.  

## TEST 🧪 

1. Add two gauges with and without legends. 
2. Edit an existing gauge. It should have `show legend` set to true by default to keep the current behavior. You can set it to false and disable the legend. 


# Screenshots

<img width="890" height="314" alt="image" src="https://github.com/user-attachments/assets/b2148e3c-0c1d-4f5e-a890-99dfcd6234ef" />



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).