### PR TITLE
[IGNORE] TracingGanttChart: return null instead of undefined in React components

### DIFF
--- a/tracingganttchart/src/PanelActions.tsx
+++ b/tracingganttchart/src/PanelActions.tsx
@@ -31,7 +31,7 @@ export function DownloadTraceAction(props: TracingGanttChartPanelProps) {
   }, [trace]);
 
   if (!trace) {
-    return;
+    return null;
   }
 
   return (

--- a/tracingganttchart/src/TracingGanttChart/GanttTable/SpanLinksButton.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/SpanLinksButton.tsx
@@ -32,7 +32,7 @@ export function SpanLinksButton(props: SpanLinksButtonProps) {
   const isOpen = Boolean(anchorEl);
 
   if (!RouterComponent || !customLinks.links.span) {
-    return;
+    return null;
   }
 
   // if there is a single span link, render the button directly without a menu


### PR DESCRIPTION
# Description

Returning undefined is only supported in React 18+, and will throw an error in React 17.
https://github.com/reactwg/react-18/discussions/75

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).