### PR TITLE
[BUGFIX] Track query editor datasource change

### DIFF
--- a/prometheus/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/prometheus/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -74,6 +74,10 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
 
   const handleDatasourceChange: DatasourceSelectProps['onChange'] = (next) => {
     if (isPrometheusDatasourceSelector(next)) {
+      /* Good to know: The usage of onchange here causes an immediate spec update which eventually updates the panel
+         This was probably intentional to allow for quick switching between datasources.
+         Could have been triggered only with Run Query button as well.
+      */
       onChange(
         produce(value, (draft) => {
           // If they're using the default, just omit the datasource prop (i.e. set to undefined)
@@ -81,6 +85,8 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
           draft.datasource = nextDatasource;
         })
       );
+      if (queryHandlerSettings?.setWatchOtherSpecs)
+        queryHandlerSettings.setWatchOtherSpecs({ ...value, datasource: next });
       return;
     }
 


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3282

# Description

Details can be found on the issue

## What was the issue ❓ 

Forgot to track the changes of the data source just like other fields!

## Test 🧪 

Attach to the plugin, and try to reproduce the mentioned bug in the issue

>  ./percli.exe plugin start /projects/plugins/prometheus/


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).