### PR TITLE
[BUGFIX] Prometheus: Track the changes of variable

### DIFF
--- a/tempo/src/plugins/tempo-trace-query/TempoTraceQueryEditor.tsx
+++ b/tempo/src/plugins/tempo-trace-query/TempoTraceQueryEditor.tsx
@@ -59,6 +59,8 @@ export function TempoTraceQueryEditor(props: TraceQueryEditorProps): ReactElemen
           draft.datasource = nextDatasource;
         })
       );
+      if (queryHandlerSettings?.setWatchOtherSpecs)
+        queryHandlerSettings.setWatchOtherSpecs({ ...value, datasource: next });
       return;
     }
 


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3265

# Description
Details of the bug can be found in the issue

## What was the problem ❓ 

Changes of the prometheus\src\plugins\prometheus-variables.tsx had not been tracked. Consequently, clicking on the Run Query Button would eliminate the dangling state of the controls. 

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).