### PR TITLE
[BUGFIX] Prometheus: fix diplay names of variable plugins

### DIFF
--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -85,7 +85,7 @@
         "kind": "Variable",
         "spec": {
           "display": {
-            "name": "Prometheus Label Variable"
+            "name": "Prometheus Label Values Variable"
           },
           "name": "PrometheusLabelValuesVariable"
         }
@@ -94,7 +94,7 @@
         "kind": "Variable",
         "spec": {
           "display": {
-            "name": "Prometheus Names Variable"
+            "name": "Prometheus Label Names Variable"
           },
           "name": "PrometheusLabelNamesVariable"
         }


### PR DESCRIPTION
# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).