### PR TITLE
[BUGFIX] Tempo: do not escape raw strings in TraceQL auto-complete

### DIFF
--- a/tempo/src/components/complete.test.ts
+++ b/tempo/src/components/complete.test.ts
@@ -216,6 +216,8 @@ describe('complete', () => {
     // cursor before `
     { doc: '{ .http.method=`', completion: 'GET', from: 15, expected: '{ .http.method=`GET`' },
     { doc: '{ .http.method=`', completion: 'GE"T', from: 16, expected: '{ .http.method=`GE"T`' },
+    { doc: '{ .http.method=`', completion: 'GE\\T', from: 16, expected: '{ .http.method=`GE\\T`' },
+    { doc: '{ .http.method=`', completion: 'GE \\ " T', from: 16, expected: '{ .http.method=`GE \\ " T`' },
   ])('quote completion $completion at $doc pos $pos', ({ doc, completion, from, to, expected }) => {
     const state = EditorState.create({ doc });
     const view = new EditorView({ state });

--- a/tempo/src/components/complete.ts
+++ b/tempo/src/components/complete.ts
@@ -253,11 +253,15 @@ async function completeTagName(
 }
 
 function escapeString(input: string, quoteChar: string) {
-  let escaped = input;
-  escaped = escaped.replaceAll('\\', '\\\\');
-  if (quoteChar == '"') {
-    escaped = escaped.replaceAll('"', '\\"');
+  // do not escape raw strings (when using backticks)
+  if (quoteChar === '`') {
+    return input;
   }
+
+  let escaped = input;
+  // escape sequences: https://grafana.com/docs/tempo/v2.8.x/traceql/construct-traceql-queries/#quoted-attribute-names
+  escaped = escaped.replaceAll('\\', '\\\\');
+  escaped = escaped.replaceAll('"', '\\"');
   return escaped;
 }
 


### PR DESCRIPTION
# Description

Tempo: do not escape raw strings in TraceQL auto-complete
Follow-up fix for #278

# Screenshots

no UI changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).