### PR TITLE
[BUGFIX] Interaction with controls should not update spec directly

### DIFF
--- a/prometheus/src/plugins/prometheus-variables.tsx
+++ b/prometheus/src/plugins/prometheus-variables.tsx
@@ -19,7 +19,7 @@ import {
   VariableOption,
 } from '@perses-dev/plugin-system';
 import { produce } from 'immer';
-import { ReactElement, useCallback } from 'react';
+import { ReactElement, useCallback, useState } from 'react';
 import { PromQLEditor } from '../components';
 import {
   DEFAULT_PROM,
@@ -55,7 +55,8 @@ export function PrometheusLabelValuesVariableEditor(
     queryHandlerSettings,
   } = props;
   const selectedDatasource = datasource ?? DEFAULT_PROM;
-
+  const [labelValue, setLabelValue] = useState(props.value.labelName);
+  const [matchersValues, setMatchersValues] = useState(props.value.matchers ?? []);
   const handleDatasourceChange: DatasourceSelectProps['onChange'] = useCallback(
     (next) => {
       if (isPrometheusDatasourceSelector(next)) {
@@ -77,19 +78,19 @@ export function PrometheusLabelValuesVariableEditor(
 
   const handleLabelChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      onChange({ ...value, labelName: e.target.value });
+      setLabelValue(e.target.value);
       if (queryHandlerSettings?.setWatchOtherSpecs)
         queryHandlerSettings.setWatchOtherSpecs({ ...value, labelName: e.target.value });
     },
-    [value, queryHandlerSettings, onChange]
+    [value, queryHandlerSettings]
   );
 
   const handleMatchEditorsChange = useCallback(
     (e: string[]) => {
-      onChange({ ...value, matchers: e });
+      setMatchersValues(e);
       if (queryHandlerSettings?.setWatchOtherSpecs) queryHandlerSettings.setWatchOtherSpecs({ ...value, matchers: e });
     },
-    [value, queryHandlerSettings, onChange]
+    [value, queryHandlerSettings]
   );
 
   return (
@@ -107,17 +108,13 @@ export function PrometheusLabelValuesVariableEditor(
       <TextField
         label="Label Name"
         required
-        value={props.value.labelName}
+        value={labelValue}
         onChange={handleLabelChange}
         InputProps={{
           readOnly: props.isReadonly,
         }}
       />
-      <MatcherEditor
-        matchers={props.value.matchers ?? []}
-        onChange={handleMatchEditorsChange}
-        isReadonly={props.isReadonly}
-      />
+      <MatcherEditor matchers={matchersValues} onChange={handleMatchEditorsChange} isReadonly={props.isReadonly} />
     </Stack>
   );
 }
@@ -133,7 +130,7 @@ export function PrometheusLabelNamesVariableEditor(
   } = props;
 
   const selectedDatasource = datasource ?? DEFAULT_PROM;
-
+  const [matchersValues, setMatchersValues] = useState(props.value.matchers ?? []);
   const handleDatasourceChange: DatasourceSelectProps['onChange'] = useCallback(
     (next) => {
       if (isPrometheusDatasourceSelector(next)) {
@@ -155,10 +152,12 @@ export function PrometheusLabelNamesVariableEditor(
 
   const handleMatchEditorChange = useCallback(
     (e: string[]) => {
-      onChange({ ...value, matchers: e });
-      if (queryHandlerSettings?.setWatchOtherSpecs) queryHandlerSettings.setWatchOtherSpecs({ ...value, matchers: e });
+      setMatchersValues(e);
+      if (queryHandlerSettings?.setWatchOtherSpecs) {
+        queryHandlerSettings.setWatchOtherSpecs({ ...value, matchers: e });
+      }
     },
-    [onChange, value, queryHandlerSettings]
+    [value, queryHandlerSettings]
   );
 
   return (
@@ -173,11 +172,7 @@ export function PrometheusLabelNamesVariableEditor(
           label="Prometheus Datasource"
         />
       </FormControl>
-      <MatcherEditor
-        matchers={props.value.matchers ?? []}
-        isReadonly={props.isReadonly}
-        onChange={handleMatchEditorChange}
-      />
+      <MatcherEditor matchers={matchersValues} isReadonly={props.isReadonly} onChange={handleMatchEditorChange} />
     </Stack>
   );
 }
@@ -195,7 +190,7 @@ export function PrometheusPromQLVariableEditor(
 
   const { data: client } = useDatasourceClient<PrometheusClient>(selectedDatasource);
   const promURL = client?.options.datasourceUrl;
-
+  const [labelValue, setLableValue] = useState(props.value.labelName);
   const handleDatasourceChange: DatasourceSelectProps['onChange'] = useCallback(
     (next) => {
       if (isPrometheusDatasourceSelector(next)) {
@@ -232,11 +227,11 @@ export function PrometheusPromQLVariableEditor(
 
   const handleLabelNameChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      onChange({ ...value, labelName: e.target.value });
+      setLableValue(e.target.value);
       if (queryHandlerSettings?.setWatchOtherSpecs)
         queryHandlerSettings?.setWatchOtherSpecs({ ...value, labelName: e.target.value });
     },
-    [onChange, queryHandlerSettings, value]
+    [queryHandlerSettings, value]
   );
 
   return (
@@ -262,7 +257,7 @@ export function PrometheusPromQLVariableEditor(
       <TextField
         label="Label Name"
         required
-        value={props.value.labelName}
+        value={labelValue}
         InputProps={{
           readOnly: props.isReadonly,
         }}

--- a/staticlistvariable/src/StaticListVariable.tsx
+++ b/staticlistvariable/src/StaticListVariable.tsx
@@ -8,7 +8,7 @@ type StaticListVariableOptions = {
 };
 
 function StaticListVariableOptionEditor(props: OptionsEditorProps<StaticListVariableOptions>) {
-  const value = props.value.values.map((v) => {
+  const value = (props.value.values || []).map((v) => {
     if (typeof v === 'string') {
       return v;
     } else {


### PR DESCRIPTION
>⚠️ SHOULD BE REVIEWED AND TESTED WITH https://github.com/perses/perses/pull/3298

Closes https://github.com/perses/perses/issues/3283

## Description 🖊️ 

Details can be found in the corresponding issue https://github.com/perses/perses/issues/3283

## What does this PR do ❓ 

This PR removes direct specification update by the label and matcher inputs. Only data source change is allowed to update the spec directly. 

## Test 🧪 

> ⚠️ To test this PR you need to attach to the **Prometheus** Plugin using `Perses CLI Plugin Start Command`
> ⚠️ To test this PR you need to attach to the **StaticListVariable** Plugin using `Perses CLI Plugin Start Command`

1. Try to **create/update** variables
2. Interaction with Label Name should not make any request to the backend (Check the network tab)
3. Interaction with the matchers should not make any request to the backend (Check the network)
4. Press the refresh button (**Later this button will also be removed**) A request should be made to the netwrok
5. Check the payload and ensure it is the expected one
6. Variable Preview should update accordingly

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).