### PR TITLE
[ENHANCEMENT] TimeSeriesChart: improve migration to tackle byRegexp color overrides

### DIFF
--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -15,6 +15,7 @@ package migrate
 
 import (
 	commonMigrate "github.com/perses/perses/cue/common/migrate"
+	"strings"
 )
 
 #grafanaType: "timeseries" | "graph"
@@ -136,14 +137,14 @@ spec: {
 		visual: stack: "all"
 	}
 
-	// migrate byName-based fixedColor overrides to querySettings when applicable
+	// migrate fixedColor overrides to querySettings when applicable
 	#querySettings: [
 		for override in (*#panel.fieldConfig.overrides | [])
-		if override.matcher.id == "byName" && override.matcher.options != _|_
+		if (override.matcher.id == "byName" || override.matcher.id == "byRegexp") && override.matcher.options != _|_
 		for property in override.properties
 		if (*property.value.fixedColor | null) != null
 		for i, target in (*#panel.targets | [])
-		if target.legendFormat == override.matcher.options {
+		if target.legendFormat == override.matcher.options || target.legendFormat =~ strings.Trim(override.matcher.options, "/") {
 			queryIndex: i
 			colorMode: "fixed"
 			colorValue: property.value.fixedColor

--- a/timeserieschart/schemas/migrate/tests/byregexp-colors/expected.json
+++ b/timeserieschart/schemas/migrate/tests/byregexp-colors/expected.json
@@ -1,0 +1,37 @@
+{
+  "kind": "TimeSeriesChart",
+  "spec": {
+    "legend": {
+      "position": "right",
+      "mode": "table",
+      "values": [
+        "min",
+        "max",
+        "mean"
+      ]
+    },
+    "yAxis": {
+      "format": {
+        "unit": "bytes"
+      }
+    },
+    "visual": {
+      "lineWidth": 2,
+      "areaOpacity": 0.1,
+      "connectNulls": false,
+      "display": "line"
+    },
+    "querySettings": [
+      {
+        "queryIndex": 2,
+        "colorMode": "fixed",
+        "colorValue": "#F2495C"
+      },
+      {
+        "queryIndex": 1,
+        "colorMode": "fixed",
+        "colorValue": "#5794F2"
+      }
+    ]
+  }
+}

--- a/timeserieschart/schemas/migrate/tests/byregexp-colors/input.json
+++ b/timeserieschart/schemas/migrate/tests/byregexp-colors/input.json
@@ -1,0 +1,184 @@
+{
+  "id": 7,
+  "type": "timeseries",
+  "title": "Memory ($memory) [$cluster - $pod - $container]",
+  "description": "$memory memory for selected containers\n- Lt: memory limit (if set)\n- Rq: memory request (if set)\n\nMemory types to display:\n- <b>rss</b><br/>Resident set size in bytes (RSS).\n- <b>working_set_bytes</b><br/>Working set in bytes (WSS).\n- <b>usage_bytes</b><br/>Total memory usage in bytes (including cache).\n- <b>cache</b><br/>Number of bytes of page cache memory.\n- <b>swap</b><br/>Container swap usage in bytes. ",
+  "gridPos": {
+    "x": 0,
+    "y": 2,
+    "h": 9,
+    "w": 24
+  },
+  "fieldConfig": {
+    "defaults": {
+      "custom": {
+        "drawStyle": "line",
+        "lineInterpolation": "linear",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "lineWidth": 2,
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "spanNulls": false,
+        "insertNulls": false,
+        "showPoints": "never",
+        "pointSize": 5,
+        "stacking": {
+          "mode": "none",
+          "group": "A"
+        },
+        "axisPlacement": "auto",
+        "axisLabel": "Memory",
+        "axisColorMode": "text",
+        "axisBorderShow": false,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "axisCenteredZero": false,
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        },
+        "axisSoftMin": 0
+      },
+      "color": {
+        "mode": "palette-classic"
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": []
+      },
+      "unit": "bytes"
+    },
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byRegexp",
+          "options": "/^(Rq|Lt): .+$/"
+        },
+        "properties": [
+          {
+            "id": "custom.fillOpacity",
+            "value": 0
+          },
+          {
+            "id": "custom.lineWidth",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byRegexp",
+          "options": "/^Lt: .+$/"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "#F2495C",
+              "mode": "fixed"
+            }
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byRegexp",
+          "options": "/^Rq: .+$/"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "#5794F2",
+              "mode": "fixed"
+            }
+          },
+          {
+            "id": "custom.lineStyle",
+            "value": {
+              "dash": [
+                8,
+                10
+              ],
+              "fill": "dash"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "pluginVersion": "11.6.3",
+  "targets": [
+    {
+      "exemplar": false,
+      "expr": "max by (cluster,pod,container) (container_memory_$memory{cluster=~\"$cluster\",pod=~\"$pod\",container=~\"$container\"})",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "interval": "$sampling",
+      "intervalFactor": 1,
+      "legendFormat": "{{container_name}} - {{pod_name}} - {{cluster}}",
+      "refId": "memory_a",
+      "datasource": {
+        "uid": "$datasource"
+      }
+    },
+    {
+      "exemplar": false,
+      "expr": "max by (cluster,pod,container) (kube_pod_container_resource_requests{cluster=~\"$cluster\",pod=~\"$pod\",container=~\"$container\",resource=\"memory\"})",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "interval": "$sampling",
+      "intervalFactor": 1,
+      "legendFormat": "Rq: {{container}} - {{pod}} - {{cluster}}",
+      "refId": "memory_c",
+      "datasource": {
+        "uid": "$datasource"
+      }
+    },
+    {
+      "exemplar": false,
+      "expr": "max by (cluster,pod,container) (kube_pod_container_resource_limits{cluster=~\"$cluster\",pod=~\"$pod\",container=~\"$container\",resource=\"memory\"})",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "interval": "$sampling",
+      "intervalFactor": 1,
+      "legendFormat": "Lt: {{container}} - {{pod}} - {{cluster}}",
+      "refId": "memory_d",
+      "datasource": {
+        "uid": "$datasource"
+      }
+    }
+  ],
+  "datasource": {
+    "uid": "$datasource"
+  },
+  "options": {
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc",
+      "hideZeros": false
+    },
+    "legend": {
+      "showLegend": true,
+      "displayMode": "table",
+      "placement": "right",
+      "calcs": [
+        "min",
+        "max",
+        "mean"
+      ],
+      "sortBy": "Max",
+      "sortDesc": true
+    }
+  }
+}


### PR DESCRIPTION
# Description

Since on Perses side we do not support regexp-based overrides (yet), the new logic checks migrates a byRegexp color overrides if ever it matches a legendFormat

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).