### PR TITLE
[ENHANCEMENT] Disable Prometheus query editor controls accordingly

### DIFF
--- a/prometheus/src/components/PromQLEditor.tsx
+++ b/prometheus/src/components/PromQLEditor.tsx
@@ -32,12 +32,14 @@ const treeViewCloseStr = 'Close ' + treeViewStr;
 export type PromQLEditorProps = {
   completeConfig: CompleteConfiguration;
   datasource: PrometheusDatasourceSelector;
+  isReadOnly?: boolean;
 } & Omit<ReactCodeMirrorProps, 'theme' | 'extensions'>;
 
-export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEditorProps): ReactElement {
+export function PromQLEditor({ completeConfig, datasource, isReadOnly, ...rest }: PromQLEditorProps): ReactElement {
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
   const [isTreeViewVisible, setTreeViewVisible] = useState(false);
+  const readOnly = isReadOnly ?? false;
 
   const promQLExtension = useMemo(() => {
     return new PromQLExtension().activateLinter(false).setComplete(completeConfig).asExtension();
@@ -79,6 +81,7 @@ export function PromQLEditor({ completeConfig, datasource, ...rest }: PromQLEdit
         {...rest}
         style={{ border: `1px solid ${theme.palette.divider}` }}
         theme={isDarkMode ? 'dark' : 'light'}
+        readOnly={readOnly}
         basicSetup={{
           highlightActiveLine: false,
           highlightActiveLineGutter: false,

--- a/prometheus/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/prometheus/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -49,6 +49,7 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
     value,
     value: { query, datasource },
     queryHandlerSettings,
+    isReadonly,
   } = props;
 
   const datasourceSelectValue = datasource ?? DEFAULT_PROM;
@@ -131,6 +132,7 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
           labelId={datasourceSelectLabelID}
           label="Prometheus Datasource"
           notched
+          readOnly={isReadonly}
         />
       </FormControl>
       <PromQLEditor
@@ -139,6 +141,7 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
         datasource={selectedDatasource}
         onChange={handlePromQlEditorChanges}
         onBlur={queryHandlerSettings?.runWithOnBlur ? handleQueryBlur : undefined}
+        isReadOnly={isReadonly}
       />
       <Stack direction="row" spacing={2}>
         <TextField
@@ -149,6 +152,7 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
           value={format ?? ''}
           onChange={handleLegendSpecChange}
           onBlur={queryHandlerSettings?.runWithOnBlur ? handleFormatBlur : undefined}
+          disabled={isReadonly}
         />
         <TextField
           label="Min Step"
@@ -158,6 +162,7 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
           onChange={handleMinStepSpecChange}
           onBlur={queryHandlerSettings?.runWithOnBlur ? handleMinStepBlur : undefined}
           sx={{ width: '250px' }}
+          disabled={isReadonly}
         />
       </Stack>
     </Stack>


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3218

>⚠️ This PR only covers the Plugin Side - Prometheus. There will be a PR for Perses/Perses as well

> ⚠️ There will be  separate PRs for the Temp as well

## Description 🖊️ 

Quick Query Viewer controls should be read-only. Otherwise, it may make confusion for the users. 

# Screenshots

## Read-only fields

<img width="2248" height="864" alt="image" src="https://github.com/user-attachments/assets/99f26097-6485-47e7-b4a9-ef2e9fadafd2" />

## You can still use tree view

<img width="1383" height="624" alt="image" src="https://github.com/user-attachments/assets/11ce9364-cf3a-4474-9ad5-1c6b0c9ba40f" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).