### PR TITLE
[ENHANCEMENT] tracingganttchart: add number of events and links in tab

### DIFF
--- a/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
@@ -54,7 +54,7 @@ export function DetailPane(props: DetailPaneProps): ReactElement {
         {span.name}
       </Typography>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={tab} onChange={(_, tab) => setTab(tab)}>
+        <Tabs value={tab} onChange={(_, tab) => setTab(tab)} variant="scrollable">
           <Tab sx={{ p: 0 }} value="attributes" label="Attributes" />
           {span.events.length > 0 && (
             <Tab

--- a/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
+++ b/tracingganttchart/src/TracingGanttChart/DetailPane/DetailPane.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, IconButton, Tab, Tabs, Typography } from '@mui/material';
+import { Box, Chip, IconButton, Tab, Tabs, Typography } from '@mui/material';
 import { ReactElement, useState } from 'react';
 import CloseIcon from 'mdi-material-ui/Close';
 import { Span, Trace } from '../trace';
@@ -56,8 +56,24 @@ export function DetailPane(props: DetailPaneProps): ReactElement {
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Tabs value={tab} onChange={(_, tab) => setTab(tab)}>
           <Tab sx={{ p: 0 }} value="attributes" label="Attributes" />
-          {span.events.length > 0 && <Tab value="events" label="Events" />}
-          {span.links.length > 0 && <Tab value="links" label="Links" />}
+          {span.events.length > 0 && (
+            <Tab
+              value="events"
+              label="Events"
+              icon={<Chip label={span.events.length} />}
+              iconPosition="end"
+              sx={{ minHeight: 48, height: 48 }} // MUI Tabs with icon are bigger than those without by default
+            />
+          )}
+          {span.links.length > 0 && (
+            <Tab
+              value="links"
+              label="Links"
+              icon={<Chip label={span.links.length} />}
+              iconPosition="end"
+              sx={{ minHeight: 48, height: 48 }} // MUI Tabs with icon are bigger than those without by default
+            />
+          )}
         </Tabs>
       </Box>
       {tab === 'attributes' && <TraceAttributes customLinks={customLinks} trace={trace} span={span} />}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Added the number of events or links in the tab. Easier to see if a span has a lot of events or links.

# Screenshots

<!-- If there are UI changes -->
<img width="457" height="191" alt="image" src="https://github.com/user-attachments/assets/11dbef1b-a321-4848-90de-a91c0cf6b99f" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).