### PR TITLE
[ENHANCEMENT] pyroscope: improve query editor responsive + use autocomplete for some inputs

### DIFF
--- a/pyroscope/src/components/DeleteFilterItem.tsx
+++ b/pyroscope/src/components/DeleteFilterItem.tsx
@@ -24,10 +24,15 @@ export function DeleteFilterItem(props: DeleteFilterItemProps): ReactElement {
 
   return (
     <ToolbarIconButton
-      sx={{
-        borderTopLeftRadius: '0',
-        borderBottomLeftRadius: '0',
-      }}
+      sx={(theme) => ({
+        borderTopLeftRadius: 0,
+        borderBottomLeftRadius: 0,
+        width: '100%',
+        height: '100%',
+        [theme.breakpoints.down('sm')]: {
+          borderTopRightRadius: 0,
+        },
+      })}
       aria-label="delete filter"
       onClick={onClick}
     >

--- a/pyroscope/src/components/FilterItem.tsx
+++ b/pyroscope/src/components/FilterItem.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { ReactElement } from 'react';
-import { Stack } from '@mui/material';
+import { Grid2 as Grid, Stack } from '@mui/material';
 import { PyroscopeDatasourceSelector } from '../model';
 import { LabelFilter, OperatorType } from '../utils/types';
 import { LabelName } from './LabelName';
@@ -47,16 +47,30 @@ export function FilterItem(props: FilterItemProps): ReactElement {
   };
 
   return (
-    <Stack direction="row" spacing={0} sx={{ flexWrap: 'wrap', maxWidth: '100%' }}>
-      <LabelName datasource={datasource} value={value.labelName} onChange={handleLabelNameChange} />
-      <Operator value={value.operator} onChange={handleOperatorChange} />
-      <LabelValue
-        datasource={datasource}
-        value={value.labelValue}
-        labelName={value.labelName}
-        onChange={handleLabelValueChange}
-      />
-      <DeleteFilterItem onClick={handleDeleteClick} />
+    <Stack
+      direction="row"
+      spacing={0}
+      sx={(theme) => ({ flexWrap: 'wrap', width: 500, [theme.breakpoints.down('sm')]: { width: '100%' } })}
+    >
+      <Grid container sx={{ width: '100%' }}>
+        <Grid size={{ xs: 9.5, md: 4.5 }}>
+          <LabelName datasource={datasource} value={value.labelName} onChange={handleLabelNameChange} />
+        </Grid>
+        <Grid size={{ xs: 2.5, md: 1.5 }}>
+          <Operator value={value.operator} onChange={handleOperatorChange} />
+        </Grid>
+        <Grid size={{ xs: 10, md: 5 }}>
+          <LabelValue
+            datasource={datasource}
+            value={value.labelValue}
+            labelName={value.labelName}
+            onChange={handleLabelValueChange}
+          />
+        </Grid>
+        <Grid size={{ xs: 2, md: 1 }}>
+          <DeleteFilterItem onClick={handleDeleteClick} />
+        </Grid>
+      </Grid>
     </Stack>
   );
 }

--- a/pyroscope/src/components/LabelName.tsx
+++ b/pyroscope/src/components/LabelName.tsx
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ReactElement } from 'react';
-import { Select, MenuItem, CircularProgress, Stack } from '@mui/material';
+import { ReactElement, useMemo } from 'react';
+import { TextField, Autocomplete } from '@mui/material';
 import { PyroscopeDatasourceSelector } from '../model';
 import { useLabelNames, filterLabelNamesOptions } from '../utils/use-query';
 
@@ -27,32 +27,35 @@ export function LabelName(props: LabelNameProps): ReactElement {
 
   const { data: labelNamesOptions, isLoading: isLabelNamesOptionsLoading } = useLabelNames(datasource);
 
+  const filteredLabelNamesOptions = useMemo(
+    () => filterLabelNamesOptions(labelNamesOptions?.names ?? []),
+    [labelNamesOptions]
+  );
+
   return (
-    <Select
-      sx={{ borderTopRightRadius: '0', borderBottomRightRadius: '0' }}
+    <Autocomplete
+      disableClearable
+      options={filteredLabelNamesOptions}
       value={value}
-      size="small"
-      onChange={(event) => onChange?.(event.target.value)}
-      displayEmpty
-      renderValue={(selected) => {
-        if (selected === '') {
-          return 'Select label name';
-        }
-        return selected;
+      sx={(theme) => ({
+        width: '100%',
+        '& .MuiOutlinedInput-root': {
+          borderTopRightRadius: 0,
+          borderBottomRightRadius: 0,
+          [theme.breakpoints.down('sm')]: {
+            borderBottomLeftRadius: 0,
+          },
+        },
+      })}
+      loading={isLabelNamesOptionsLoading}
+      renderInput={(params) => {
+        return <TextField {...params} placeholder="Select label name" size="small" />;
       }}
-    >
-      {isLabelNamesOptionsLoading ? (
-        <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
-          <CircularProgress color="inherit" size={20} />
-        </Stack>
-      ) : (
-        labelNamesOptions?.names &&
-        filterLabelNamesOptions(labelNamesOptions?.names).map((labelName) => (
-          <MenuItem key={labelName} value={labelName}>
-            {labelName}
-          </MenuItem>
-        ))
-      )}
-    </Select>
+      onChange={(_event, newValue) => {
+        if (newValue !== null) {
+          onChange?.(newValue);
+        }
+      }}
+    />
   );
 }

--- a/pyroscope/src/components/LabelValue.tsx
+++ b/pyroscope/src/components/LabelValue.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { ReactElement } from 'react';
-import { Select, MenuItem, CircularProgress, Stack } from '@mui/material';
+import { TextField, Autocomplete } from '@mui/material';
 import { PyroscopeDatasourceSelector } from '../model';
 import { useLabelValues } from '../utils/use-query';
 
@@ -29,32 +29,30 @@ export function LabelValue(props: LabelValueProps): ReactElement {
   const { data: labelValuesOptions, isLoading: isLabelValuesOptionsLoading } = useLabelValues(datasource, labelName);
 
   return (
-    <Select
-      sx={{ borderRadius: '0' }}
+    <Autocomplete
+      freeSolo
+      disableClearable
+      options={labelValuesOptions?.names ?? []}
       value={value}
-      size="small"
-      onChange={(event) => onChange?.(event.target.value)}
-      displayEmpty
-      disabled={!labelName || labelName === ''} // Disabled if labelName is not defined yet
-      renderValue={(selected) => {
-        if (selected === '') {
-          return 'Select label value';
-        }
-        return selected;
+      sx={(theme) => ({
+        width: '100%',
+        '& .MuiOutlinedInput-root': {
+          borderRadius: 0,
+          width: '100%',
+          [theme.breakpoints.down('sm')]: {
+            borderBottomLeftRadius: 4,
+          },
+        },
+      })}
+      loading={isLabelValuesOptionsLoading}
+      renderInput={(params) => {
+        return <TextField {...params} placeholder="Select label value" size="small" />;
       }}
-    >
-      {isLabelValuesOptionsLoading ? (
-        <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
-          <CircularProgress color="inherit" size={20} />
-        </Stack>
-      ) : (
-        labelValuesOptions?.names &&
-        labelValuesOptions?.names.map((labelValue) => (
-          <MenuItem key={labelValue} value={labelValue}>
-            {labelValue}
-          </MenuItem>
-        ))
-      )}
-    </Select>
+      onChange={(_event, newInputValue) => {
+        if (newInputValue !== null) {
+          onChange?.(newInputValue);
+        }
+      }}
+    />
   );
 }

--- a/pyroscope/src/components/Operator.tsx
+++ b/pyroscope/src/components/Operator.tsx
@@ -25,7 +25,18 @@ export function Operator(props: OperatorProps): ReactElement {
   const operators = ['=', '!=', '=~', '!~'];
 
   return (
-    <Select sx={{ borderRadius: '0' }} value={value} size="small" onChange={(event) => onChange?.(event.target.value)}>
+    <Select
+      sx={(theme) => ({
+        borderRadius: 0,
+        width: '100%',
+        [theme.breakpoints.down('sm')]: {
+          borderTopRightRadius: 4,
+        },
+      })}
+      value={value}
+      size="small"
+      onChange={(event) => onChange?.(event.target.value)}
+    >
       {operators.map((op) => (
         <MenuItem key={op} value={op}>
           {op}

--- a/pyroscope/src/components/ProfileTypeSelector.tsx
+++ b/pyroscope/src/components/ProfileTypeSelector.tsx
@@ -28,7 +28,7 @@ export function ProfileTypeSelector(props: ProfileTypeSelectorProps): ReactEleme
   const { data: profileTypesOptions, isLoading: isProfileTypesOptionsLoading } = useProfileTypes(datasource);
 
   return (
-    <Stack position="relative" sx={{ flexGrow: 1, maxWidth: '100%' }}>
+    <Stack position="relative" sx={{ width: '100%' }}>
       <TextField
         select
         label="Profile Type"

--- a/pyroscope/src/components/Service.tsx
+++ b/pyroscope/src/components/Service.tsx
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ReactElement } from 'react';
-import { Stack, TextField, MenuItem, CircularProgress, useTheme } from '@mui/material';
+import { ReactElement, SyntheticEvent } from 'react';
+import { Stack, TextField, Autocomplete } from '@mui/material';
 import { PyroscopeDatasourceSelector } from '../model';
 import { useServices } from '../utils/use-query';
 
@@ -27,31 +27,29 @@ export function Service(props: ServiceProps): ReactElement {
 
   const { data: servicesOptions, isLoading: isServicesOptionsLoading } = useServices(datasource);
 
+  function handleServiceChange(_event: SyntheticEvent, newValue: string | null): void {
+    if (newValue !== null) {
+      onChange?.(newValue);
+    }
+  }
+
   return (
     <Stack
       position="relative"
       sx={{
-        flexGrow: 1,
-        maxWidth: '100%',
-        [useTheme().breakpoints.down('sm')]: {
-          width: '100%',
-        },
+        width: '100%',
       }}
     >
-      <TextField select label="Service" value={value} size="small" onChange={(event) => onChange?.(event.target.value)}>
-        {isServicesOptionsLoading ? (
-          <Stack width="100%" sx={{ alignItems: 'center', justifyContent: 'center' }}>
-            <CircularProgress color="inherit" size={20} />
-          </Stack>
-        ) : (
-          servicesOptions?.names &&
-          servicesOptions?.names.map((service) => (
-            <MenuItem key={service} value={service}>
-              {service}
-            </MenuItem>
-          ))
-        )}
-      </TextField>
+      <Autocomplete
+        options={servicesOptions?.names ?? []}
+        value={value}
+        sx={{ minWidth: 200 }}
+        loading={isServicesOptionsLoading}
+        renderInput={(params) => {
+          return <TextField {...params} label="Service" size="small" />;
+        }}
+        onChange={handleServiceChange}
+      />
     </Stack>
   );
 }

--- a/pyroscope/src/plugins/pyroscope-profile-query/PyroscopeProfileQueryEditor.tsx
+++ b/pyroscope/src/plugins/pyroscope-profile-query/PyroscopeProfileQueryEditor.tsx
@@ -14,14 +14,14 @@
 import { DatasourceSelect, DatasourceSelectProps } from '@perses-dev/plugin-system';
 import { useId } from '@perses-dev/components';
 import { produce } from 'immer';
-import { FormControl, InputLabel, Stack, TextField } from '@mui/material';
+import { FormControl, InputLabel, Stack, TextField, useTheme } from '@mui/material';
 import { ReactElement } from 'react';
 import {
   DEFAULT_PYROSCOPE,
   isDefaultPyroscopeSelector,
   isPyroscopeDatasourceSelector,
   PYROSCOPE_DATASOURCE_KIND,
-} from '../../model/pyroscope-selectors';
+} from '../../model';
 import { ProfileTypeSelector, Service, Filters } from '../../components';
 import {
   ProfileQueryEditorProps,
@@ -49,8 +49,7 @@ export function PyroscopeProfileQueryEditor(props: ProfileQueryEditorProps): Rea
         onChange(
           produce(value, (draft) => {
             // If they're using the default, just omit the datasource prop (i.e. set to undefined)
-            const nextDatasource = isDefaultPyroscopeSelector(next) ? undefined : next;
-            draft.datasource = nextDatasource;
+            draft.datasource = isDefaultPyroscopeSelector(next) ? undefined : next;
           })
         );
         return;
@@ -77,22 +76,25 @@ export function PyroscopeProfileQueryEditor(props: ProfileQueryEditorProps): Rea
       </FormControl>
       <Stack
         direction="row"
-        spacing={0}
         sx={{
-          flexWrap: 'wrap',
-          rowGap: 1,
+          [useTheme().breakpoints.down('sm')]: {
+            flexWrap: 'wrap',
+          },
           gap: 2,
+          rowGap: 1,
         }}
       >
         <Service datasource={selectedDatasource} value={service} onChange={handleServiceChange} />
         <ProfileTypeSelector datasource={selectedDatasource} value={profileType} onChange={handleProfileTypeChange} />
         <TextField
+          type="number"
           size="small"
           label="Max Nodes"
           value={maxNodes}
           error={maxNodesHasError}
           onChange={(e) => handleMaxNodesChange(e.target.value)}
-          sx={{ width: '110px' }}
+          sx={(theme) => ({ width: 250, [theme.breakpoints.down('sm')]: { width: '100%' } })}
+          slotProps={{ htmlInput: { step: 1 } }}
         />
       </Stack>
       <Filters datasource={selectedDatasource} value={filters} onChange={handleFiltersChange} />


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Improving pyroscope editor responsive on small screen + add autocomplete for some inputs (service, filter label names and values)

# Screenshots

<!-- If there are UI changes -->

BEFORE:
<img width="2543" height="444" alt="image" src="https://github.com/user-attachments/assets/23b3b589-db6f-44b8-94bc-a09198f097dd" />

<img width="385" height="680" alt="image" src="https://github.com/user-attachments/assets/0557d778-c8f9-4115-95ad-4cf69d2d7798" />



AFTER:
<img width="2542" height="433" alt="image" src="https://github.com/user-attachments/assets/911a228a-52a0-4e68-b516-2b24e1fc4054" />

<img width="399" height="693" alt="image" src="https://github.com/user-attachments/assets/1eaa9cd0-ca41-4dba-918d-5498721ccbba" />



# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).