### PR TITLE
[BUGFIX] prometheus: query-editor: use readonly instead of disabled prop

### DIFF
--- a/prometheus/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
+++ b/prometheus/src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQueryEditor.tsx
@@ -152,7 +152,10 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
           value={format ?? ''}
           onChange={handleLegendSpecChange}
           onBlur={queryHandlerSettings?.runWithOnBlur ? handleFormatBlur : undefined}
-          disabled={isReadonly}
+          slotProps={{
+            inputLabel: { shrink: isReadonly ? true : undefined },
+            input: { readOnly: isReadonly },
+          }}
         />
         <TextField
           label="Min Step"
@@ -162,7 +165,10 @@ export function PrometheusTimeSeriesQueryEditor(props: PrometheusTimeSeriesQuery
           onChange={handleMinStepSpecChange}
           onBlur={queryHandlerSettings?.runWithOnBlur ? handleMinStepBlur : undefined}
           sx={{ width: '250px' }}
-          disabled={isReadonly}
+          slotProps={{
+            inputLabel: { shrink: isReadonly ? true : undefined },
+            input: { readOnly: isReadonly },
+          }}
         />
       </Stack>
     </Stack>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fixing readonly inputs for prometheus query editor. This dialog need to use Perses Dialog component.

# Screenshots

<!-- If there are UI changes -->
BEFORE:
<img width="1217" height="352" alt="image" src="https://github.com/user-attachments/assets/1730634c-3696-4e97-82c2-8f3fe2fe9107" />

AFTER:
<img width="1225" height="351" alt="image" src="https://github.com/user-attachments/assets/b0f77cb3-71f8-4b9e-8cf8-d7f042ee715d" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).