### PR TITLE
[ENHANCEMENT]: TimeSeriesChart Migration Fix

### DIFF
--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -81,9 +81,6 @@ spec: {
 		},
 		null,
 	][0]
-	if #min != null {
-		yAxis: min: #min
-	}
 
 	#max: [// switch
 		if (*#panel.fieldConfig.defaults.max | null) != null {
@@ -94,8 +91,21 @@ spec: {
 		},
 		null,
 	][0]
-	if #max != null {
-		yAxis: max: #max
+
+	// Handle yAxis min/max together to ensure schema constraints are met
+	if #min != null || #max != null {
+		yAxis: {
+			if #min != null {
+				min: #min
+			}
+			if #max != null {
+				max: #max
+				// If max is set but min is not, provide a default min value of 0. otherwise, Perses schema validation will fail.
+				if #min == null {
+					min: 0
+				}
+			}
+		}
 	}
 
 	#yAxisLabel: *#panel.fieldConfig.defaults.custom.axisLabel | null

--- a/timeserieschart/schemas/migrate/tests/basic-3/expected.json
+++ b/timeserieschart/schemas/migrate/tests/basic-3/expected.json
@@ -1,0 +1,23 @@
+{
+  "kind": "TimeSeriesChart",
+  "spec": {
+    "legend": {
+      "mode": "list",
+      "position": "bottom",
+      "values": []
+    },
+    "visual": {
+      "areaOpacity": 0.1,
+      "connectNulls": false,
+      "display": "line",
+      "lineWidth": 1
+    },
+    "yAxis": {
+      "format": {
+        "unit": "decimal"
+      },
+      "min": 0,
+      "max": 1
+    }
+  }
+}

--- a/timeserieschart/schemas/migrate/tests/basic-3/input.json
+++ b/timeserieschart/schemas/migrate/tests/basic-3/input.json
@@ -1,0 +1,97 @@
+{
+  "id": 14,
+  "type": "timeseries",
+  "title": "APIC endpoint accessibility",
+  "gridPos": {
+    "x": 0,
+    "y": 0,
+    "h": 8,
+    "w": 11
+  },
+  "fieldConfig": {
+    "defaults": {
+      "custom": {
+        "drawStyle": "line",
+        "lineInterpolation": "linear",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "lineWidth": 1,
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "spanNulls": false,
+        "insertNulls": false,
+        "showPoints": "never",
+        "pointSize": 5,
+        "stacking": {
+          "mode": "none",
+          "group": "A"
+        },
+        "axisPlacement": "auto",
+        "axisLabel": "",
+        "axisColorMode": "text",
+        "axisBorderShow": false,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "axisCenteredZero": false,
+        "hideFrom": {
+          "tooltip": false,
+          "viz": false,
+          "legend": false
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "color": {
+        "mode": "palette-classic"
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "value": null,
+            "color": "green"
+          },
+          {
+            "value": 80,
+            "color": "red"
+          }
+        ]
+      },
+      "unit": "short",
+      "max": 1
+    },
+    "overrides": []
+  },
+  "pluginVersion": "12.1.1",
+  "targets": [
+    {
+      "expr": "network_apic_accessible",
+      "interval": "",
+      "legendFormat": "{{ apicHost }}",
+      "refId": "A",
+      "datasource": {
+        "uid": "prometheus-infra-collector"
+      }
+    }
+  ],
+  "datasource": {
+    "uid": "prometheus-infra-collector"
+  },
+  "options": {
+    "tooltip": {
+      "mode": "multi",
+      "sort": "none",
+      "hideZeros": false
+    },
+    "legend": {
+      "showLegend": true,
+      "displayMode": "list",
+      "placement": "bottom",
+      "calcs": []
+    },
+    "dataLinks": []
+  }
+}


### PR DESCRIPTION
## Problem
CUE validation error during Grafana to Perses migration:
```
invalid panel 1: spec.yAxis.max: cannot reference optional field: min
```

## Root Cause
The TimeSeriesChart migration script could set `yAxis.max` without `yAxis.min`, but the schema constraint `max?: number & >= min` requires both fields to be present for validation.

https://github.com/perses/plugins/blob/02f28cd27a3870e9c28186a9ee3ec145a184c7da/timeserieschart/schemas/time-series.cue#L55

## Solution
Modified `timeserieschart/schemas/migrate/migrate.cue` to handle yAxis min/max values together:

- When `max` is specified without `min`, automatically provide `min: 0` as a sensible default
- Ensures schema constraints are always satisfied during migration
- Added tests for this use-case

## Impact
- Fixes migration failures for Grafana panels with only max values set
- Prevents schema validation errors during dashboard migration