### PR TITLE
[BUGFIX] Add abort functionality to get time series

### DIFF
--- a/prometheus/src/plugins/prometheus-datasource.tsx
+++ b/prometheus/src/plugins/prometheus-datasource.tsx
@@ -48,13 +48,20 @@ const createClient: DatasourcePlugin<PrometheusDatasourceSpec, PrometheusClient>
       datasourceUrl,
     },
     healthCheck: healthCheck({ datasourceUrl, headers: specHeaders }),
-    instantQuery: (params, headers) => instantQuery(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    rangeQuery: (params, headers) => rangeQuery(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    labelNames: (params, headers) => labelNames(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    labelValues: (params, headers) => labelValues(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    metricMetadata: (params, headers) => metricMetadata(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    series: (params, headers) => series(params, { datasourceUrl, headers: headers ?? specHeaders }),
-    parseQuery: (params, headers) => parseQuery(params, { datasourceUrl, headers: headers ?? specHeaders }),
+    instantQuery: (params, headers, abortSignal) =>
+      instantQuery(params, { datasourceUrl, headers: headers ?? specHeaders, abortSignal }),
+    rangeQuery: (params, headers, abortSignal) =>
+      rangeQuery(params, { datasourceUrl, headers: headers ?? specHeaders, abortSignal }),
+    labelNames: (params, headers, abortSignal) =>
+      labelNames(params, { datasourceUrl, headers: headers ?? specHeaders, abortSignal }),
+    labelValues: (params, headers, abortSignal) =>
+      labelValues(params, { datasourceUrl, headers: headers ?? specHeaders, abortSignal }),
+    metricMetadata: (params, headers, abortSignal) =>
+      metricMetadata(params, { datasourceUrl, headers: headers ?? specHeaders, abortSignal }),
+    series: (params, headers, abortSignal) =>
+      series(params, { datasourceUrl, headers: headers ?? specHeaders, abortSignal }),
+    parseQuery: (params, headers, abortSignal) =>
+      parseQuery(params, { datasourceUrl, headers: headers ?? specHeaders, abortSignal }),
   };
 };
 

--- a/prometheus/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/prometheus/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -41,7 +41,8 @@ import { replacePromBuiltinVariables } from './replace-prom-builtin-variables';
 
 export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
   spec,
-  context
+  context,
+  abortSignal
 ) => {
   if (spec.query === undefined || spec.query === null || spec.query === '') {
     // Do not make a request to the backend, instead return an empty TimeSeriesData
@@ -111,22 +112,31 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   const client: PrometheusClient = await context.datasourceStore.getDatasourceClient(selectedDatasource);
 
   // Make the request to Prom
+
   let response;
   switch (context.mode) {
     case 'instant':
-      response = await client.instantQuery({
-        query,
-        time: end,
-      });
+      response = await client.instantQuery(
+        {
+          query,
+          time: end,
+        },
+        undefined,
+        abortSignal
+      );
       break;
     case 'range':
     default:
-      response = await client.rangeQuery({
-        query,
-        start,
-        end,
-        step,
-      });
+      response = await client.rangeQuery(
+        {
+          query,
+          start,
+          end,
+          step,
+        },
+        undefined,
+        abortSignal
+      );
       break;
   }
 


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3340

# Description 🖊️ 
This change **aborts** the suspending network requests when the relevant component is dismounted. Under the hood React Query knows which network requests have been dispatched by which components. Therefore, by sending an Abort Signal the suspending network requests could be aborted.  

# Test  🧪 
There is a block of code for the testing purpose. Try to reproduce the bug mentioned by @jgbernalp here https://github.com/perses/perses/issues/3340

```typescript
  /* PREPARED FOR THE REVIEWER TO TEST THE FEATURE, SHOULD BE REMOVED AFTER APPROVAL! */
  abortSignal?.addEventListener('abort', () => {
    console.log(`Aborted the request to ${client.options.datasourceUrl} at ${Date.now()}`);
  });
```

```typescript
const approve_pr = if_you_see_the_log ? true : false
```

<img width="1720" height="523" alt="image" src="https://github.com/user-attachments/assets/b1599e9c-0dbd-4380-b2f4-91202773a52a" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).