### PR TITLE
[ENHANCEMENT] TimeSeriesChart: migration: support lineStyle & opacity override

### DIFF
--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -186,7 +186,7 @@ spec: {
 					lineStyle: #lineStyleMapping[property.value.fill]
 				}
 				if property.id == "custom.fillOpacity" {
-					areaOpacity: property.value
+					areaOpacity: property.value / 100
 				}
 			}
 		}

--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -182,8 +182,8 @@ spec: {
 					colorMode: "fixed"
 					colorValue: property.value.fixedColor
 				}
-				if property.id == "custom.lineStyle" if (*property.value.dash | null) != null {
-					lineStyle: "dashed"
+				if property.id == "custom.lineStyle" if (*property.value.fill | null) != null {
+					lineStyle: #lineStyleMapping[property.value.fill]
 				}
 				if property.id == "custom.fillOpacity" {
 					areaOpacity: property.value

--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -21,6 +21,13 @@ import (
 #grafanaType: "timeseries" | "graph"
 #panel:       _
 
+// key: grafana line style, value: perses line style
+#lineStyleMapping: {
+	solid:  "solid"
+	dash: "dashed"
+	dot: "dotted"
+}
+
 kind: "TimeSeriesChart"
 spec: {
 	// legend
@@ -132,6 +139,11 @@ spec: {
 		if #lineWidth >= 0.25 && #lineWidth <= 3 {
 			visual: lineWidth: #lineWidth
 		}
+	}
+
+	#lineStyle: *#panel.fieldConfig.defaults.custom.lineStyle.fill | null
+	if #lineStyle != null {
+		visual: lineStyle: #lineStyleMapping[#lineStyle]
 	}
 
 	#fillOpacity: *#panel.fieldConfig.defaults.custom.fillOpacity | null

--- a/timeserieschart/schemas/migrate/tests/basic-3/expected.json
+++ b/timeserieschart/schemas/migrate/tests/basic-3/expected.json
@@ -10,7 +10,8 @@
       "areaOpacity": 0.1,
       "connectNulls": false,
       "display": "line",
-      "lineWidth": 1
+      "lineWidth": 1,
+      "lineStyle": "dotted"
     },
     "yAxis": {
       "format": {

--- a/timeserieschart/schemas/migrate/tests/basic-3/input.json
+++ b/timeserieschart/schemas/migrate/tests/basic-3/input.json
@@ -41,6 +41,13 @@
         },
         "thresholdsStyle": {
           "mode": "off"
+        },
+        "lineStyle": {
+          "fill": "dot",
+          "dash": [
+            0,
+            10
+          ]
         }
       },
       "color": {

--- a/timeserieschart/schemas/migrate/tests/basic/expected.json
+++ b/timeserieschart/schemas/migrate/tests/basic/expected.json
@@ -10,7 +10,8 @@
       "areaOpacity": 0.1,
       "connectNulls": false,
       "display": "line",
-      "lineWidth": 1
+      "lineWidth": 1,
+      "lineStyle": "solid"
     },
     "yAxis": {
       "format": {

--- a/timeserieschart/schemas/migrate/tests/basic/input.json
+++ b/timeserieschart/schemas/migrate/tests/basic/input.json
@@ -24,6 +24,9 @@
         "insertNulls": false,
         "lineInterpolation": "linear",
         "lineWidth": 1,
+        "lineStyle": {
+          "fill": "solid"
+        },
         "pointSize": 5,
         "scaleDistribution": {
           "type": "linear"

--- a/timeserieschart/schemas/migrate/tests/byregexp-colors/expected.json
+++ b/timeserieschart/schemas/migrate/tests/byregexp-colors/expected.json
@@ -25,14 +25,17 @@
     },
     "querySettings": [
       {
-        "queryIndex": 2,
-        "colorMode": "fixed",
-        "colorValue": "#F2495C"
-      },
-      {
         "queryIndex": 1,
         "colorMode": "fixed",
-        "colorValue": "#5794F2"
+        "colorValue": "#5794F2",
+        "lineStyle": "dashed",
+        "areaOpacity": 0
+      },
+      {
+        "queryIndex": 2,
+        "colorMode": "fixed",
+        "colorValue": "#F2495C",
+        "areaOpacity": 0
       }
     ]
   }

--- a/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/expected.json
+++ b/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/expected.json
@@ -20,7 +20,8 @@
       {
         "queryIndex": 2,
         "colorMode": "fixed",
-        "colorValue": "#890F02"
+        "colorValue": "#890F02",
+        "areaOpacity": 1
       },
       {
         "queryIndex": 4,

--- a/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/expected.json
+++ b/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/expected.json
@@ -8,16 +8,6 @@
     },
     "querySettings": [
       {
-        "queryIndex": 2,
-        "colorMode": "fixed",
-        "colorValue": "#890F02"
-      },
-      {
-        "queryIndex": 5,
-        "colorMode": "fixed",
-        "colorValue": "#052B51"
-      },
-      {
         "queryIndex": 0,
         "colorMode": "fixed",
         "colorValue": "#EAB839"
@@ -28,9 +18,19 @@
         "colorValue": "#0A437C"
       },
       {
+        "queryIndex": 2,
+        "colorMode": "fixed",
+        "colorValue": "#890F02"
+      },
+      {
         "queryIndex": 4,
         "colorMode": "fixed",
         "colorValue": "#6D1F62"
+      },
+      {
+        "queryIndex": 5,
+        "colorMode": "fixed",
+        "colorValue": "#052B51"
       }
     ],
     "visual": {

--- a/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/input.json
+++ b/timeserieschart/schemas/migrate/tests/color-based-on-legend-text/input.json
@@ -74,6 +74,10 @@
               "fixedColor": "#890F02",
               "mode": "fixed"
             }
+          },
+          {
+            "id": "custom.fillOpacity",
+            "value": 100
           }
         ]
       },


### PR DESCRIPTION
# Description

Grafana migration logic improvements corresponding to https://github.com/perses/plugins/pull/347 & https://github.com/perses/plugins/pull/386.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).