### PR TITLE
[IGNORE] bump perses core version to v0.52.0

### DIFF
--- a/barchart/package.json
+++ b/barchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/bar-chart-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/flamechart/package.json
+++ b/flamechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/flame-chart-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/gaugechart/package.json
+++ b/gaugechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/gauge-chart-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/histogramchart/package.json
+++ b/histogramchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/histogram-chart-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/loki/package.json
+++ b/loki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/loki-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",

--- a/markdown/package.json
+++ b/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/markdown-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
     },
     "barchart": {
       "name": "@perses-dev/bar-chart-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -141,7 +141,7 @@
     },
     "flamechart": {
       "name": "@perses-dev/flame-chart-plugin",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@types/color-hash": "^2.0.0"
       },
@@ -164,7 +164,7 @@
     },
     "gaugechart": {
       "name": "@perses-dev/gauge-chart-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -198,7 +198,7 @@
     },
     "histogramchart": {
       "name": "@perses-dev/histogram-chart-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "peerDependencies": {
         "@perses-dev/components": "^0.52.0",
         "@perses-dev/core": "^0.52.0",
@@ -212,7 +212,7 @@
     },
     "loki": {
       "name": "@perses-dev/loki-plugin",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@grafana/lezer-logql": "^0.2.8"
       },
@@ -239,7 +239,7 @@
     },
     "markdown": {
       "name": "@perses-dev/markdown-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "dompurify": "^3.2.3",
         "marked": "^15.0.6"
@@ -16129,7 +16129,7 @@
     },
     "piechart": {
       "name": "@perses-dev/pie-chart-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16149,7 +16149,7 @@
     },
     "prometheus": {
       "name": "@perses-dev/prometheus-plugin",
-      "version": "0.53.3",
+      "version": "0.53.4",
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
         "@prometheus-io/codemirror-promql": "^0.304.2",
@@ -16184,7 +16184,7 @@
     },
     "pyroscope": {
       "name": "@perses-dev/pyroscope-plugin",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
         "@lezer/highlight": "^1.2.1x"
@@ -16213,7 +16213,7 @@
     },
     "scatterchart": {
       "name": "@perses-dev/scatter-chart-plugin",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "react-virtuoso": "^4.12.2"
       },
@@ -16238,7 +16238,7 @@
     },
     "statchart": {
       "name": "@perses-dev/stat-chart-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16258,7 +16258,7 @@
     },
     "staticlistvariable": {
       "name": "@perses-dev/static-list-variable-plugin",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "color-hash": "^2.0.2"
       },
@@ -16280,7 +16280,7 @@
     },
     "statushistorychart": {
       "name": "@perses-dev/status-history-chart-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16300,7 +16300,7 @@
     },
     "table": {
       "name": "@perses-dev/table-plugin",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16320,7 +16320,7 @@
     },
     "tempo": {
       "name": "@perses-dev/tempo-plugin",
-      "version": "0.53.1",
+      "version": "0.53.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
         "@grafana/lezer-traceql": "^0.0.20",
@@ -16350,7 +16350,7 @@
     },
     "timeserieschart": {
       "name": "@perses-dev/timeseries-chart-plugin",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "color-hash": "^2.0.2"
       },
@@ -16373,7 +16373,7 @@
     },
     "timeseriestable": {
       "name": "@perses-dev/timeseries-table-plugin",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16393,7 +16393,7 @@
     },
     "tracetable": {
       "name": "@perses-dev/trace-table-plugin",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@mui/x-data-grid": "^7.20.0"
       },
@@ -16418,7 +16418,7 @@
     },
     "tracingganttchart": {
       "name": "@perses-dev/tracing-gantt-chart-plugin",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "color-hash": "^2.0.2"
       },

--- a/piechart/package.json
+++ b/piechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/pie-chart-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/prometheus-plugin",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/pyroscope/package.json
+++ b/pyroscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/pyroscope-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/scatterchart/package.json
+++ b/scatterchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/scatter-chart-plugin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     "react-dom": "^17.0.2 || ^18.0.0",
     "use-resize-observer": "^9.0.0"
   },
-   "devDependencies": {
+  "devDependencies": {
     "react-router-dom": "^5 || ^6 || ^7"
   },
   "files": [

--- a/statchart/package.json
+++ b/statchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/stat-chart-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/staticlistvariable/package.json
+++ b/staticlistvariable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/static-list-variable-plugin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/statushistorychart/package.json
+++ b/statushistorychart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/status-history-chart-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/table/package.json
+++ b/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/table-plugin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/tempo/package.json
+++ b/tempo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tempo-plugin",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/timeserieschart/package.json
+++ b/timeserieschart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/timeseries-chart-plugin",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/timeseriestable/package.json
+++ b/timeseriestable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/timeseries-table-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/tracetable/package.json
+++ b/tracetable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/trace-table-plugin",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/tracingganttchart/package.json
+++ b/tracingganttchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tracing-gantt-chart-plugin",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Bump plugins versions so npm packages have valid Perses core dependencies version of v0.52

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).