### PR TITLE
[IGNORE] fix previous tag script to account for new plugins

### DIFF
--- a/scripts/release/changelog.go
+++ b/scripts/release/changelog.go
@@ -27,6 +27,12 @@ func getPreviousTag(pluginName string) string {
 	pluginName = strings.ToLower(pluginName)
 	data, err := exec.Command("git", "describe", "--tags", "--abbrev=0", "--match", fmt.Sprintf("%s/v*", pluginName)).Output()
 	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.ExitCode() == 128 {
+				return ""
+			}
+		}
+
 		logrus.Fatal(err)
 	}
 	return string(bytes.ReplaceAll(data, []byte("\n"), []byte("")))


### PR DESCRIPTION
# Description

Handle exit error of gh command to handle new plugin change logs

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).