### PR TITLE
[ENHANCEMENT] Build shared rsbuild + module federation config

### DIFF
--- a/barchart/rsbuild.config.ts
+++ b/barchart/rsbuild.config.ts
@@ -11,55 +11,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/BarChart/';
-
-export default defineConfig({
-  server: { port: 3005 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'BarChart',
+  rsbuildConfig: {
+    server: { port: 3005 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'BarChart',
-      exposes: {
-        './BarChart': './src/BarChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '^18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '^18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        'use-resize-observer': { requiredVersion: '^9.1.0', singleton: true },
-        'mdi-material-ui': { requiredVersion: '^7.4.0', singleton: true },
-        immer: { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './BarChart': './src/BarChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '^18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '^18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      'use-resize-observer': { requiredVersion: '^9.1.0', singleton: true },
+      'mdi-material-ui': { requiredVersion: '^7.4.0', singleton: true },
+      immer: { singleton: true },
+    },
   },
 });

--- a/clickhouse/rsbuild.config.ts
+++ b/clickhouse/rsbuild.config.ts
@@ -11,63 +11,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ModuleFederationOptions, pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-export const assetPrefix = '/plugins/ClickHouse/';
-
-// Expose the components that will be used in the UI, either Perses UI or embedded.
-const exposedModules: ModuleFederationOptions['exposes'] = [
-  { './ClickHouseDatasource': './src/datasources/click-house-datasource' },
-  { './ClickHouseTimeSeriesQuery': './src/queries/click-house-time-series-query' },
-  { './ClickHouseLogQuery': './src/queries/click-house-log-query' },
-  { './Logs': './src/panels/logs' },
-];
-
-export default defineConfig({
-  server: { port: 3119 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'ClickHouse',
+  rsbuildConfig: {
+    server: { port: 3119 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'ClickHouse',
-      exposes: exposedModules,
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@perses-dev/explore': { singleton: true },
-        '@perses-dev/dashboards': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        '@tanstack/react-query': { singleton: true },
-        'react-hook-form': { singleton: true },
-        'react-router-dom': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './ClickHouseDatasource': './src/datasources/click-house-datasource',
+      './ClickHouseTimeSeriesQuery': './src/queries/click-house-time-series-query',
+      './ClickHouseLogQuery': './src/queries/click-house-log-query',
+      './Logs': './src/panels/logs',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@perses-dev/explore': { singleton: true },
+      '@perses-dev/dashboards': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      '@tanstack/react-query': { singleton: true },
+      'react-hook-form': { singleton: true },
+      'react-router-dom': { singleton: true },
+    },
   },
 });

--- a/datasourcevariable/rsbuild.config.ts
+++ b/datasourcevariable/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/DatasourceVariable/';
-
-export default defineConfig({
-  server: { port: 3022 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'DatasourceVariable',
+  rsbuildConfig: {
+    server: { port: 3022 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'DatasourceVariable',
-      exposes: {
-        './DatasourceVariable': './src/DatasourceVariable.tsx',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './DatasourceVariable': './src/DatasourceVariable.tsx',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/flamechart/rsbuild.config.ts
+++ b/flamechart/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/FlameChart/';
-
-export default defineConfig({
-  server: { port: 3021 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'FlameChart',
+  rsbuildConfig: {
+    server: { port: 3021 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'FlameChart',
-      exposes: {
-        './FlameChart': './src/FlameChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './FlameChart': './src/FlameChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/gaugechart/rsbuild.config.ts
+++ b/gaugechart/rsbuild.config.ts
@@ -11,55 +11,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/GaugeChart/';
-
-export default defineConfig({
-  server: { port: 3006 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'GaugeChart',
+  rsbuildConfig: {
+    server: { port: 3006 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'GaugeChart',
-      exposes: {
-        './GaugeChart': './src/GaugeChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        'use-resize-observer': { requiredVersion: '9.1.0', singleton: true },
-        'mdi-material-ui': { requiredVersion: '7.4.0', singleton: true },
-        immer: { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './GaugeChart': './src/GaugeChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      'use-resize-observer': { requiredVersion: '9.1.0', singleton: true },
+      'mdi-material-ui': { requiredVersion: '7.4.0', singleton: true },
+      immer: { singleton: true },
+    },
   },
 });

--- a/heatmapchart/rsbuild.config.ts
+++ b/heatmapchart/rsbuild.config.ts
@@ -11,49 +11,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/HeatMapChart/';
-
-export default defineConfig({
-  server: { port: 3021 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'HeatMapChart',
+  rsbuildConfig: {
+    server: { port: 3021 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'HeatMapChart',
-      exposes: {
-        './HeatMapChart': './src/HeatMapChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/core': { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        immer: { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './HeatMapChart': './src/HeatMapChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/core': { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      immer: { singleton: true },
+    },
   },
 });

--- a/histogramchart/rsbuild.config.ts
+++ b/histogramchart/rsbuild.config.ts
@@ -11,49 +11,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/HistogramChart/';
-
-export default defineConfig({
-  server: { port: 3020 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'HistogramChart',
+  rsbuildConfig: {
+    server: { port: 3020 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'HistogramChart',
-      exposes: {
-        './HistogramChart': './src/HistogramChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/core': { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        immer: { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './HistogramChart': './src/HistogramChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/core': { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      immer: { singleton: true },
+    },
   },
 });

--- a/loki/rsbuild.config.ts
+++ b/loki/rsbuild.config.ts
@@ -1,60 +1,36 @@
-import { ModuleFederationOptions, pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-export const assetPrefix = '/plugins/Loki/';
-
-// Expose the components that will be used in the UI, either Perses UI or embedded.
-const exposedModules: ModuleFederationOptions['exposes'] = [
-  { './LokiDatasource': './src/datasources/loki-datasource' },
-  { './LokiTimeSeriesQuery': './src/queries/loki-time-series-query' },
-  { './LokiLogQuery': './src/queries/loki-log-query' },
-  { './LogsTable': './src/panels/logstable' },
-];
-
-export default defineConfig({
-  server: { port: 3119 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'Loki',
+  rsbuildConfig: {
+    server: { port: 3119 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'Loki',
-      exposes: exposedModules,
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@perses-dev/explore': { singleton: true },
-        '@perses-dev/dashboards': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        '@tanstack/react-query': { singleton: true },
-        'react-hook-form': { singleton: true },
-        'react-router-dom': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './LokiDatasource': './src/datasources/loki-datasource',
+      './LokiTimeSeriesQuery': './src/queries/loki-time-series-query',
+      './LokiLogQuery': './src/queries/loki-log-query',
+      './LogsTable': './src/panels/logstable',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@perses-dev/explore': { singleton: true },
+      '@perses-dev/dashboards': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      '@tanstack/react-query': { singleton: true },
+      'react-hook-form': { singleton: true },
+      'react-router-dom': { singleton: true },
+    },
   },
 });

--- a/markdown/rsbuild.config.ts
+++ b/markdown/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/Markdown/';
-
-export default defineConfig({
-  server: { port: 3007 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'Markdown',
+  rsbuildConfig: {
+    server: { port: 3007 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'Markdown',
-      exposes: {
-        './Markdown': './src/Markdown.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './Markdown': './src/Markdown.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/piechart/rsbuild.config.ts
+++ b/piechart/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/PieChart/';
-
-export default defineConfig({
-  server: { port: 3008 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'PieChart',
+  rsbuildConfig: {
+    server: { port: 3008 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'PieChart',
-      exposes: {
-        './PieChart': './src/PieChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './PieChart': './src/PieChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/prometheus/rsbuild.config.ts
+++ b/prometheus/rsbuild.config.ts
@@ -11,62 +11,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/Prometheus/';
-
-export default defineConfig({
-  server: { port: 3009 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'Prometheus',
+  rsbuildConfig: {
+    server: { port: 3009 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'Prometheus',
-      exposes: {
-        './PrometheusDatasource': './src/plugins/prometheus-datasource.tsx',
-        './PrometheusTimeSeriesQuery': './src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts',
-        './PrometheusLabelValuesVariable': './src/plugins/PrometheusLabelValuesVariable.tsx',
-        './PrometheusLabelNamesVariable': './src/plugins/PrometheusLabelNamesVariable.tsx',
-        './PrometheusPromQLVariable': './src/plugins/PrometheusPromQLVariable.tsx',
-        './PrometheusExplorer': './src/explore/PrometheusExplorer.tsx',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@perses-dev/explore': { singleton: true },
-        '@perses-dev/dashboards': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        '@tanstack/react-query': { singleton: true },
-        'react-hook-form': { singleton: true },
-        'react-router-dom': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './PrometheusDatasource': './src/plugins/prometheus-datasource.tsx',
+      './PrometheusTimeSeriesQuery': './src/plugins/prometheus-time-series-query/PrometheusTimeSeriesQuery.ts',
+      './PrometheusLabelValuesVariable': './src/plugins/PrometheusLabelValuesVariable.tsx',
+      './PrometheusLabelNamesVariable': './src/plugins/PrometheusLabelNamesVariable.tsx',
+      './PrometheusPromQLVariable': './src/plugins/PrometheusPromQLVariable.tsx',
+      './PrometheusExplorer': './src/explore/PrometheusExplorer.tsx',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@perses-dev/explore': { singleton: true },
+      '@perses-dev/dashboards': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      '@tanstack/react-query': { singleton: true },
+      'react-hook-form': { singleton: true },
+      'react-router-dom': { singleton: true },
+    },
   },
 });

--- a/pyroscope/rsbuild.config.ts
+++ b/pyroscope/rsbuild.config.ts
@@ -11,59 +11,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/Pyroscope/';
-
-export default defineConfig({
-  server: { port: 3020 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'Pyroscope',
+  rsbuildConfig: {
+    server: { port: 3020 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'Pyroscope',
-      exposes: {
-        './PyroscopeDatasource': './src/plugins/pyroscope-datasource.tsx',
-        './PyroscopeProfileQuery': './src/plugins/pyroscope-profile-query/PyroscopeProfileQuery.ts',
-        './PyroscopeExplorer': './src/explore/PyroscopeExplorer.tsx',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@perses-dev/explore': { singleton: true },
-        '@perses-dev/dashboards': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        '@tanstack/react-query': { singleton: true },
-        'react-hook-form': { singleton: true },
-        'react-router-dom': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './PyroscopeDatasource': './src/plugins/pyroscope-datasource.tsx',
+      './PyroscopeProfileQuery': './src/plugins/pyroscope-profile-query/PyroscopeProfileQuery.ts',
+      './PyroscopeExplorer': './src/explore/PyroscopeExplorer.tsx',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@perses-dev/explore': { singleton: true },
+      '@perses-dev/dashboards': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      '@tanstack/react-query': { singleton: true },
+      'react-hook-form': { singleton: true },
+      'react-router-dom': { singleton: true },
+    },
   },
 });

--- a/rsbuild.shared.ts
+++ b/rsbuild.shared.ts
@@ -1,0 +1,140 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ModuleFederationOptions, pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+import { mergeRsbuildConfig, RsbuildConfig } from '@rsbuild/core';
+
+/** The base path for all plugin assets. This should match the path where plugins are stored on the Perses server.
+ * @see {@link https://github.com/perses/perses}
+ */
+const PLUGINS_PATH = '/plugins';
+
+/**
+ * Configuration options for building a Perses plugin with rsbuild.
+ * @see {@link createConfigForPlugin}
+ */
+interface PluginConfigOptions {
+  /**
+   * The name of the plugin. Typically PascalCase
+   */
+  name: string;
+  /**
+   * Any rsbuild configuration options to merge with the base config. Note that
+   * the `server.port` and `output.assetPrefix` are automatically set based on
+   * the plugin name but can be overridden here. Additionally, the
+   * ModuleFederation plugin is automatically added after any plugins specified
+   * here. It's options can be configured via the `moduleFederation` property.
+   *
+   * @see {@link getRsbuildConfig}
+   */
+  rsbuildConfig?: RsbuildConfig;
+  /**
+   * Module Federation configuration options to pass to the Module Federation
+   * plugin. Note that the `name` is inherited from the `name` property defined
+   * alongside this object. Any values defined here will be merged over the base
+   * config.
+   *
+   * @see {@link getBaseModuleFederationConfig}
+   */
+  moduleFederation?: ModuleFederationOptions;
+}
+
+/**
+ * Creates a complete rsbuild configuration for a Perses plugin, including sensible defaults for the dev server, output
+ * asset prefix, and module federation plugin configuration.
+ *
+ * @param options Configuration options for the plugin build.
+ * @returns A complete rsbuild configuration object.
+ *
+ * @example
+ * ```ts
+ * import { createConfigForPlugin } from './rsbuild.shared';
+ * import type { RsbuildConfig } from '@rsbuild/core';
+ * import type { ModuleFederationOptions } from '@module-federation/rsbuild-plugin';
+ *
+ * const config: RsbuildConfig = createConfigForPlugin({
+ *   name: 'MyPlugin',
+ *   rsbuildConfig: {
+ *     // any additional rsbuild config options here
+ *   },
+ *   moduleFederation: {
+ *     // any additional module federation options here
+ *   },
+ * });
+ * ```
+ */
+export function createConfigForPlugin(options: PluginConfigOptions) {
+  const { name, rsbuildConfig = {}, moduleFederation = {} } = options;
+
+  const mfConfig: ModuleFederationOptions = {
+    ...getBaseModuleFederationConfig(name), // base config first
+    ...moduleFederation, // then any user config overrides
+  };
+
+  const baseConfig: RsbuildConfig = getRsbuildConfig(name);
+  const rsbuildConfigWithMfPlugin: RsbuildConfig = { plugins: [pluginModuleFederation(mfConfig)] };
+
+  return mergeRsbuildConfig(
+    baseConfig, // base config first
+    rsbuildConfig, // then any user config overrides
+    rsbuildConfigWithMfPlugin // then add the Module Federation plugin last
+  );
+}
+
+function getAssetPrefix(name: string): string {
+  return `${PLUGINS_PATH}/${name}/`;
+}
+
+function getRsbuildConfig(name: string): RsbuildConfig {
+  const assetPrefix = getAssetPrefix(name);
+
+  return {
+    server: {
+      port: 3000 + Math.floor(Math.random() * 1000),
+      strictPort: false,
+      printUrls: process.env.PERSES_CLI
+        ? ({ port, protocol }) => {
+            // custom output for `percli plugin start` to detect port for dev server
+            console.log(`[PERSES_PLUGIN] NAME="${name}" PORT="${port}" PROTOCOL="${protocol}"\n`);
+            console.log(`Local: ${protocol}://localhost:${port}`);
+            return [];
+          }
+        : true,
+      cors: { origin: '*' },
+    },
+    dev: { assetPrefix },
+    source: { entry: { main: './src/index-federation.ts' } },
+    output: {
+      assetPrefix,
+      copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
+      distPath: {
+        root: 'dist',
+        js: '__mf/js',
+        css: '__mf/css',
+        font: '__mf/font',
+      },
+    },
+    tools: {
+      htmlPlugin: false,
+    },
+  };
+}
+
+function getBaseModuleFederationConfig(name: string): ModuleFederationOptions {
+  return {
+    name,
+    dts: false,
+    runtime: false,
+    getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${getAssetPrefix(name)}"; }`,
+  };
+}

--- a/scatterchart/rsbuild.config.ts
+++ b/scatterchart/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/ScatterChart/';
-
-export default defineConfig({
-  server: { port: 3010 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'ScatterChart',
+  rsbuildConfig: {
+    server: { port: 3010 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'ScatterChart',
-      exposes: {
-        './ScatterChart': './src/ScatterChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './ScatterChart': './src/ScatterChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/statchart/rsbuild.config.ts
+++ b/statchart/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/StatChart/';
-
-export default defineConfig({
-  server: { port: 3011 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'StatChart',
+  rsbuildConfig: {
+    server: { port: 3011 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'StatChart',
-      exposes: {
-        './StatChart': './src/StatChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './StatChart': './src/StatChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/staticlistvariable/rsbuild.config.ts
+++ b/staticlistvariable/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/StaticListVariable/';
-
-export default defineConfig({
-  server: { port: 3012 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'StaticListVariable',
+  rsbuildConfig: {
+    server: { port: 3012 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'StaticListVariable',
-      exposes: {
-        './StaticListVariable': './src/StaticListVariable.tsx',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './StaticListVariable': './src/StaticListVariable.tsx',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/statushistorychart/rsbuild.config.ts
+++ b/statushistorychart/rsbuild.config.ts
@@ -11,54 +11,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/StatusHistoryChart/';
-
-export default defineConfig({
-  server: { port: 3013 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'StatusHistoryChart',
+  rsbuildConfig: {
+    server: { port: 3013 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'StatusHistoryChart',
-      exposes: {
-        './StatusHistoryChart': './src/StatusHistoryChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        '@tanstack/react-query': { singleton: true },
-        'react-hook-form': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './StatusHistoryChart': './src/StatusHistoryChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      '@tanstack/react-query': { singleton: true },
+      'react-hook-form': { singleton: true },
+    },
   },
 });

--- a/table/rsbuild.config.ts
+++ b/table/rsbuild.config.ts
@@ -11,56 +11,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/Table/';
-
-export default defineConfig({
-  server: { port: 3014 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'Table',
+  rsbuildConfig: {
+    server: { port: 3014 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'Table',
-      exposes: {
-        './Table': './src/Table.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/core': { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@perses-dev/dashboards': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        '@tanstack/react-query': { singleton: true },
-        'react-hook-form': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './Table': './src/Table.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/core': { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@perses-dev/dashboards': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      '@tanstack/react-query': { singleton: true },
+      'react-hook-form': { singleton: true },
+    },
   },
 });

--- a/tempo/rsbuild.config.ts
+++ b/tempo/rsbuild.config.ts
@@ -11,58 +11,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/Tempo/';
-
-export default defineConfig({
-  server: { port: 3015 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'Tempo',
+  rsbuildConfig: {
+    server: { port: 3015 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'Tempo',
-      exposes: {
-        './TempoDatasource': './src/plugins/tempo-datasource.tsx',
-        './TempoTraceQuery': './src/plugins/tempo-trace-query/TempoTraceQuery.ts',
-        './TempoExplorer': './src/explore/TempoExplorer.tsx',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@perses-dev/explore': { singleton: true },
-        '@perses-dev/dashboards': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        '@tanstack/react-query': { singleton: true },
-        'react-hook-form': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './TempoDatasource': './src/plugins/tempo-datasource.tsx',
+      './TempoTraceQuery': './src/plugins/tempo-trace-query/TempoTraceQuery.ts',
+      './TempoExplorer': './src/explore/TempoExplorer.tsx',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@perses-dev/explore': { singleton: true },
+      '@perses-dev/dashboards': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      '@tanstack/react-query': { singleton: true },
+      'react-hook-form': { singleton: true },
+    },
   },
 });

--- a/timeserieschart/rsbuild.config.ts
+++ b/timeserieschart/rsbuild.config.ts
@@ -11,56 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/TimeSeriesChart/';
-
-export default defineConfig({
-  server: { port: 3016 },
-  dev: { assetPrefix },
-  source: {
-    entry: {
-      main: './src/index-federation.ts',
-    },
+export default createConfigForPlugin({
+  name: 'TimeSeriesChart',
+  rsbuildConfig: {
+    server: { port: 3016 },
+    plugins: [pluginReact()],
   },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
+  moduleFederation: {
+    exposes: {
+      './TimeSeriesChart': './src/TimeSeriesChart.ts',
     },
-  },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'TimeSeriesChart',
-      exposes: {
-        './TimeSeriesChart': './src/TimeSeriesChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/timeseriestable/rsbuild.config.ts
+++ b/timeseriestable/rsbuild.config.ts
@@ -11,55 +11,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/TimeSeriesTable/';
-
-export default defineConfig({
-  server: { port: 3017 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'TimeSeriesTable',
+  rsbuildConfig: {
+    server: { port: 3017 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'TimeSeriesTable',
-      exposes: {
-        './TimeSeriesTable': './src/TimeSeriesTable.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/core': { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/dashboards': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-        'use-resize-observer': { requiredVersion: '^9.1.0', singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './TimeSeriesTable': './src/TimeSeriesTable.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/core': { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/dashboards': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+      'use-resize-observer': { requiredVersion: '^9.1.0', singleton: true },
+    },
   },
 });

--- a/tracetable/rsbuild.config.ts
+++ b/tracetable/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/TraceTable/';
-
-export default defineConfig({
-  server: { port: 3018 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'TraceTable',
+  rsbuildConfig: {
+    server: { port: 3018 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'TraceTable',
-      exposes: {
-        './TraceTable': './src/TraceTable.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './TraceTable': './src/TraceTable.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/tracingganttchart/rsbuild.config.ts
+++ b/tracingganttchart/rsbuild.config.ts
@@ -11,52 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
-import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { createConfigForPlugin } from '../rsbuild.shared';
 
-const assetPrefix = '/plugins/TracingGanttChart/';
-
-export default defineConfig({
-  server: { port: 3019 },
-  dev: { assetPrefix },
-  source: { entry: { main: './src/index-federation.ts' } },
-  output: {
-    assetPrefix,
-    copy: [{ from: 'package.json' }, { from: 'README.md' }, { from: '../LICENSE', to: './LICENSE', toType: 'file' }],
-    distPath: {
-      root: 'dist',
-      js: '__mf/js',
-      css: '__mf/css',
-      font: '__mf/font',
-    },
+export default createConfigForPlugin({
+  name: 'TracingGanttChart',
+  rsbuildConfig: {
+    server: { port: 3019 },
+    plugins: [pluginReact()],
   },
-  plugins: [
-    pluginReact(),
-    pluginModuleFederation({
-      name: 'TracingGanttChart',
-      exposes: {
-        './TracingGanttChart': './src/TracingGanttChart.ts',
-      },
-      shared: {
-        react: { requiredVersion: '18.2.0', singleton: true },
-        'react-dom': { requiredVersion: '18.2.0', singleton: true },
-        echarts: { singleton: true },
-        'date-fns': { singleton: true },
-        'date-fns-tz': { singleton: true },
-        lodash: { singleton: true },
-        '@perses-dev/components': { singleton: true },
-        '@perses-dev/plugin-system': { singleton: true },
-        '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
-        '@emotion/styled': { singleton: true },
-        '@hookform/resolvers': { singleton: true },
-      },
-      dts: false,
-      runtime: false,
-      getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${assetPrefix}"; }`,
-    }),
-  ],
-  tools: {
-    htmlPlugin: false,
+  moduleFederation: {
+    exposes: {
+      './TracingGanttChart': './src/TracingGanttChart.ts',
+    },
+    shared: {
+      react: { requiredVersion: '18.2.0', singleton: true },
+      'react-dom': { requiredVersion: '18.2.0', singleton: true },
+      echarts: { singleton: true },
+      'date-fns': { singleton: true },
+      'date-fns-tz': { singleton: true },
+      lodash: { singleton: true },
+      '@perses-dev/components': { singleton: true },
+      '@perses-dev/plugin-system': { singleton: true },
+      '@emotion/react': { requiredVersion: '^11.11.3', singleton: true },
+      '@emotion/styled': { singleton: true },
+      '@hookform/resolvers': { singleton: true },
+    },
   },
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./rsbuild.shared.ts", "**/rsbuild.config.ts"]
+}


### PR DESCRIPTION
# Description

Since the majority of the configuration for both rspack and the module federation plugin is the same across all plugins, this PR refactors the configuration files to use a shared configuration generator. The common configuration is now in `rspack.shared.ts` exports a `createConfigForPlugin` function that takes a plugin name and any additional rspack and mf configuration options to merge with the base configuration.

I tested that there are no changes to the build output by running the `turbo build` command on main, then running `turbo build` again after switching to this branch and `diff`ing the output.

<details>

<summary>Testing Outcomes</summary>

> [!NOTE]
> These differences have all been discussed and will be resolved in other PRs

<img width="427" height="266" alt="Screenshot 2025-09-29 at 10 53 47 AM" src="https://github.com/user-attachments/assets/ac3bb286-5ae6-45ca-a446-eb5f8d2b8bcf" />

### ClickHouse

> [!NOTE]
> License should be included, Resolved in #393

This plugin does not include the `LICENSE` file by default. As the PR is now, the LICENSE file is included again but if this is not desired, I'll add an option to the shared config to disable it. [See here](https://github.com/perses/plugins/pull/391/files#diff-a696651a6f68344a225db13442489e5e99685a3eb5c500a7add0b22f8719fc3cR118).

~~***Question:*** _Is this expected?_~~

### Scatterchart

> [!NOTE]
> ScatterChart plugin was missing the source entrypoint. Resolved in #395

This one is a little confusing. When building from main, the ScatterChart plugin shows no requirements in the exposed module but in this branch it does. It seems like it should include these requirements but the settings didn't change from one branch to the other.

~~***Question:*** _Which is correct?_~~

<table>
<thead>
<tr><td colspan="2">`scatterchart/dist/mf-stats.json`</td></tr>
</thead>
<tbody>
<tr>
<td>
         
```diff
  "exposes": [
    {
      "path": "./ScatterChart",
      "id": "ScatterChart:ScatterChart",
      "name": "ScatterChart",
-     "requires": [],




      "file": "src/ScatterChart.ts",
      "assets": {
        "js": {
          "sync": [
-           "__mf/js/101.3314ba33.js",
-           "__mf/js/async/516.bffdf7cf.js",
-           "__mf/js/async/__federation_expose_ScatterChart.90cafc30.js"
          ],
          "async": [
            "__mf/js/async/238.16ecfee4.js",
            "__mf/js/async/224.fc2a8424.js",
            "__mf/js/async/292.5884e762.js",
-           "__mf/js/async/356.77a672cf.js",
            "__mf/js/async/422.e34eaeff.js",
            "__mf/js/async/lib-router.0da6cd3a.js",
            "__mf/js/async/488.064b892d.js"
          ]
        },
        "css": {
          "sync": [],
          "async": [
            "__mf/css/async/341.9c79ef64.css",
-           "__mf/css/async/759.9c79ef64.css"
          ]
        }
      }
    }
  ]
```   
            
</td>
<td>

```diff
  "exposes": [
    {
      "path": "./ScatterChart",
      "id": "ScatterChart:ScatterChart",
      "name": "ScatterChart",
+     "requires": [
+       "react",
+       "@perses-dev/components",
+       "@perses-dev/plugin-system"
+     ],
      "file": "src/ScatterChart.ts",
      "assets": {
        "js": {
          "sync": [
+           "__mf/js/async/743.9917d883.js",
+           "__mf/js/async/250.4bb21c32.js",
+           "__mf/js/async/__federation_expose_ScatterChart.80c2364e.js"
          ],
          "async": [
            "__mf/js/async/238.16ecfee4.js",
            "__mf/js/async/224.fc2a8424.js",
            "__mf/js/async/292.5884e762.js",
+           "__mf/js/async/356.8494085d.js",
            "__mf/js/async/422.e34eaeff.js",
            "__mf/js/async/lib-router.0da6cd3a.js",
            "__mf/js/async/488.064b892d.js"
          ]
        },
        "css": {
          "sync": [],
          "async": [
            "__mf/css/async/341.9c79ef64.css",
+           "__mf/css/async/263.9c79ef64.css"
          ]
        }
      }
    }
  ]
```

</td>
<tr>
</tbody>
</table>

### Pyroscope, Tempo

> ![NOTE]
> Discussed, not a critical difference

These two only seems to have changed the output order of the `usedIn` key in for `@perses-dev/plugin-system`. I'm assuming this is because of the rsbuild `mergeConfig` function messing with the order, but it doesn't seem like this is a critical difference regardless of the cause.

`prometheus/dist/mf-stats.json`
         
```diff
{
  ...
  "shared": [
    ...
    {
      "singleton": true,
      "requiredVersion": "^0.52.0",
      "shareScope": "default",
      "name": "@perses-dev/plugin-system",
      ...
      "usedIn": [
-        "./PrometheusPromQLVariable",
+        "./PrometheusTimeSeriesQuery",
        "./PrometheusExplorer",
        "./PrometheusLabelNamesVariable",
        "./PrometheusLabelValuesVariable",
-       "./PrometheusDatasource",
-       "./PrometheusTimeSeriesQuery"
+        "./PrometheusPromQLVariable",
+        "./PrometheusDatasource"
      ]
  ...
```

`tempo/dist/mf-stats.json`
         
```diff
{
  ...
  "shared": [
    ...
    {
      "singleton": true,
      "requiredVersion": "^0.52.0",
      "shareScope": "default",
      "name": "@perses-dev/plugin-system",
      ...
      "usedIn": [
-        "./TempoTraceQuery",
        "./TempoExplorer",
-        "./TempoDatasource"
+        "./TempoDatasource",
+        "./TempoTraceQuery"
      ]
  ...
```

</details>


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).