### PR TITLE
[BUGFIX] Migration: Fix wrong threshold color value in several plugins

### DIFF
--- a/gaugechart/schemas/migrate/migrate.cue
+++ b/gaugechart/schemas/migrate/migrate.cue
@@ -47,7 +47,7 @@ spec: {
 					if step.value == null {0},
 					step.value,
 				][0]
-				color: step.color
+				color: *commonMigrate.#mapping.color[step.color] | step.color
 			}]
 		}
 	}

--- a/gaugechart/schemas/migrate/tests/basic/expected.json
+++ b/gaugechart/schemas/migrate/tests/basic/expected.json
@@ -9,11 +9,11 @@
     "thresholds": {
       "steps": [
         {
-          "color": "green",
+          "color": "#73bf69",
           "value": 0
         },
         {
-          "color": "red",
+          "color": "#f2495c",
           "value": 80
         }
       ]

--- a/statchart/schemas/migrate/migrate.cue
+++ b/statchart/schemas/migrate/migrate.cue
@@ -80,7 +80,7 @@ spec: {
 					if step.value == null {0},
 					{step.value},
 				][0]
-				color: step.color // TODO how to manage the overrides part?
+				color: *commonMigrate.#mapping.color[step.color] | step.color // TODO how to manage the overrides part?
 			}]
 		}
 	}

--- a/statchart/schemas/migrate/tests/basic/expected.json
+++ b/statchart/schemas/migrate/tests/basic/expected.json
@@ -10,11 +10,11 @@
     "thresholds": {
       "steps": [
         {
-          "color": "green",
+          "color": "#73bf69",
           "value": 0
         },
         {
-          "color": "red",
+          "color": "#f2495c",
           "value": 5
         }
       ]

--- a/statchart/schemas/migrate/tests/mappings/expected.json
+++ b/statchart/schemas/migrate/tests/mappings/expected.json
@@ -55,7 +55,7 @@
     "thresholds": {
       "steps": [
         {
-          "color": "blue",
+          "color": "#5794f2",
           "value": 0
         }
       ]

--- a/statchart/schemas/migrate/tests/overrides_to_mappings/expected.json
+++ b/statchart/schemas/migrate/tests/overrides_to_mappings/expected.json
@@ -47,11 +47,11 @@
     "thresholds": {
       "steps": [
         {
-          "color": "red",
+          "color": "#f2495c",
           "value": 0
         },
         {
-          "color": "green",
+          "color": "#73bf69",
           "value": 1
         }
       ]

--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -122,7 +122,7 @@ spec: {
 					if step.value == null {0},
 					step.value,
 				][0]
-				color: step.color // TODO how to manage the overrides part?
+				color: *commonMigrate.#mapping.color[step.color] | step.color // TODO how to manage the overrides part?
 			}]
 		}
 	}

--- a/timeserieschart/schemas/migrate/tests/basic/expected.json
+++ b/timeserieschart/schemas/migrate/tests/basic/expected.json
@@ -19,6 +19,18 @@
       },
       "label": "Amount of endpoints succesfully monitored",
       "min": 0
+    },
+    "thresholds": {
+      "steps": [
+        {
+          "color": "#73bf69",
+          "value": 0
+        },
+        {
+          "color": "#f2cc0c",
+          "value": 80
+        }
+      ]
     }
   }
 }

--- a/timeserieschart/schemas/migrate/tests/basic/input.json
+++ b/timeserieschart/schemas/migrate/tests/basic/input.json
@@ -38,7 +38,7 @@
           "mode": "none"
         },
         "thresholdsStyle": {
-          "mode": "off"
+          "mode": "line"
         }
       },
       "links": [],
@@ -52,7 +52,7 @@
             "value": null
           },
           {
-            "color": "red",
+            "color": "semi-dark-yellow",
             "value": 80
           }
         ]


### PR DESCRIPTION
# Description

This bug went unnoticed until then because the common color codes like "red", "green", "blue" are actually well interpreted by the Perses vizualisation in the end. More exotic ones like "semi-dark-yellow" aren't. Anyway the color picker doesn't like these, thus we want in any case to convert to hexa code.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).