### PR TITLE
[ENHANCEMENT] StaticListVariable: allow customizing label & value independently

### DIFF
--- a/staticlistvariable/src/StaticListVariable.tsx
+++ b/staticlistvariable/src/StaticListVariable.tsx
@@ -1,5 +1,8 @@
+/* eslint-disable jsx-a11y/no-autofocus */
 import { VariablePlugin, VariableOption, OptionsEditorProps } from '@perses-dev/plugin-system';
-import { Autocomplete, TextField } from '@mui/material';
+import { Autocomplete, Chip, IconButton, TextField, Typography } from '@mui/material';
+import { useCallback, useState } from 'react';
+import PlusCircleIcon from 'mdi-material-ui/PlusCircle';
 
 type StaticListOption = string | VariableOption;
 
@@ -8,47 +11,223 @@ type StaticListVariableOptions = {
 };
 
 function StaticListVariableOptionEditor(props: OptionsEditorProps<StaticListVariableOptions>) {
-  const value = (props.value.values || []).map((v) => {
-    if (typeof v === 'string') {
-      return v;
-    } else {
-      return v.value;
-    }
-  });
+  const {
+    value: { values: variables = [] },
+    onChange,
+  } = props;
 
-  const onChange = (__: unknown, value: string[]) => {
-    props.onChange({
-      values: value.map((v) => {
-        return { value: v, label: v };
-      }),
-    });
-  };
+  const [editModeOption, setEditModeOption] = useState<string>('');
+
+  const onChangeHandler = useCallback(
+    (_: unknown, value: string[]): void => {
+      const newVariable = value.pop();
+
+      const valueExists = variables
+        .map((v) => {
+          return typeof v === 'string' ? v : (v as VariableOption)?.value || '';
+        })
+        .some((v) => v === newVariable);
+
+      if (valueExists) return;
+
+      onChange({
+        values: [...variables, { value: String(newVariable), label: String(newVariable) }],
+      });
+    },
+    [onChange, variables]
+  );
+
+  const onPasteHandler = useCallback(
+    (e: React.ClipboardEvent<HTMLDivElement>) => {
+      const v = e.clipboardData.getData('text/plain');
+      if (v) {
+        const items = v
+          .split(',')
+          .filter((i) => {
+            const exists = variables
+              .map((v) => {
+                return (v as VariableOption)?.value || String(v);
+              })
+              .some((v) => v === i);
+            return !exists;
+          })
+          .map((item) => ({ value: item.trim(), label: '' }));
+        onChange({ values: [...variables, ...items] });
+        e.preventDefault();
+      }
+    },
+    [onChange, variables]
+  );
+
+  const tagDeleteHandler = useCallback(
+    (option: string) => {
+      const filteredVariables = variables.filter(
+        (v) => !((v as string) === option || (v as VariableOption)?.value === option)
+      );
+      onChange({ values: [...filteredVariables] });
+      setEditModeOption('');
+    },
+    [variables, onChange]
+  );
+
+  const renderTagsHandler = useCallback(
+    (tagValue: string[]) => {
+      const updateVariableWithLabel = (optionKey: string, label: string): Array<string | VariableOption> => {
+        if (!optionKey || !label) return variables;
+        /* Prevent duplicate label */
+        const labelAlreadyExists = variables.filter((v) => typeof v !== 'string').some((v) => v?.label === label);
+        if (labelAlreadyExists) return variables;
+
+        return variables.map((v) => {
+          if (typeof v === 'string') return v;
+          const variableOption = v as VariableOption;
+          if (variableOption!.value !== optionKey) return variableOption;
+          const updatedVariableOption: VariableOption = {
+            label,
+            value: variableOption!.value,
+          };
+          return updatedVariableOption;
+        });
+      };
+
+      return tagValue.map((_, index) => {
+        const foundVariable = variables[index];
+        if (!foundVariable) return null;
+
+        const labelObject: { value: string; label: string } = { value: '', label: '' };
+
+        if (typeof foundVariable === 'string') {
+          /* value and label are identical */
+          labelObject.value = foundVariable;
+          labelObject.label = foundVariable;
+        } else {
+          labelObject.value = foundVariable.value;
+          labelObject.label = foundVariable.label || foundVariable.value;
+        }
+
+        /* The value and key are the same thing, they can be used interchangeably  */
+        const optionKey = (foundVariable as VariableOption)?.value || (foundVariable as string);
+
+        return (
+          <Chip
+            key={optionKey}
+            sx={{ margin: '4px' }}
+            label={
+              editModeOption !== optionKey ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <Typography variant="body2">{labelObject.value}</Typography>
+                  {labelObject?.value !== labelObject?.label && (
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        backgroundColor: (theme) => theme.palette.grey[200],
+                        color: (theme) => theme.palette.text.primary,
+                        padding: '4px 8px',
+                        borderRadius: '4px',
+                        fontWeight: 500,
+                      }}
+                    >
+                      {labelObject.label}
+                    </Typography>
+                  )}
+                  {/* Label can be added once and then no longer it will be editable */}
+                  {typeof foundVariable !== 'string' && labelObject.value === labelObject.label && (
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditModeOption(optionKey);
+                      }}
+                      sx={{
+                        color: (theme) => theme.palette.action.disabled,
+                      }}
+                    >
+                      <PlusCircleIcon fontSize="small" />
+                    </IconButton>
+                  )}
+                </div>
+              ) : (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <span>{optionKey}</span>
+                  <TextField
+                    defaultValue={labelObject.label}
+                    onBlur={(e) => {
+                      const {
+                        target: { value: input },
+                      } = e;
+                      if (input) {
+                        const updatedVariables = updateVariableWithLabel(optionKey, input);
+                        onChange({ values: updatedVariables });
+                      }
+                      setEditModeOption('');
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        const { value: input } = e.target as HTMLInputElement;
+                        const updatedVariables = updateVariableWithLabel(optionKey, input);
+                        onChange({ values: updatedVariables });
+                        setEditModeOption('');
+                      } else if (e.key === 'Escape') {
+                        setEditModeOption('');
+                      }
+                    }}
+                    size="small"
+                    autoFocus
+                    sx={{
+                      width: '100%',
+                      padding: 0,
+                      margin: 0,
+                      backgroundColor: (theme) => theme.palette.background.default,
+                      '& .MuiInputBase-root': {
+                        fontSize: '0.875rem',
+                        padding: 0,
+                      },
+                      '& .MuiOutlinedInput-notchedOutline': {
+                        border: 'none',
+                      },
+                    }}
+                    inputProps={{
+                      style: {
+                        padding: 0,
+                      },
+                    }}
+                  />
+                </div>
+              )
+            }
+            onDelete={() => {
+              tagDeleteHandler(optionKey);
+            }}
+          />
+        );
+      });
+    },
+    [variables, tagDeleteHandler, editModeOption, onChange]
+  );
 
   return (
     <div>
       <Autocomplete
-        onPaste={(e) => {
-          // Append new values on paste
-          const v = e.clipboardData.getData('text/plain');
-          if (v) {
-            const values = v.split(',');
-            onChange(null, value.concat(values));
-            e.preventDefault();
-          }
-        }}
+        onPaste={onPasteHandler}
         multiple
-        value={value}
-        onChange={onChange}
+        value={variables.map((vr) => (typeof vr === 'string' ? vr : vr.label || vr.value))}
+        onChange={onChangeHandler}
         options={[]}
         freeSolo
         clearOnBlur
         readOnly={props.isReadonly}
+        renderTags={renderTagsHandler}
         renderInput={(params) => (
           <TextField
             {...params}
             label="Values"
             placeholder="Values"
-            helperText='Type new value then press "Enter" to add.'
+            helperText='Type new value then press "Enter" to add. Optionally define a label by clicking on the "+" button.'
+            onKeyDown={(e) => {
+              if (e.key === 'Backspace' && !params.inputProps.value) {
+                e.stopPropagation();
+              }
+            }}
           />
         )}
       />


### PR DESCRIPTION
# Description 🖊️ 

Closes https://github.com/perses/perses/issues/3393 - as explained there every item of the Static List Variable should be able to receive both label and value.  

# The Change 🔧 

This PR adds a button to the autocomplete chips, so the user can add their desired label. 

<img width="623" height="359" alt="image" src="https://github.com/user-attachments/assets/efb01bfd-71ed-41af-8b42-131a94ff6802" />


# Test 🧪 

All following scenarios should work without any issue

- Add items (value only)
- Add items and edit some labels
- After a label is added for variable, the add icon should be removed and the chip should no longer be editable
- Should capture the label both with onBlur and Enter
- Should cancel label edit mode by pressing Escape button
- Remove items
- Duplicate values and labels must be prevented
- Text from clipboard should be handled properly (Prevent duplication)
- Save and Reload
- Edit and Reload




# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).