### PR TITLE
[ENHANCEMENT] Tempo: use default MUI checkbox icons

### DIFF
--- a/tempo/src/components/AttributeFilters.tsx
+++ b/tempo/src/components/AttributeFilters.tsx
@@ -16,8 +16,6 @@ import { Autocomplete, Checkbox, Stack, TextField, TextFieldProps } from '@mui/m
 import { isAbsoluteTimeRange, toAbsoluteTimeRange } from '@perses-dev/core';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { useQuery } from '@tanstack/react-query';
-import CheckboxOutline from 'mdi-material-ui/CheckboxOutline';
-import CheckboxBlankOutline from 'mdi-material-ui/CheckboxBlankOutline';
 import { TempoClient } from '../model';
 import { filterToTraceQL } from './filter/filter_to_traceql';
 import { traceQLToFilter } from './filter/traceql_to_filter';
@@ -102,9 +100,6 @@ interface StringAttributeFilterProps {
   setValue: (value: string[]) => void;
 }
 
-const checkboxBlankIcon = <CheckboxBlankOutline fontSize="small" />;
-const checkedMarkedIcon = <CheckboxOutline fontSize="small" />;
-
 function StringAttributeFilter(props: StringAttributeFilterProps) {
   const { label, width, options, value, setValue } = props;
 
@@ -121,12 +116,7 @@ function StringAttributeFilter(props: StringAttributeFilterProps) {
         const { key, ...optionProps } = props;
         return (
           <li key={key} {...optionProps}>
-            <Checkbox
-              icon={checkboxBlankIcon}
-              checkedIcon={checkedMarkedIcon}
-              style={{ marginRight: 8 }}
-              checked={selected}
-            />
+            <Checkbox style={{ marginRight: 8 }} checked={selected} />
             {option}
           </li>
         );


### PR DESCRIPTION
# Description

Use default MUI checkbox icons in Tempo Filter Bar.
Ref. https://github.com/perses/perses/pull/3415#issuecomment-3361248908 cc @Gladorme 

# Screenshots
Before (left) / After (right):
<img  height="400" src="https://github.com/user-attachments/assets/f2d8b177-54b3-439a-8137-f4876a26a7d4" /> <img height="400" src="https://github.com/user-attachments/assets/518cbefd-456f-4b32-a8bb-353bd238dc89" />


<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).