### PR TITLE
[BUGFIX] Tempo: Do not fetch filter bar values on re-render

### DIFF
--- a/tempo/src/components/AttributeFilters.tsx
+++ b/tempo/src/components/AttributeFilters.tsx
@@ -13,10 +13,10 @@
 
 import { ReactElement, SyntheticEvent, useCallback, useEffect, useState } from 'react';
 import { Autocomplete, Checkbox, Stack, TextField, TextFieldProps } from '@mui/material';
-import { isAbsoluteTimeRange, toAbsoluteTimeRange } from '@perses-dev/core';
 import { useTimeRange } from '@perses-dev/plugin-system';
 import { useQuery } from '@tanstack/react-query';
 import { TempoClient } from '../model';
+import { getUnixTimeRange } from '../plugins/tempo-trace-query/get-trace-data';
 import { filterToTraceQL } from './filter/filter_to_traceql';
 import { traceQLToFilter } from './filter/traceql_to_filter';
 import { DurationField, Filter, splitByUnquotedWhitespace } from './filter/filter';
@@ -37,24 +37,22 @@ export function AttributeFilters(props: AttributeFiltersProps): ReactElement {
     setQuery(filterToTraceQL(filter));
   };
 
-  const { timeRange } = useTimeRange();
-  const absTimeRange = !isAbsoluteTimeRange(timeRange) ? toAbsoluteTimeRange(timeRange) : timeRange;
-  const startTime = Math.round(absTimeRange.start.getTime() / 1000);
-  const endTime = Math.round(absTimeRange.end.getTime() / 1000);
+  const { absoluteTimeRange } = useTimeRange();
+  const { start, end } = getUnixTimeRange(absoluteTimeRange);
 
   const { data: serviceNameOptions } = useTagValues(
     client,
     'resource.service.name',
     filterToTraceQL({ ...filter, serviceName: [] }),
-    startTime,
-    endTime
+    start,
+    end
   );
   const { data: spanNameOptions } = useTagValues(
     client,
     'name',
     filterToTraceQL({ ...filter, spanName: [] }),
-    startTime,
-    endTime
+    start,
+    end
   );
 
   return (


### PR DESCRIPTION
# Description

Previously, the absolute time range was calculated from the relative time range (e.g. "last 30 minutes") on every re-render, which resulted in a network request on every re-render of the filter bar.

To fix this, we can use `absoluteTimeRange` from `TimeRangeProvider`, which keeps the absolute time range during re-renders.

# Screenshots

no visible changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).