### PR TITLE
[ENHANCEMENT] Tempo: Use absolute time from TimeRangeProvider for TraceQL auto-completion

### DIFF
--- a/tempo/src/components/TraceQLEditor.tsx
+++ b/tempo/src/components/TraceQLEditor.tsx
@@ -27,10 +27,10 @@ export function TraceQLEditor({ client, ...rest }: TraceQLEditorProps): ReactEle
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
 
-  const { timeRange } = useTimeRange();
+  const { absoluteTimeRange } = useTimeRange();
   const traceQLExtension = useMemo(() => {
-    return TraceQLExtension({ client, timeRange });
-  }, [client, timeRange]);
+    return TraceQLExtension({ client, timeRange: absoluteTimeRange });
+  }, [client, absoluteTimeRange]);
 
   const codemirrorTheme = useMemo(() => {
     // https://github.com/mui/material-ui/blob/v5.16.7/packages/mui-material/src/OutlinedInput/OutlinedInput.js#L43

--- a/tempo/src/components/TraceQLExtension.ts
+++ b/tempo/src/components/TraceQLExtension.ts
@@ -15,7 +15,7 @@ import { LRLanguage } from '@codemirror/language';
 import { parser } from '@grafana/lezer-traceql';
 import { CompletionContext } from '@codemirror/autocomplete';
 import { Extension } from '@uiw/react-codemirror';
-import { TimeRangeValue } from '@perses-dev/core';
+import { AbsoluteTimeRange } from '@perses-dev/core';
 import { TempoClient } from '../model/tempo-client';
 import { traceQLHighlight } from './highlight';
 import { complete } from './complete';
@@ -37,7 +37,7 @@ export interface CompletionConfig {
   client?: TempoClient;
 
   /** search for tag values in a given time range */
-  timeRange?: TimeRangeValue;
+  timeRange?: AbsoluteTimeRange;
 
   /** limit number of returned tag values */
   limit?: number;


### PR DESCRIPTION
# Description

When the time range is set to a relative value, e.g. "last 30 minutes", the TraceQL auto-complete should use the stored absolute time of the TimeRangeProvider instead of calculating e.g. "last 30 minutes" from the current time.

In other words, the absolute time range should be identical for search results, filter bar suggestions and TraceQL auto-completions.

# Screenshots

no visible changes

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).