### PR TITLE
[ENHANCEMENT] Allow __mf/js/async assets to use proxy

### DIFF
--- a/rsbuild.shared.ts
+++ b/rsbuild.shared.ts
@@ -126,6 +126,11 @@ function getRsbuildConfig(name: string): RsbuildConfig {
     },
     tools: {
       htmlPlugin: false,
+      rspack: (config) => {
+        config.output = config.output || {};
+        config.output.publicPath = 'auto';
+        return config;
+      },
     },
   };
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Enable dynamic publicPath for Module Federation async chunks

  Problem: Plugin async chunks (__mf/js/async/*) were loading from hardcoded paths instead of using the proxy URL, causing 404 errors.

  Solution: Dynamically set ` __webpack_public_path__` to allow for reverse proxies 

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes
! No UI changes
- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
