### PR TITLE
[FEATURE] StatChart: Add background color customization

### DIFF
--- a/statchart/schemas/stat.cue
+++ b/statchart/schemas/stat.cue
@@ -29,4 +29,5 @@ spec: close({
 	})
 	valueFontSize?: number
 	mappings?: [...common.#mappings]
+	backgroundColor?: string
 })

--- a/statchart/src/StatChartBase.tsx
+++ b/statchart/src/StatChartBase.tsx
@@ -44,10 +44,11 @@ export interface StatChartProps {
   sparkline?: LineSeriesOption;
   showSeriesName?: boolean;
   valueFontSize?: FontSizeOption;
+  backgroundColor?: string;
 }
 
 export const StatChartBase: FC<StatChartProps> = (props) => {
-  const { width, height, data, sparkline, showSeriesName, format, valueFontSize } = props;
+  const { width, height, data, sparkline, showSeriesName, format, valueFontSize, backgroundColor } = props;
   const chartsTheme = useChartsTheme();
   const color = data.color;
 
@@ -88,12 +89,12 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
   seriesNameFontSize = Math.min(optimalValueFontSize * 0.7, seriesNameFontSize);
 
   const option: EChartsCoreOption = useMemo(() => {
-    if (data.seriesData === undefined) return chartsTheme.noDataOption;
+    if (!data.seriesData) return chartsTheme.noDataOption;
 
     const series = data.seriesData;
     const statSeries: LineSeriesOption[] = [];
 
-    if (sparkline !== undefined) {
+    if (sparkline) {
       const lineSeries = {
         type: 'line',
         name: series.name,
@@ -107,7 +108,8 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
       statSeries.push(mergedSeries);
     }
 
-    const option = {
+    const option: EChartsCoreOption = {
+      backgroundColor,
       title: {
         show: false,
       },
@@ -142,7 +144,7 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
     };
 
     return option;
-  }, [data, chartsTheme, sparkline]);
+  }, [data, chartsTheme, sparkline, backgroundColor]);
 
   const textAlignment = sparkline ? 'auto' : 'center';
   const textStyles = {
@@ -159,13 +161,20 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
           {data.seriesData?.name}
         </SeriesName>
       )}
-      <Value variant="h3" color={color} fontSize={optimalValueFontSize} padding={containerPadding}>
+      <Value
+        variant="h3"
+        color={color}
+        backgroundColor={backgroundColor}
+        fontSize={optimalValueFontSize}
+        padding={containerPadding}
+      >
         {formattedValue}
       </Value>
-      {sparkline !== undefined && (
+      {sparkline && (
         <EChart
           sx={{
             width: '100%',
+            backgroundColor,
           }}
           style={{
             // ECharts rounds the height to the nearest integer by default.
@@ -194,9 +203,10 @@ const SeriesName = styled(Typography, {
 
 const Value = styled(Typography, {
   shouldForwardProp: (prop) => prop !== 'color' && prop !== 'padding' && prop !== 'fontSize' && prop !== 'sparkline',
-})<{ color?: string; padding?: number; fontSize?: number; sparkline?: boolean }>(
-  ({ theme, color, padding, fontSize, sparkline }) => ({
+})<{ color?: string; padding?: number; fontSize?: number; sparkline?: boolean; backgroundColor?: string }>(
+  ({ theme, color, padding, fontSize, sparkline, backgroundColor }) => ({
     color: color ?? theme.palette.text.primary,
+    backgroundColor: backgroundColor ?? theme.palette.background.default,
     fontSize: `${fontSize}px`,
     padding: sparkline ? `${padding}px ${padding}px 0 ${padding}px` : ` 0 ${padding}px`,
     whiteSpace: 'nowrap',

--- a/statchart/src/StatChartOptionsEditorSettings.tsx
+++ b/statchart/src/StatChartOptionsEditorSettings.tsx
@@ -11,19 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Switch, SwitchProps } from '@mui/material';
+import { Switch, SwitchProps, useTheme } from '@mui/material';
 import {
   FontSizeOption,
   FontSizeSelector,
   FontSizeSelectorProps,
   FormatControls,
   FormatControlsProps,
+  OptionsColorPicker,
   OptionsEditorColumn,
   OptionsEditorControl,
   OptionsEditorGrid,
   OptionsEditorGroup,
   ThresholdsEditor,
   ThresholdsEditorProps,
+  OptionsColorPickerProps,
 } from '@perses-dev/components';
 import { FormatOptions } from '@perses-dev/core';
 import {
@@ -34,13 +36,15 @@ import {
 } from '@perses-dev/plugin-system';
 import { produce } from 'immer';
 import merge from 'lodash/merge';
-import { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 import { StatChartOptions, StatChartOptionsEditorProps } from './stat-chart-model';
 
 const DEFAULT_FORMAT: FormatOptions = { unit: 'percent-decimal' };
+const DEMONSTRATION_WHITE_BACKGROUND = '#F5F5F5';
 
 export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProps): ReactElement {
   const { onChange, value } = props;
+  const theme = useTheme();
 
   // ensures decimalPlaces defaults to correct value
   const format = merge({}, DEFAULT_FORMAT, value.format);
@@ -96,6 +100,31 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
     );
   };
 
+  const onHandlerColorChange: OptionsColorPickerProps['onColorChange'] = (color: string) => {
+    let backgroundColor = '';
+    backgroundColor =
+      theme.palette.mode === 'light' && color === DEMONSTRATION_WHITE_BACKGROUND
+        ? theme.palette.background.default
+        : color;
+
+    onChange(
+      produce(value, (draft: StatChartOptions) => {
+        draft.backgroundColor = backgroundColor;
+      })
+    );
+  };
+
+  const colorPickerSelectedColor = useMemo((): string => {
+    if (value?.backgroundColor) return value?.backgroundColor;
+
+    if (theme.palette.mode === 'dark') return theme.palette.background.default;
+
+    /* The white color picker on the white editor panel form will be completely invisible
+       So, let's make it slightly darker JUST for demonstration.   
+    */
+    return DEMONSTRATION_WHITE_BACKGROUND;
+  }, [theme, value?.backgroundColor]);
+
   return (
     <OptionsEditorGrid>
       <OptionsEditorColumn>
@@ -103,6 +132,16 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
           <OptionsEditorControl
             label="Sparkline"
             control={<Switch checked={!!value.sparkline} onChange={handleSparklineChange} />}
+          />
+          <OptionsEditorControl
+            label="Background color"
+            control={
+              <OptionsColorPicker
+                label="Background color"
+                color={colorPickerSelectedColor}
+                onColorChange={onHandlerColorChange}
+              />
+            }
           />
           <FormatControls value={format} onChange={handleUnitChange} />
           <CalculationSelector value={value.calculation} onChange={handleCalculationChange} />

--- a/statchart/src/StatChartPanel.tsx
+++ b/statchart/src/StatChartPanel.tsx
@@ -31,7 +31,7 @@ export type StatChartPanelProps = PanelProps<StatChartOptions, TimeSeriesData>;
 export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
   const { spec, contentDimensions, queryResults } = props;
 
-  const { format, sparkline, valueFontSize: valueFontSize } = spec;
+  const { format, sparkline, valueFontSize: valueFontSize, backgroundColor } = spec;
   const chartsTheme = useChartsTheme();
   const statChartData = useStatChartData(queryResults, spec, chartsTheme);
 
@@ -74,6 +74,7 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
               sparkline={sparklineConfig}
               showSeriesName={isMultiSeries}
               valueFontSize={valueFontSize}
+              backgroundColor={backgroundColor}
             />
           );
         })

--- a/statchart/src/stat-chart-model.ts
+++ b/statchart/src/stat-chart-model.ts
@@ -30,6 +30,7 @@ export interface StatChartOptions {
   sparkline?: StatChartSparklineOptions;
   valueFontSize?: FontSizeOption;
   mappings?: ValueMapping[];
+  backgroundColor?: string;
 }
 
 export interface StatChartSparklineOptions {


### PR DESCRIPTION
# IN PROGRESS ⛔ 

Closes https://github.com/perses/perses/issues/3446

# Description 🖊️ 

This change adds **Background Color Configuration** to the StatChart. 

# Test 🧪 

1. Add background color to your stat chart
2. check if the background color appears
3. check both with and without sparkline
4. If the color is not set, it should pick the theme default background color
5. Check both the dark and light modes

## With spark line

<img width="1711" height="776" alt="image" src="https://github.com/user-attachments/assets/c931fec1-e190-4d86-b174-f56abd978460" />

## Without spark line

<img width="1410" height="606" alt="image" src="https://github.com/user-attachments/assets/de1803a7-bc03-408c-8734-e3b7e6a9e19e" />

## With spark line - dark mode

<img width="1602" height="821" alt="image" src="https://github.com/user-attachments/assets/68377c70-a76e-4853-8e2d-48a0d13d6de1" />


## Dark without spark line

<img width="1447" height="788" alt="image" src="https://github.com/user-attachments/assets/1e2e1429-a29e-4ba5-a0eb-b00d3e6be036" />


## Not aggregated results

<img width="1349" height="579" alt="image" src="https://github.com/user-attachments/assets/1cd95b2c-6e4c-42b6-a07b-10a94ef6464f" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
