### PR TITLE
[FEATURE] Add Color Mode to the stat chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4857,6 +4857,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chroma-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-3.1.2.tgz",
+      "integrity": "sha512-YBTQqArPN8A0niHXCwrO1z5x++a+6l0mLBykncUpr23oIPW7L4h39s6gokdK/bDrPmSh8+TjMmrhBPnyiaWPmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/color-hash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/color-hash/-/color-hash-2.0.0.tgz",
@@ -6866,6 +6873,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chroma-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.1.2.tgz",
+      "integrity": "sha512-IJnETTalXbsLx1eKEgx19d5L6SRM7cH4vINw/99p/M11HCuXGRWL+6YmCm7FWFGIo6dtWuQoQi1dc5yQ7ESIHg==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
@@ -16159,7 +16172,7 @@
     },
     "piechart": {
       "name": "@perses-dev/pie-chart-plugin",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16269,6 +16282,12 @@
     "statchart": {
       "name": "@perses-dev/stat-chart-plugin",
       "version": "0.10.0",
+      "dependencies": {
+        "chroma-js": "^3.1.2"
+      },
+      "devDependencies": {
+        "@types/chroma-js": "^3.1.2"
+      },
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",

--- a/statchart/package.json
+++ b/statchart/package.json
@@ -33,11 +33,11 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "echarts": "5.5.0",
+    "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0",
-    "use-resize-observer": "^9.0.0",
-    "immer": "^10.1.1"
+    "use-resize-observer": "^9.0.0"
   },
   "files": [
     "lib/**/*",
@@ -57,5 +57,11 @@
         }
       }
     ]
+  },
+  "dependencies": {
+    "chroma-js": "^3.1.2"
+  },
+  "devDependencies": {
+    "@types/chroma-js": "^3.1.2"
   }
 }

--- a/statchart/schemas/stat.cue
+++ b/statchart/schemas/stat.cue
@@ -28,5 +28,6 @@ spec: close({
 		width?: number
 	})
 	valueFontSize?: number
+	colorMode?: *"value" | "background_solid" | "none"
 	mappings?: [...common.#mappings]
 })

--- a/statchart/src/StatChartOptionsEditorSettings.tsx
+++ b/statchart/src/StatChartOptionsEditorSettings.tsx
@@ -22,6 +22,7 @@ import {
   OptionsEditorControl,
   OptionsEditorGrid,
   OptionsEditorGroup,
+  SettingsAutocomplete,
   ThresholdsEditor,
   ThresholdsEditorProps,
 } from '@perses-dev/components';
@@ -34,8 +35,13 @@ import {
 } from '@perses-dev/plugin-system';
 import { produce } from 'immer';
 import merge from 'lodash/merge';
-import { ReactElement } from 'react';
-import { StatChartOptions, StatChartOptionsEditorProps } from './stat-chart-model';
+import { ReactElement, useCallback, useMemo } from 'react';
+import {
+  COLOR_MODE_LABELS,
+  ColorModeLabelItem,
+  StatChartOptions,
+  StatChartOptionsEditorProps,
+} from './stat-chart-model';
 
 const DEFAULT_FORMAT: FormatOptions = { unit: 'percent-decimal' };
 
@@ -96,6 +102,36 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
     );
   };
 
+  const handleColorModeChange = useCallback(
+    (_: unknown, newColorMode: ColorModeLabelItem): void => {
+      onChange(
+        produce(value, (draft: StatChartOptions) => {
+          draft.colorMode = newColorMode.id;
+        })
+      );
+    },
+    [onChange, value]
+  );
+
+  const selectColorMode = useMemo((): ReactElement => {
+    return (
+      <OptionsEditorControl
+        label="Color mode"
+        control={
+          <SettingsAutocomplete
+            onChange={handleColorModeChange}
+            options={COLOR_MODE_LABELS.map(({ id, label }) => ({ id, label }))}
+            disableClearable
+            value={
+              COLOR_MODE_LABELS.find((i) => i.id === value.colorMode) ??
+              COLOR_MODE_LABELS.find((i) => i.id === 'value')!
+            }
+          />
+        }
+      />
+    );
+  }, [value.colorMode, handleColorModeChange]);
+
   return (
     <OptionsEditorGrid>
       <OptionsEditorColumn>
@@ -108,6 +144,7 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
           <CalculationSelector value={value.calculation} onChange={handleCalculationChange} />
           <MetricLabelInput value={value.metricLabel} onChange={handleMetricLabelChange} />
           <FontSizeSelector value={value.valueFontSize} onChange={handleFontSizeChange} />
+          {selectColorMode}
         </OptionsEditorGroup>
       </OptionsEditorColumn>
       <OptionsEditorColumn>

--- a/statchart/src/StatChartPanel.tsx
+++ b/statchart/src/StatChartPanel.tsx
@@ -31,13 +31,13 @@ export type StatChartPanelProps = PanelProps<StatChartOptions, TimeSeriesData>;
 export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
   const { spec, contentDimensions, queryResults } = props;
 
-  const { format, sparkline, valueFontSize: valueFontSize } = spec;
+  const { format, sparkline, valueFontSize: valueFontSize, colorMode } = spec;
   const chartsTheme = useChartsTheme();
   const statChartData = useStatChartData(queryResults, spec, chartsTheme);
 
   const isMultiSeries = statChartData.length > 1;
 
-  if (contentDimensions === undefined) return null;
+  if (!contentDimensions) return null;
 
   // Calculates chart width
   const spacing = SPACING * (statChartData.length - 1);
@@ -74,6 +74,7 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
               sparkline={sparklineConfig}
               showSeriesName={isMultiSeries}
               valueFontSize={valueFontSize}
+              colorMode={colorMode}
             />
           );
         })

--- a/statchart/src/stat-chart-model.ts
+++ b/statchart/src/stat-chart-model.ts
@@ -22,6 +22,19 @@ export interface StatChartDefinition extends Definition<StatChartOptions> {
   kind: 'StatChart';
 }
 
+export type ColorMode = 'none' | 'value' | 'background_solid';
+
+export type ColorModeLabelItem = {
+  id: ColorMode;
+  label: string;
+};
+
+export const COLOR_MODE_LABELS: ColorModeLabelItem[] = [
+  { id: 'none', label: 'None' },
+  { id: 'value', label: 'Text' },
+  { id: 'background_solid', label: 'Background' },
+];
+
 export interface StatChartOptions {
   calculation: CalculationType;
   format: FormatOptions;
@@ -30,6 +43,7 @@ export interface StatChartOptions {
   sparkline?: StatChartSparklineOptions;
   valueFontSize?: FontSizeOption;
   mappings?: ValueMapping[];
+  colorMode?: ColorMode;
 }
 
 export interface StatChartSparklineOptions {


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3446

# Stat Chart Color Mode 🖌️ 

This new feature adds the Color Mode property into the Stat Chart Settings Editor. Color Mode could be set with 3 different values which are None, Text, and Background. Given value for the color mode change the chart style accordingly. The default value is Text. 

## Color Mode Text

For both dark and light theme the formatted value and the sparkline (if exists) will take the threshold color and the chart background will be transparent.

<img width="1267" height="627" alt="image" src="https://github.com/user-attachments/assets/dc767c35-fabd-424a-a443-4077770456cb" />

<img width="1265" height="580" alt="image" src="https://github.com/user-attachments/assets/03788553-4f81-4e1f-ae5d-216e566e4302" />

<img width="1266" height="581" alt="image" src="https://github.com/user-attachments/assets/e80e7959-7bce-431e-92ce-f0af46c6d34b" />

<img width="1296" height="587" alt="image" src="https://github.com/user-attachments/assets/ba42a7ab-2477-4ea8-8618-7784a96ff4bb" />

## Color Mode Background

The Background is covered by the threshold color and the formatted value will be either black or white based on the calculated luminance ratio. **Besides**, if sparkline is enabled, sparkline need to add some opacity to be visible.

<img width="1282" height="550" alt="image" src="https://github.com/user-attachments/assets/d393a8a2-c4cd-44e5-929c-75dc0a6574e5" />

<img width="1271" height="588" alt="image" src="https://github.com/user-attachments/assets/c22c464a-a619-4eb4-9c71-ede28e9cbe28" />

<img width="1297" height="576" alt="image" src="https://github.com/user-attachments/assets/2b5ac35e-eb6a-4206-908f-9bb1194ac5fe" />

<img width="1303" height="575" alt="image" src="https://github.com/user-attachments/assets/d1d94a0d-5818-4def-acc8-46684e4ec0b7" />

<img width="1288" height="542" alt="image" src="https://github.com/user-attachments/assets/62c9dcbd-c387-48ce-b33d-f2203f8febbd" />

## Color Mode None 

Only the Sparkline takes the threshold color. The background will be transparent and the text will be either black or white based on the dark/light theme.

<img width="1282" height="493" alt="image" src="https://github.com/user-attachments/assets/2e4741eb-4211-457a-996f-7c2a0f1059b9" />

<img width="1263" height="432" alt="image" src="https://github.com/user-attachments/assets/2a88d694-22d5-4c2d-8b69-91f4439511c1" />

<img width="1280" height="552" alt="image" src="https://github.com/user-attachments/assets/748a3fe4-ff82-489a-8283-11d996693e85" />



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
