### PR TITLE
Bump plugins version

### DIFF
--- a/clickhouse/package.json
+++ b/clickhouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/clickhouse-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",

--- a/gaugechart/package.json
+++ b/gaugechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/gauge-chart-plugin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/loki/package.json
+++ b/loki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/loki-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "npm run build-mf && concurrently \"npm:build:*\"",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
     },
     "clickhouse": {
       "name": "@perses-dev/clickhouse-plugin",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -166,7 +166,7 @@
     },
     "gaugechart": {
       "name": "@perses-dev/gauge-chart-plugin",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -234,7 +234,7 @@
     },
     "loki": {
       "name": "@perses-dev/loki-plugin",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@grafana/lezer-logql": "^0.2.8"
       },
@@ -16168,7 +16168,7 @@
     },
     "piechart": {
       "name": "@perses-dev/pie-chart-plugin",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16188,7 +16188,7 @@
     },
     "prometheus": {
       "name": "@perses-dev/prometheus-plugin",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
         "@prometheus-io/codemirror-promql": "^0.304.2",
@@ -16277,7 +16277,7 @@
     },
     "statchart": {
       "name": "@perses-dev/stat-chart-plugin",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "chroma-js": "^3.1.2"
       },
@@ -16303,7 +16303,7 @@
     },
     "staticlistvariable": {
       "name": "@perses-dev/static-list-variable-plugin",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "color-hash": "^2.0.2"
       },
@@ -16325,7 +16325,7 @@
     },
     "statushistorychart": {
       "name": "@perses-dev/status-history-chart-plugin",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16345,7 +16345,7 @@
     },
     "table": {
       "name": "@perses-dev/table-plugin",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -16365,7 +16365,7 @@
     },
     "tempo": {
       "name": "@perses-dev/tempo-plugin",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
         "@grafana/lezer-traceql": "^0.0.25",
@@ -16463,7 +16463,7 @@
     },
     "tracingganttchart": {
       "name": "@perses-dev/tracing-gantt-chart-plugin",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "color-hash": "^2.0.2"
       },

--- a/piechart/package.json
+++ b/piechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/pie-chart-plugin",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/prometheus-plugin",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/statchart/package.json
+++ b/statchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/stat-chart-plugin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/staticlistvariable/package.json
+++ b/staticlistvariable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/static-list-variable-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/statushistorychart/package.json
+++ b/statushistorychart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/status-history-chart-plugin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/table/package.json
+++ b/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/table-plugin",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/tempo/package.json
+++ b/tempo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tempo-plugin",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/tracingganttchart/package.json
+++ b/tracingganttchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tracing-gantt-chart-plugin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumping the version of the following plugin in order to release them: 

- clickhouse
- gaugechart
- loki
- pack
- piechart
- prometheus
- statchart
- staticlistvariable
- statushistorychart
- table
- tempo
- tracingganttchart
