### PR TITLE
[BUGFIX] use auto public path only for production builds

### DIFF
--- a/rsbuild.shared.ts
+++ b/rsbuild.shared.ts
@@ -128,7 +128,9 @@ function getRsbuildConfig(name: string): RsbuildConfig {
       htmlPlugin: false,
       rspack: (config) => {
         config.output = config.output || {};
-        config.output.publicPath = 'auto';
+        if (process.env.NODE_ENV !== 'development') {
+          config.output.publicPath = 'auto';
+        }
         return config;
       },
     },


### PR DESCRIPTION
# Description

The new setting to allow module federation behind proxies, should not apply during development as `percli` uses a predefined path to register the plugin and watch for changes.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
