### PR TITLE
[BUGFIX] StatusHistoryChart: Show no data when the result array is empty

### DIFF
--- a/statushistorychart/src/StatusHistoryChartBase.tsx
+++ b/statushistorychart/src/StatusHistoryChartBase.tsx
@@ -149,7 +149,15 @@ export const StatusHistoryChartBase: FC<StatusHistoryChartBaseProps> = (props) =
   };
 
   return (
-    <Box style={{ height: height }} sx={{ overflow: 'auto' }}>
+    <Box
+      style={{ height: height }}
+      sx={{
+        overflow: 'auto',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
       {data.length ? (
         <EChart
           style={{

--- a/statushistorychart/src/StatusHistoryPanel.tsx
+++ b/statushistorychart/src/StatusHistoryPanel.tsx
@@ -43,10 +43,6 @@ export function StatusHistoryPanel(props: StatusHistoryChartPanelProps): ReactEl
       }
     : undefined;
 
-  if (!statusHistoryData || statusHistoryData.length === 0) {
-    return null;
-  }
-
   return (
     <Box sx={{ padding: `${PADDING}px` }}>
       <ContentWithLegend
@@ -68,7 +64,7 @@ export function StatusHistoryPanel(props: StatusHistoryChartPanelProps): ReactEl
               <StatusHistoryChartBase
                 xAxisCategories={xAxisCategories}
                 yAxisCategories={yAxisCategories}
-                data={statusHistoryData}
+                data={statusHistoryData ?? []}
                 timeScale={timeScale}
                 height={height}
                 colors={colors}


### PR DESCRIPTION
# Description 🖊️ 

Closes https://github.com/perses/perses/issues/3563
When the Status history chart is empty replace it with `No data`

Hey @andreasgerstmayr , 
This part dropped from my fix yesterday. Sorry!
 
## No data

<img width="808" height="416" alt="image" src="https://github.com/user-attachments/assets/031bf9e2-793c-4bd9-a71c-ff13be82af6a" />

## With data

<img width="806" height="421" alt="image" src="https://github.com/user-attachments/assets/7a7aff57-1cfc-422e-aa5c-cde3d4ec35b5" />



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
