### PR TITLE
[BUGFIX]: Add showLegend option to StatChart with auto/on/off modes

### DIFF
--- a/statchart/schemas/stat.cue
+++ b/statchart/schemas/stat.cue
@@ -29,6 +29,6 @@ spec: close({
 	})
 	valueFontSize?: number
 	colorMode?: *"value" | "background_solid" | "none"
-	showLegendMode?: *"auto" | "on" | "off"
+	legendMode?: *"auto" | "on" | "off"
 	mappings?: [...common.#mappings]
 })

--- a/statchart/src/StatChartOptionsEditorSettings.tsx
+++ b/statchart/src/StatChartOptionsEditorSettings.tsx
@@ -73,7 +73,7 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
     (_: unknown, newShowLegend: ShowLegendLabelItem): void => {
       onChange(
         produce(value, (draft: StatChartOptions) => {
-          draft.showLegendMode = newShowLegend.id;
+          draft.legendMode = newShowLegend.id;
         })
       );
     },
@@ -136,14 +136,14 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
             options={SHOW_LEGEND_LABELS}
             disableClearable
             value={
-              SHOW_LEGEND_LABELS.find((i) => i.id === value.showLegendMode) ??
+              SHOW_LEGEND_LABELS.find((i) => i.id === value.legendMode) ??
               SHOW_LEGEND_LABELS.find((i) => i.id === 'auto')!
             }
           />
         }
       />
     );
-  }, [value.showLegendMode, handleShowLegendChange]);
+  }, [value.legendMode, handleShowLegendChange]);
 
   const selectColorMode = useMemo((): ReactElement => {
     return (

--- a/statchart/src/StatChartPanel.tsx
+++ b/statchart/src/StatChartPanel.tsx
@@ -38,7 +38,7 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
   const isMultiSeries = statChartData.length > 1;
 
   // Handle three-state showLegend: 'on' | 'off' | 'auto' (or undefined for backward compatibility)
-  const shouldShowLegend = spec.showLegendMode === 'on' ? true : spec.showLegendMode === 'off' ? false : isMultiSeries;
+  const shouldShowLegend = spec.legendMode === 'on' ? true : spec.legendMode === 'off' ? false : isMultiSeries;
 
   if (!contentDimensions) return null;
 

--- a/statchart/src/stat-chart-model.ts
+++ b/statchart/src/stat-chart-model.ts
@@ -35,10 +35,10 @@ export const COLOR_MODE_LABELS: ColorModeLabelItem[] = [
   { id: 'background_solid', label: 'Background' },
 ];
 
-export type ShowLegendMode = 'auto' | 'on' | 'off';
+export type legendMode = 'auto' | 'on' | 'off';
 
 export type ShowLegendLabelItem = {
-  id: ShowLegendMode;
+  id: legendMode;
   label: string;
   description?: string;
 };
@@ -58,7 +58,7 @@ export interface StatChartOptions {
   valueFontSize?: FontSizeOption;
   mappings?: ValueMapping[];
   colorMode?: ColorMode;
-  showLegendMode?: ShowLegendMode;
+  legendMode?: legendMode;
 }
 
 export interface StatChartSparklineOptions {
@@ -75,6 +75,6 @@ export function createInitialStatChartOptions(): StatChartOptions {
       unit: 'decimal',
     },
     sparkline: {},
-    showLegendMode: 'auto',
+    legendMode: 'auto',
   };
 }


### PR DESCRIPTION
This Pull Request closes https://github.com/perses/perses/issues/3516

# Description

Adds a new `showLegend` option to the StatChart plugin, allowing users to control whether the series name (legend) is displayed on stat charts.

## Implementation
Implemented as a three-state dropdown selector:
- **Auto** (default) - Show for multi-series data, hide for single series
- **On** - Always show legend
- **Off** - Always hide legend

It will be confusing for the users without the `Auto` state. Grafana also does the same. 


# Screen Recording
https://github.com/user-attachments/assets/278a9581-9d04-4096-8617-dff2b22308b4


# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
