### PR TITLE
[BUGFIX] Prometheus calculate interval and minstep for query replacement

### DIFF
--- a/prometheus/src/components/PromQLEditor.tsx
+++ b/prometheus/src/components/PromQLEditor.tsx
@@ -33,10 +33,21 @@ export type PromQLEditorProps = {
   completeConfig: CompleteConfiguration;
   datasource: PrometheusDatasourceSelector;
   isReadOnly?: boolean;
+  treeViewMetadata?: {
+    minStepMs: number;
+    intervalMs: number;
+  };
 } & Omit<ReactCodeMirrorProps, 'theme' | 'extensions'>;
 
-export function PromQLEditor({ completeConfig, datasource, isReadOnly, ...rest }: PromQLEditorProps): ReactElement {
+export function PromQLEditor({
+  completeConfig,
+  datasource,
+  isReadOnly,
+  treeViewMetadata,
+  ...rest
+}: PromQLEditorProps): ReactElement {
   const theme = useTheme();
+
   const isDarkMode = theme.palette.mode === 'dark';
   const [isTreeViewVisible, setTreeViewVisible] = useState(false);
   const readOnly = isReadOnly ?? false;
@@ -46,12 +57,9 @@ export function PromQLEditor({ completeConfig, datasource, isReadOnly, ...rest }
   }, [completeConfig]);
 
   let queryExpr = useReplaceVariablesInString(rest.value);
-  if (queryExpr) {
-    // TODO placeholder values for steps to be replaced with actual values
-    // Looks like providing proper values involves some refactoring: currently we'd need to rely on the timeseries query context,
-    // but these step values are actually computed independently / before the queries are getting fired, so it's useless to fire
-    // queries here, so maybe we should extract this part to independant hook(s), to be reused here?
-    queryExpr = replacePromBuiltinVariables(queryExpr, 12345, 12345);
+  if (queryExpr && treeViewMetadata) {
+    const { minStepMs, intervalMs } = treeViewMetadata;
+    queryExpr = replacePromBuiltinVariables(queryExpr, minStepMs, intervalMs);
   }
 
   const { data: parseQueryResponse, isLoading, error } = useParseQuery(queryExpr ?? '', datasource, isTreeViewVisible);

--- a/prometheus/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/prometheus/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -73,6 +73,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
       // TODO add a validation check to make sure the variable is a DurationString, to avoid the back & forth cast here
       replaceVariables(spec.minStep as string, context.variableState) as DurationString
     ) ?? datasourceScrapeInterval;
+
   const timeRange = getPrometheusTimeRange(context.timeRange);
   const step = getRangeStep(timeRange, minStep, undefined, context.suggestedStepMs); // TODO: resolution
 
@@ -99,6 +100,7 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   // Replace variable placeholders in PromQL query
   const intervalMs = step * 1000;
   const minStepMs = minStep * 1000;
+
   let query = replacePromBuiltinVariables(spec.query, minStepMs, intervalMs);
   query = replaceVariables(query, context.variableState);
 


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3209
# Description 🖊️ 

This PR fixes the  Prometheus built-in interval variables issue. So far, the **minStepMs** and **intervalMs** were simply **placeholders** (equal to 12345 = 12s45ms) For more technical details please check the issue. 

## Solution

As the issue suggests these values are calculated before the query is executed. 
> prometheus\src\plugins\prometheus-time-series-query\get-time-series-data.ts

This means using the same code the values could be reproduced and passed down to the tree_view. 

## Test 🧪 

1. Attach to the Prometheus plugin 
2. Use the following query 

> sum by (method) (rate(promhttp_metric_handler_requests_total[$__interval]))

3. You should not see the place holder. 
4. And changing the minStep should update the tree view according
5. You should also be able to use a variable for the minStep
6. Your actual query and the tree view replaced value should be identical

## minSTep direct value manipulation 

<img width="1830" height="1081" alt="image" src="https://github.com/user-attachments/assets/19623ca3-72ad-4b8a-9903-bfac9838bba8" />

## minStep by a variable 
<img width="1711" height="1102" alt="image" src="https://github.com/user-attachments/assets/fbdb02b6-d95f-4ba2-808f-4d9492291644" />



## ⚠️ Don't forget the duration unit please!

Please take into account that duration unit is mandatory!

<img width="1649" height="979" alt="image" src="https://github.com/user-attachments/assets/07df2411-d642-499c-921a-914976926153" />





# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
