### PR TITLE
[ENHANCEMENT] ScatterChart: remove time label, reduce chart padding, reduce amount of y axis labels

### DIFF
--- a/scatterchart/src/Scatterplot.tsx
+++ b/scatterchart/src/Scatterplot.tsx
@@ -64,19 +64,19 @@ export function Scatterplot(props: ScatterplotProps): ReactElement {
     series: options.series,
     dataZoom: options.dataZoom,
     grid: {
-      bottom: 40,
-      top: 50,
-      left: 50,
-      right: 100,
+      top: 45,
+      bottom: 20,
+      left: 30,
+      right: 20,
     },
     xAxis: {
       type: 'time',
-      name: 'Local Time',
     },
     yAxis: {
       scale: true,
       type: 'value',
       name: 'Duration',
+      splitNumber: 4,
       axisLabel: {
         formatter: (durationMs: number) => formatValue(durationMs, { unit: 'milliseconds' }),
       },


### PR DESCRIPTION
# Description

* remove time label on x axis, as it takes a lot of space and the time on the x axis is default for almost all charts in Perses
* reduce chart padding to increase the size of the chart itself
* reduce amount of labels on the y axis to increase the padding between them

# Screenshots

Before:
<img width="1894" height="486" alt="Bildschirmfoto vom 2025-11-18 17-14-20" src="https://github.com/user-attachments/assets/0226cd55-4d68-44d6-ad93-39b8d2f76932" />
After:
<img width="1894" height="486" alt="Bildschirmfoto vom 2025-11-18 17-14-31" src="https://github.com/user-attachments/assets/df249517-992f-4223-b332-278a6c52d23f" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
