### PR TITLE
[ENHANCEMENT] TimeSeriesChart: migration: support byFrameRefID-based overrides

### DIFF
--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -176,9 +176,10 @@ spec: {
 		for i, target in (*#panel.targets | []) {
 			queryIndex: i
 			for override in (*#panel.fieldConfig.overrides | [])
-			if (override.matcher.id == "byName" || override.matcher.id == "byRegexp") && override.matcher.options != _|_
+			if (override.matcher.id == "byName" || override.matcher.id == "byRegexp" || override.matcher.id == "byFrameRefID") && override.matcher.options != _|_
 			for property in override.properties
-			if target.legendFormat == override.matcher.options || target.legendFormat =~ strings.Trim(override.matcher.options, "/") {
+			if (override.matcher.id == "byName" || override.matcher.id == "byRegexp") && (target.legendFormat == override.matcher.options || target.legendFormat =~ strings.Trim(override.matcher.options, "/")) ||
+			   (override.matcher.id == "byFrameRefID" && target.refId == override.matcher.options) {
 				if property.id == "color" if (*property.value.fixedColor | null) != null {
 					colorMode: "fixed"
 					colorValue: property.value.fixedColor

--- a/timeserieschart/schemas/migrate/tests/multiple-overrides/expected.json
+++ b/timeserieschart/schemas/migrate/tests/multiple-overrides/expected.json
@@ -36,6 +36,17 @@
         "colorMode": "fixed",
         "colorValue": "#F2495C",
         "areaOpacity": 0
+      },
+      {
+        "queryIndex": 3,
+        "colorMode": "fixed",
+        "colorValue": "#3274D9"
+      },
+      {
+        "queryIndex": 4,
+        "colorMode": "fixed",
+        "colorValue": "yellow",
+        "lineStyle": "dashed"
       }
     ]
   }

--- a/timeserieschart/schemas/migrate/tests/multiple-overrides/input.json
+++ b/timeserieschart/schemas/migrate/tests/multiple-overrides/input.json
@@ -112,6 +112,54 @@
             }
           }
         ]
+      },
+      {
+        "matcher": {
+          "id": "byFrameRefID",
+          "options": "forecast"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "yellow",
+              "mode": "fixed"
+            }
+          },
+          {
+            "id": "unit",
+            "value": "tps"
+          },
+          {
+            "id": "custom.lineStyle",
+            "value": {
+              "dash": [
+                10,
+                10
+              ],
+              "fill": "dash"
+            }
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byFrameRefID",
+          "options": "throughput"
+        },
+        "properties": [
+          {
+            "id": "color",
+            "value": {
+              "fixedColor": "#3274D9",
+              "mode": "fixed"
+            }
+          },
+          {
+            "id": "unit",
+            "value": "tps"
+          }
+        ]
       }
     ]
   },
@@ -155,6 +203,34 @@
       "intervalFactor": 1,
       "legendFormat": "Lt: {{container}} - {{pod}} - {{cluster}}",
       "refId": "memory_d",
+      "datasource": {
+        "uid": "$datasource"
+      }
+    },
+    {
+      "exemplar": false,
+      "expr": "max by (cluster,pod,container) (my_throughput_metric{cluster=~\"$cluster\",pod=~\"$pod\",container=~\"$container\"})",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "interval": "$sampling",
+      "intervalFactor": 1,
+      "legendFormat": "tps",
+      "refId": "throughput",
+      "datasource": {
+        "uid": "$datasource"
+      }
+    },
+    {
+      "exemplar": false,
+      "expr": "max by (cluster,pod,container) (my_throughput_metric:forecast{cluster=~\"$cluster\",pod=~\"$pod\",container=~\"$container\"})",
+      "format": "time_series",
+      "hide": false,
+      "instant": false,
+      "interval": "$sampling",
+      "intervalFactor": 1,
+      "legendFormat": "tps (forecast)",
+      "refId": "forecast",
       "datasource": {
         "uid": "$datasource"
       }


### PR DESCRIPTION
# Description

Closes https://github.com/perses/perses/issues/3634.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
