### PR TITLE
[BUGFIX] Table render no data if no record exists

### DIFF
--- a/table/src/components/TablePanel.tsx
+++ b/table/src/components/TablePanel.tsx
@@ -16,7 +16,7 @@ import { Table, TableCellConfigs, TableColumnConfig } from '@perses-dev/componen
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { formatValue, Labels, QueryDataType, TimeSeries, TimeSeriesData, transformData } from '@perses-dev/core';
 import { PaginationState, SortingState, ColumnFiltersState } from '@tanstack/react-table';
-import { useTheme, Theme } from '@mui/material';
+import { useTheme, Theme, Typography, Box } from '@mui/material';
 import { ColumnSettings, TableOptions, evaluateConditionalFormatting } from '../models';
 import { EmbeddedPanel } from './EmbeddedPanel';
 
@@ -447,8 +447,23 @@ export function TablePanel({ contentDimensions, spec, queryResults }: TableProps
     return null;
   }
 
+  if (!data?.length) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
+        }}
+      >
+        <Typography>No data</Typography>
+      </Box>
+    );
+  }
+
   return (
-    <div>
+    <>
       {spec.enableFiltering && (
         <div
           style={{
@@ -542,7 +557,6 @@ export function TablePanel({ contentDimensions, spec, queryResults }: TableProps
           })}
         </div>
       )}
-
       <Table
         data={filteredData}
         columns={columns}
@@ -557,6 +571,6 @@ export function TablePanel({ contentDimensions, spec, queryResults }: TableProps
         pagination={pagination}
         onPaginationChange={setPagination}
       />
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3564

# Description 🖊️ 
If no data exists, the table contains a `No data` message. 

🧪 To test this you can use a query which returns no results. 

<img width="1941" height="896" alt="image" src="https://github.com/user-attachments/assets/d4ca444f-5741-4f58-a27b-fc1a2ebb7482" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
