### PR TITLE
[BUGFIX] - Table remove duplication of columnSetting

### DIFF
--- a/table/src/components/TablePanel.tsx
+++ b/table/src/components/TablePanel.tsx
@@ -269,7 +269,6 @@ export function TablePanel({ contentDimensions, spec, queryResults }: TableProps
 
     // Process columnSettings if they exist
     for (const columnSetting of spec.columnSettings ?? []) {
-      if (!columnSetting || !keys.includes(columnSetting.name)) continue;
       if (customizedColumns.has(columnSetting.name)) continue; // Skip duplicates
 
       const columnConfig = generateColumnConfig(columnSetting.name, spec.columnSettings ?? []);


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This PR resolves [PR-3639](https://github.com/perses/perses/issues/3639)
ColumnSettings on tables looked like this before:

<img width="900" height="1042" alt="image" src="https://github.com/user-attachments/assets/dc2b607f-1134-428e-a919-39fc7726f2a3" />

with the changes the second column settings applied to column is ignored.


# Screenshots

<img width="1059" height="499" alt="image" src="https://github.com/user-attachments/assets/25ce36f4-d687-4387-84e5-5404901b6bbc" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
