### PR TITLE
[BUGFIX] Tempo: encode trace and span IDs in lowercase hex format

### DIFF
--- a/tempo/src/plugins/plugin.test.ts
+++ b/tempo/src/plugins/plugin.test.ts
@@ -72,11 +72,11 @@ describe('TempoTraceQuery', () => {
   });
 
   it('should convert base64-encoded trace IDs and span IDs in the response to hex format', async () => {
-    const results = await TempoTraceQuery.getTraceData({ query: 'FBD37845209D43CDCCD418DC5F9FF021' }, stubTempoContext);
+    const results = await TempoTraceQuery.getTraceData({ query: 'fbd37845209d43cdccd418dc5f9ff021' }, stubTempoContext);
     expect(results.trace?.resourceSpans[0]?.scopeSpans[0]?.spans[1]?.traceId).toEqual(
-      'FBD37845209D43CDCCD418DC5F9FF021'
+      'fbd37845209d43cdccd418dc5f9ff021'
     );
-    expect(results.trace?.resourceSpans[0]?.scopeSpans[0]?.spans[1]?.spanId).toEqual('8467BCA11377C166');
-    expect(results.trace?.resourceSpans[0]?.scopeSpans[0]?.spans[1]?.parentSpanId).toEqual('9C22EB77CB5C14C7');
+    expect(results.trace?.resourceSpans[0]?.scopeSpans[0]?.spans[1]?.spanId).toEqual('8467bca11377c166');
+    expect(results.trace?.resourceSpans[0]?.scopeSpans[0]?.spans[1]?.parentSpanId).toEqual('9c22eb77cb5c14c7');
   });
 });

--- a/tempo/src/plugins/tempo-trace-query/get-trace-data.ts
+++ b/tempo/src/plugins/tempo-trace-query/get-trace-data.ts
@@ -94,8 +94,7 @@ function parseTraceResponse(response: QueryResponse): otlptracev1.TracesData {
 
   // Tempo returns Trace ID and Span ID base64-encoded.
   // The OTLP spec defines the encoding in the hex format:
-  // Spec: https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
-  // Example: https://github.com/open-telemetry/opentelemetry-proto/blob/v1.7.0/examples/trace.json
+  // Spec: https://opentelemetry.io/docs/specs/otel/trace/api/#retrieving-the-traceid-and-spanid
   // Therefore, let's convert it to hex encoding.
   for (const resourceSpan of trace.resourceSpans) {
     for (const scopeSpan of resourceSpan.scopeSpans) {
@@ -129,7 +128,7 @@ function base64ToHex(str: string) {
   try {
     return atob(str)
       .split('')
-      .map((char) => char.charCodeAt(0).toString(16).padStart(2, '0').toUpperCase())
+      .map((char) => char.charCodeAt(0).toString(16).padStart(2, '0'))
       .join('');
   } catch {
     return str;


### PR DESCRIPTION
# Description

According to the OTEL spec at https://opentelemetry.io/docs/specs/otel/trace/api/#retrieving-the-traceid-and-spanid the Trace ID and Span ID must be encoded in lowercase hex format.

# Screenshots

<img width="3394" height="744" alt="image" src="https://github.com/user-attachments/assets/b0be3f13-9d11-4851-b266-7227087e4e02" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
