### PR TITLE
[BREAKINGCHANGE] Markdown panel: fix CUE module name

### DIFF
--- a/markdown/cue.mod/module.cue
+++ b/markdown/cue.mod/module.cue
@@ -1,4 +1,4 @@
-module: "github.com/perses/plugins/markdownchart@v0"
+module: "github.com/perses/plugins/markdown@v0"
 language: {
 	version: "v0.14.0"
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This is a leftover from https://github.com/perses/plugins/pull/50. People relying on the CUE SDK to code dashboards will thus have to change from 
```cue
import "github.com/perses/plugins/markdownchart"
```
to
```cue
import "github.com/perses/plugins/markdown"
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
