### PR TITLE
[ignore] add codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# General codeowners for the entire repository
+/* @perses/frontend-maintainers-with-random
+
+# Dedicated codeowners for a specific file type
+*.cue @AntoineThebaud
+*.go @Nexucis
+
+# Dedicated codeowners for a plugin
+/tempo @andreasgerstmayr
+
+# Dedicated codeowners for a specific directory
+
+/docs @AntoineThebaud
+/scripts @Nexucis


### PR DESCRIPTION
I will try to find a way to assign PR using org team for victorialogs and clickhouse plugin since they are coming from the community and we don't maintain them.