### PR TITLE
[ignore] add codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# General codeowners for the entire repository
+/* @perses/frontend-maintainers-with-random
+
+# Dedicated codeowners for a specific file type
+*.cue @AntoineThebaud
+*.go @Nexucis
+
+# Dedicated codeowners for a plugin
+/tempo @andreasgerstmayr
+
+# Dedicated codeowners for a specific directory
+
+/docs @AntoineThebaud
+/scripts @Nexucis


### PR DESCRIPTION
I am updating the codeowner file with more rules because the generic rule `/* @perses/frontend-maintainers-with-random` is not applied if there is one more specific.

For example in #506, since the PR modified a cuelang file, then it assigns the PR to Antoine and it didn't add reviewer from the frontend team.