### PR TITLE
[ignore] update codeowners with specific owner for ts and tsx files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,8 @@
 /* @perses/frontend-maintainers-with-random
 
 # Dedicated codeowners for a specific file type
+*.ts @perses/frontend-maintainers-with-random
+*.tsx @perses/frontend-maintainers-with-random
 *.cue @AntoineThebaud
 *.go @Nexucis
 


### PR DESCRIPTION
I am updating the codeowner file with more rules because the generic rule `/* @perses/frontend-maintainers-with-random` is not applied if there is one more specific.

For example in https://github.com/perses/plugins/pull/506, since the PR modified a cuelang file, then it assigns the PR to Antoine and it didn't add reviewer from the frontend team.