### PR TITLE
[ENHANCEMENT] Table: improve migration of column settings

### DIFF
--- a/table/schemas/migrate/tests/legacy-panel/expected.json
+++ b/table/schemas/migrate/tests/legacy-panel/expected.json
@@ -5,7 +5,7 @@
       {
         "header": "Time",
         "hide": true,
-        "name": "Time"
+        "name": "timestamp"
       },
       {
         "align": "right",

--- a/table/schemas/migrate/tests/rename-same-using-both/expected.json
+++ b/table/schemas/migrate/tests/rename-same-using-both/expected.json
@@ -3,20 +3,12 @@
   "spec": {
     "columnSettings": [
       {
-        "header": "bonjour",
-        "name": "value"
-      },
-      {
-        "header": "family",
+        "header": "group",
         "name": "job"
       },
       {
-        "header": "group",
-        "name": "family"
-      },
-      {
         "header": "hello",
-        "name": "bonjour"
+        "name": "value"
       }
     ],
     "density": "compact"

--- a/table/schemas/migrate/tests/rename-twice-using-overrides/expected.json
+++ b/table/schemas/migrate/tests/rename-twice-using-overrides/expected.json
@@ -3,10 +3,6 @@
   "spec": {
     "columnSettings": [
       {
-        "header": "bonjour",
-        "name": "value"
-      },
-      {
         "header": "hello",
         "name": "value"
       }

--- a/table/schemas/migrate/tests/several-settings-using-both-2/expected.json
+++ b/table/schemas/migrate/tests/several-settings-using-both-2/expected.json
@@ -3,6 +3,11 @@
   "spec": {
     "columnSettings": [
       {
+        "name": "family",
+        "header": "group",
+        "width": 150
+      },
+      {
         "header": "bonjour",
         "name": "value"
       },
@@ -13,14 +18,6 @@
       {
         "header": "Timestamp",
         "name": "timestamp"
-      },
-      {
-        "header": "group",
-        "name": "family"
-      },
-      {
-        "name": "group",
-        "width": 150
       }
     ],
     "density": "compact"

--- a/table/schemas/migrate/tests/several-settings-using-both-3/expected.json
+++ b/table/schemas/migrate/tests/several-settings-using-both-3/expected.json
@@ -13,15 +13,12 @@
       },
       {
         "header": "API server",
-        "name": "apiserver"
+        "name": "apiserver",
+        "width": 300
       },
       {
         "header": "ValueCustomHeader",
         "name": "value"
-      },
-      {
-        "name": "API server",
-        "width": 300
       },
       {
         "name": "endpoint",

--- a/table/schemas/migrate/tests/several-settings-using-both/expected.json
+++ b/table/schemas/migrate/tests/several-settings-using-both/expected.json
@@ -4,19 +4,13 @@
     "columnSettings": [
       {
         "header": "hello",
-        "name": "value"
+        "hide": false,
+        "name": "value",
+        "width": 100
       },
       {
         "hide": true,
         "name": "timestamp"
-      },
-      {
-        "hide": false,
-        "name": "value"
-      },
-      {
-        "name": "hello",
-        "width": 100
       }
     ],
     "density": "compact"

--- a/table/schemas/migrate/tests/width-twice-using-overrides/expected.json
+++ b/table/schemas/migrate/tests/width-twice-using-overrides/expected.json
@@ -4,10 +4,6 @@
     "columnSettings": [
       {
         "name": "value",
-        "width": 150
-      },
-      {
-        "name": "value",
         "width": 200
       }
     ],


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

- Improve the logic of the Table migration schema to merge settings related to the same column in a single object (not 100% perfect but still better than before, see test data modifications). _As a reminder, at render time the Table panel only considers the first columnSetting it finds corresponding to a given column, thus further settings aplying to the same column are simply ignored, even if they tune different attributes._
- small improvement in the migration of legacy table panel

As a good side effect it solves https://github.com/perses/perses/issues/3701.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).