### PR TITLE
[FEATURE] Table: Add data link column setting to generate column config

### DIFF
--- a/table/src/components/TablePanel.tsx
+++ b/table/src/components/TablePanel.tsx
@@ -164,13 +164,15 @@ function generateColumnConfig(name: string, columnSettings: ColumnSettings[]): T
         return undefined;
       }
 
+      const { name, header, headerDescription, enableSorting, width, align, dataLink } = column;
       return {
         accessorKey: name,
-        header: column.header ?? name,
-        headerDescription: column.headerDescription,
-        enableSorting: column.enableSorting,
-        width: column.width,
-        align: column.align,
+        header: header ?? name,
+        headerDescription,
+        enableSorting,
+        width,
+        align,
+        dataLink,
         ...generateCellContentConfig(column),
       };
     }


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3483

# Description 🖊️ 

This small PR adds `dataLink` setting to the Column Config Generator. 
The following mentioned components located in the Shared repo will use the provided information to render the link columns accordingly. You can take a look at the following hierarchy of components which lead to the actual cells.

- components\src\Table\Table.tsx
- components\src\Table\VirtualizedTable.tsx
- components\src\Table\TableCell.tsx

<img width="1987" height="1078" alt="image" src="https://github.com/user-attachments/assets/f3d518bb-81f3-4f39-8b38-16f0ab60061e" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
