### PR TITLE
[FEATURE] Table: embed variables into datalink

### DIFF
--- a/table/src/components/TablePanel.test.tsx
+++ b/table/src/components/TablePanel.test.tsx
@@ -20,6 +20,7 @@ import {
   PluginLoader,
   PluginModuleResource,
   PluginRegistry,
+  VariableStateMap,
 } from '@perses-dev/plugin-system';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as packagejson from '../../package.json';
@@ -30,6 +31,15 @@ import {
   MOCK_TIME_SERIES_QUERY_DEFINITION,
 } from '../test/mock-query-results';
 import { TablePanel } from './TablePanel';
+
+/* mock all variables */
+jest.mock('@perses-dev/plugin-system', () => ({
+  ...jest.requireActual('@perses-dev/plugin-system'),
+  useAllVariableValues: (): VariableStateMap => ({
+    myproject: { loading: false, value: 'my_project' },
+    __range: { loading: false, value: '1h' },
+  }),
+}));
 
 const TEST_TIMEOUT = 15000; // Github Actions is slow
 const TEST_TIME_SERIES_TABLE_PROPS: Omit<TimeSeriesTableProps, 'queryResults'> = {
@@ -81,7 +91,16 @@ describe('TablePanel', () => {
     async () => {
       renderPanel(MOCK_TIME_SERIES_DATA_SINGLEVALUE, {
         columnSettings: [
-          { name: 'value', header: 'Value', headerDescription: 'Timeseries Value' },
+          {
+            name: 'value',
+            header: 'Value',
+            headerDescription: 'Timeseries Value',
+            dataLink: {
+              url: 'https://fakeurl.com/$myproject/$__range',
+              title: 'data link',
+              openNewTab: true,
+            },
+          },
           { name: 'device', width: 200 },
           { name: 'env', hide: true },
           { name: 'fstype', enableSorting: true },
@@ -95,6 +114,8 @@ describe('TablePanel', () => {
       expect(valueHeaderCell).toBeInTheDocument();
       expect(await within(valueHeaderCell).findByLabelText('Timeseries Value')).toBeInTheDocument();
       expect(await screen.findByRole('columnheader', { name: /Value/i })).toBeInTheDocument();
+      // TODO: Add this line of test after the @perses-dev\components is updated
+      // expect(await screen.getByRole('link', { name: /https:\/\/fakeurl\.com\/\$myproject\/\$__range/ }));
 
       const fstypeHeaderCell = await screen.findByRole('columnheader', { name: 'fstype' });
       expect(fstypeHeaderCell).toBeInTheDocument();


### PR DESCRIPTION
Relates to: https://github.com/perses/perses/issues/3483

# Description 🖊️ 
This feature replaces a variable notion in dataLink by its relative value. Using this feature users can set up dynamic links. 
**_All internal and custom variables are included._**

## EXAMPLE INPUT 
> http://localhost:3000/projects/$__project/dashboards/$__dashboard?var-job=avalanche&start=$__range&refresh=0s

## THE OUTPUT
> http://localhost:3000/projects/mahmoud_project/dashboards/dashboard_1?var-job=avalanche&start=1h&refresh=0s


<img width="2516" height="1130" alt="image" src="https://github.com/user-attachments/assets/ecfce028-3e2e-4b89-b113-d9f8c65f0faf" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
