### PR TITLE
[BUGFIX] Logstable: consistent No Data style for plugins

### DIFF
--- a/logstable/src/LogsTableComponent.tsx
+++ b/logstable/src/LogsTableComponent.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { ReactElement } from 'react';
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { LogsTableProps } from './model';
 import { LogsList } from './components/LogsList';
 
@@ -21,15 +21,16 @@ export function LogsTableComponent(props: LogsTableProps): ReactElement | null {
 
   if (queryResults[0]?.data.logs === undefined) {
     return (
-      <Typography
-        variant="h3"
+      <Box
         sx={{
-          textAlign: 'center',
-          marginTop: 4,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
         }}
       >
-        No logs to display
-      </Typography>
+        <Typography>No logs to display</Typography>
+      </Box>
     );
   }
   const logs = queryResults[0]?.data.logs.entries;


### PR DESCRIPTION
# Description 🖊️ 

When no data is available Logs Table style should be similar to the other components. 

> No logs to display

## Fixed version

<img width="644" height="173" alt="image" src="https://github.com/user-attachments/assets/cfec0a7a-9aa8-4964-90da-3df023dfe542" />

I think at some points `No data` should be wrapped in a separate component and be reused in other plugins

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
