### PR TITLE
[IGNORE] make export csv tooltip consistent with others

### DIFF
--- a/timeserieschart/src/TimeSeriesExportAction.tsx
+++ b/timeserieschart/src/TimeSeriesExportAction.tsx
@@ -11,11 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useCallback, useMemo } from 'react';
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton } from '@mui/material';
+import { InfoTooltip } from '@perses-dev/components';
 import DownloadIcon from 'mdi-material-ui/Download';
+import React, { useCallback, useMemo } from 'react';
+import { exportDataAsCSV, extractExportableData, isExportableData, sanitizeFilename } from './CSVExportUtils';
 import { TimeSeriesChartProps } from './TimeSeriesChartPanel';
-import { extractExportableData, isExportableData, sanitizeFilename, exportDataAsCSV } from './CSVExportUtils';
 
 export const TimeSeriesExportAction: React.FC<TimeSeriesChartProps> = ({ queryResults, definition }) => {
   const exportableData = useMemo(() => {
@@ -56,10 +57,10 @@ export const TimeSeriesExportAction: React.FC<TimeSeriesChartProps> = ({ queryRe
   }
 
   return (
-    <Tooltip title="Export as CSV">
+    <InfoTooltip description="Export as CSV">
       <IconButton size="small" onClick={handleExport} aria-label="Export time series data as CSV">
         <DownloadIcon fontSize="inherit" />
       </IconButton>
-    </Tooltip>
+    </InfoTooltip>
   );
 };


### PR DESCRIPTION
# Description

Make CSV export tooltop consistent with others:

# Screenshots

Before:
<img width="700" height="313" alt="Screenshot 2026-01-21 at 20 58 03" src="https://github.com/user-attachments/assets/ad6dbd37-236d-4590-811f-934492db9eb7" />

After:
<img width="614" height="296" alt="Screenshot 2026-01-21 at 20 57 27" src="https://github.com/user-attachments/assets/d57f3f35-3f7f-4877-8d0f-c9e54b914852" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).