### PR TITLE
[ENHANCEMENT] TracingGanttChart: show error message if panel query is a search query

### DIFF
--- a/tracingganttchart/src/TracingGanttChartPanel.tsx
+++ b/tracingganttchart/src/TracingGanttChartPanel.tsx
@@ -30,6 +30,12 @@ export function TracingGanttChartPanel(props: TracingGanttChartPanelProps): Reac
     return <TextOverlay message="This panel does not support more than one query." />;
   }
 
+  if (queryResults[0]?.data.searchResult) {
+    return (
+      <TextOverlay message="This panel does not support displaying trace search results. Please enter a trace id in the query field instead." />
+    );
+  }
+
   const trace = queryResults[0]?.data.trace;
   if (!trace) {
     return <NoDataOverlay resource="trace" />;


### PR DESCRIPTION
# Description

Show a helpful error message if panel query is a trace search query instead of a single trace.

# Screenshots

<img width="2102" height="1352" alt="image" src="https://github.com/user-attachments/assets/e08b40ba-4cc3-48ec-ba14-cf52aec9164d" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
