### PR TITLE
[ENHANCEMENT] Tempo: update more-traces-available alert styling

### DIFF
--- a/tempo/src/components/ClosableAlert.tsx
+++ b/tempo/src/components/ClosableAlert.tsx
@@ -1,0 +1,29 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback, useState } from 'react';
+import { Alert, AlertProps } from '@mui/material';
+
+export function ClosableAlert(props: AlertProps) {
+  const [isVisible, setVisible] = useState(true);
+
+  const handleClose = useCallback(() => {
+    setVisible(false);
+  }, [setVisible]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return <Alert {...props} onClose={handleClose} />;
+}

--- a/tempo/src/explore/TempoExplorer.tsx
+++ b/tempo/src/explore/TempoExplorer.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Alert, Box, Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { ErrorAlert, ErrorBoundary, LoadingOverlay, NoDataOverlay } from '@perses-dev/components';
 import { QueryDefinition, isValidTraceId } from '@perses-dev/core';
 import { Panel } from '@perses-dev/dashboards';
@@ -19,6 +19,7 @@ import { useExplorerManagerContext } from '@perses-dev/explore';
 import { DataQueriesProvider, MultiQueryEditor, useDataQueries } from '@perses-dev/plugin-system';
 import { ReactElement, useState } from 'react';
 import { TempoTraceQuerySpec } from '../model';
+import { ClosableAlert } from '../components/ClosableAlert';
 import { linkToSpan, linkToTrace } from './links';
 
 interface TracesExplorerQueryParams {
@@ -56,6 +57,11 @@ function SearchResultsPanel({ queries }: SearchResultsPanelProps): ReactElement 
 
   return (
     <Stack sx={{ height: '100%' }} gap={2}>
+      {hasMoreResults && (
+        <ClosableAlert severity="warning">
+          Not all matching traces are currently visible. Increase the display limit to view more.
+        </ClosableAlert>
+      )}
       <Box sx={{ height: '35%', flexShrink: 0 }}>
         <Panel
           panelOptions={{
@@ -97,11 +103,6 @@ function SearchResultsPanel({ queries }: SearchResultsPanelProps): ReactElement 
           },
         }}
       />
-      {hasMoreResults && (
-        <Alert severity="info">
-          Not all matching traces are currently displayed. Increase the result limit to view additional traces.
-        </Alert>
-      )}
     </Stack>
   );
 }


### PR DESCRIPTION
# Description

Our UX designer recommended the following changes to the more-traces-available alert:
* move it to the top
* update text
* use warning instead of info
* add a close button

# Screenshots

Old:
<img width="3442" height="1692" alt="image" src="https://github.com/user-attachments/assets/6452da92-87e4-409b-912c-d27e66407797" />

New:
<img width="3442" height="1692" alt="image" src="https://github.com/user-attachments/assets/0a806b61-c453-4bf3-9843-48324edcb5ea" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
