### PR TITLE
[ENHANCEMENT] Use areaOpacity for sparkline from theme

### DIFF
--- a/statchart/src/StatChartBase.tsx
+++ b/statchart/src/StatChartBase.tsx
@@ -125,7 +125,7 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
 
       const clonedSparkLine = { ...sparkline };
       if (colorMode === 'background_solid') {
-        clonedSparkLine.areaStyle = { color: WHITE_COLOR_CODE, opacity: 0.4 };
+        clonedSparkLine.areaStyle = { color: WHITE_COLOR_CODE, opacity: chartsTheme.sparkline.areaOpacity };
         clonedSparkLine.lineStyle = { color: WHITE_COLOR_CODE, opacity: 1 };
       }
 

--- a/statchart/src/stat-chart-model.ts
+++ b/statchart/src/stat-chart-model.ts
@@ -64,6 +64,7 @@ export interface StatChartOptions {
 export interface StatChartSparklineOptions {
   color?: string;
   width?: number;
+  areaOpacity?: number;
 }
 
 export type StatChartOptionsEditorProps = OptionsEditorProps<StatChartOptions>;

--- a/statchart/src/utils/data-transform.test.ts
+++ b/statchart/src/utils/data-transform.test.ts
@@ -67,6 +67,7 @@ describe('getStatChartColor', () => {
 describe('convertSparkline', () => {
   const sparkline: StatChartSparklineOptions = {
     color: 'purple',
+    areaOpacity: 0.2,
   };
 
   it('should render charts theme default threshold color', () => {
@@ -81,6 +82,7 @@ describe('convertSparkline', () => {
     const options = convertSparkline(testChartsTheme, defaultColor, sparkline) as LineSeriesOption;
     expect(options.lineStyle?.color).toEqual(defaultColor);
     expect(options.areaStyle?.color).toEqual(defaultColor);
+    expect(options.areaStyle?.opacity).toEqual(0.2);
   });
 
   it('should render orange if value meets the threshold', () => {

--- a/statchart/src/utils/data-transform.ts
+++ b/statchart/src/utils/data-transform.ts
@@ -30,7 +30,7 @@ export function convertSparkline(
     },
     areaStyle: {
       color,
-      opacity: 0.4,
+      opacity: chartsTheme.sparkline.areaOpacity,
     },
   };
 }

--- a/statchart/src/utils/data-transform.ts
+++ b/statchart/src/utils/data-transform.ts
@@ -30,7 +30,7 @@ export function convertSparkline(
     },
     areaStyle: {
       color,
-      opacity: chartsTheme.sparkline.areaOpacity,
+      opacity: sparkline.areaOpacity ?? chartsTheme.sparkline.areaOpacity,
     },
   };
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Minor change that makes sparkline use areaOpacity from theme. Same as other sparkline visual settings.

This PR depends on https://github.com/perses/shared/pull/49

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
