### PR TITLE
[FEATURE] add header and row actions to tracetable

### DIFF
--- a/tracetable/cue.mod/module.cue
+++ b/tracetable/cue.mod/module.cue
@@ -5,3 +5,9 @@ language: {
 source: {
 	kind: "git"
 }
+deps: {
+	"github.com/perses/shared/cue@v0": {
+		v:       "v0.53.0-rc.2"
+		default: true
+	}
+}

--- a/tracetable/schemas/trace-table.cue
+++ b/tracetable/schemas/trace-table.cue
@@ -13,6 +13,10 @@
 
 package model
 
+import (
+	"github.com/perses/shared/cue/common"
+)
+
 #palette: {
 	mode: "auto" | "categorical"
 }
@@ -27,6 +31,8 @@ package model
 
 kind: "TraceTable"
 spec: close({
-	visual?: #visual
-	links?:  #links
+	visual?:    #visual
+	links?:     #links
+	selection?: common.#selection
+	actions?:  	common.#actions
 })

--- a/tracetable/src/TraceTable.ts
+++ b/tracetable/src/TraceTable.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { PanelPlugin } from '@perses-dev/plugin-system';
+import { TraceTableItemSelectionActionsEditor } from './TraceTableItemSelectionActionsEditor';
 import { TraceTablePanel, TraceTablePanelProps } from './TraceTablePanel';
 import { TraceTableOptions, createInitialTraceTableOptions } from './trace-table-model';
 
@@ -20,6 +21,7 @@ import { TraceTableOptions, createInitialTraceTableOptions } from './trace-table
  */
 export const TraceTable: PanelPlugin<TraceTableOptions, TraceTablePanelProps> = {
   PanelComponent: TraceTablePanel,
+  panelOptionsEditorComponents: [{ label: 'Item Actions', content: TraceTableItemSelectionActionsEditor }],
   supportedQueryTypes: ['TraceQuery'],
   createInitialOptions: createInitialTraceTableOptions,
 };

--- a/tracetable/src/TraceTableItemSelectionActionsEditor.tsx
+++ b/tracetable/src/TraceTableItemSelectionActionsEditor.tsx
@@ -1,0 +1,44 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  ActionOptions,
+  ItemSelectionActionsEditor,
+  OptionsEditorProps,
+  SelectionOptions,
+} from '@perses-dev/plugin-system';
+import { ReactElement } from 'react';
+import { TraceTableOptions } from './trace-table-model';
+
+type TraceTableItemSelectionActionsEditorProps = OptionsEditorProps<TraceTableOptions>;
+
+export function TraceTableItemSelectionActionsEditor(props: TraceTableItemSelectionActionsEditorProps): ReactElement {
+  const { onChange, value } = props;
+
+  const handleActionsChange = (actions?: ActionOptions): void => {
+    onChange({ ...value, actions });
+  };
+
+  const handleSelectionChange = (selection?: SelectionOptions): void => {
+    onChange({ ...value, selection });
+  };
+
+  return (
+    <ItemSelectionActionsEditor
+      actionOptions={value.actions}
+      onChangeActions={handleActionsChange}
+      selectionOptions={value.selection}
+      onChangeSelection={handleSelectionChange}
+    />
+  );
+}

--- a/tracetable/src/index.ts
+++ b/tracetable/src/index.ts
@@ -15,4 +15,5 @@ export * from './DataTable';
 export { getPluginModule } from './getPluginModule';
 export * from './trace-table-model';
 export * from './TraceTable';
+export * from './TraceTableItemSelectionActionsEditor';
 export * from './TraceTablePanel';

--- a/tracetable/src/trace-table-model.ts
+++ b/tracetable/src/trace-table-model.ts
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { ActionOptions, SelectionOptions } from '@perses-dev/plugin-system';
+
 /**
  * The Options object type supported by the TraceTable panel plugin.
  */
@@ -18,6 +20,8 @@
 export interface TraceTableOptions {
   visual?: TraceTableVisualOptions;
   links?: TraceTableCustomLinks;
+  selection?: SelectionOptions;
+  actions?: ActionOptions;
 }
 
 export interface TraceTableVisualOptions {


### PR DESCRIPTION
# Description

This PR adds the selection actions to the trace table

# Screenshots

<img width="1350" height="756" alt="Screenshot 2026-02-03 at 11 50 05" src="https://github.com/user-attachments/assets/c4f6342a-4f0e-49d2-ad94-d8b9f0eb111e" />
 
<img width="1151" height="673" alt="Screenshot 2026-02-03 at 11 49 50" src="https://github.com/user-attachments/assets/09c121fc-923b-4bff-b995-a843e55b856c" />

<img width="1782" height="1005" alt="Screenshot 2026-02-03 at 11 58 47" src="https://github.com/user-attachments/assets/13c50ef5-2ca3-4910-9120-8a800a037f27" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
