### PR TITLE
[FEATURE] add header and row actions to logstable

### DIFF
--- a/logstable/cue.mod/module.cue
+++ b/logstable/cue.mod/module.cue
@@ -5,3 +5,9 @@ language: {
 source: {
 	kind: "git"
 }
+deps: {
+	"github.com/perses/shared/cue@v0": {
+		v:       "v0.53.0-rc.2"
+		default: true
+	}
+}

--- a/logstable/schemas/logstable.cue
+++ b/logstable/schemas/logstable.cue
@@ -13,9 +13,15 @@
 
 package model
 
+import (
+	"github.com/perses/shared/cue/common"
+)
+
 kind: "LogsTable"
 spec: close({
 	allowWrap?:     bool
 	enableDetails?: bool
 	showTime?:      bool
+	selection?:     common.#selection
+	actions?:       common.#actions
 })

--- a/logstable/src/LogsTable.ts
+++ b/logstable/src/LogsTable.ts
@@ -13,12 +13,16 @@
 
 import { PanelPlugin } from '@perses-dev/plugin-system';
 import { LogsTableComponent } from './LogsTableComponent';
-import { LogsTableOptions, LogsTableProps } from './model';
+import { LogsTableItemSelectionActionsEditor } from './LogsTableItemSelectionActionsEditor';
 import { LogsTableSettingsEditor } from './LogsTableSettingsEditor';
+import { LogsTableOptions, LogsTableProps } from './model';
 
 export const LogsTable: PanelPlugin<LogsTableOptions, LogsTableProps> = {
   PanelComponent: LogsTableComponent,
-  panelOptionsEditorComponents: [{ label: 'Settings', content: LogsTableSettingsEditor }],
+  panelOptionsEditorComponents: [
+    { label: 'Settings', content: LogsTableSettingsEditor },
+    { label: 'Item Actions', content: LogsTableItemSelectionActionsEditor },
+  ],
   supportedQueryTypes: ['LogQuery'],
   createInitialOptions: () => ({
     showTime: true,

--- a/logstable/src/LogsTableItemSelectionActionsEditor.tsx
+++ b/logstable/src/LogsTableItemSelectionActionsEditor.tsx
@@ -1,0 +1,35 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ActionOptions, ItemSelectionActionsEditor, SelectionOptions } from '@perses-dev/plugin-system';
+import { ReactElement } from 'react';
+import { LogsTableSettingsEditorProps } from './model';
+
+export function LogsTableItemSelectionActionsEditor({ value, onChange }: LogsTableSettingsEditorProps): ReactElement {
+  function handleActionsChange(actions: ActionOptions | undefined): void {
+    onChange({ ...value, actions: actions });
+  }
+
+  function handleSelectionChange(selection: SelectionOptions | undefined): void {
+    onChange({ ...value, selection: selection });
+  }
+
+  return (
+    <ItemSelectionActionsEditor
+      actionOptions={value.actions}
+      onChangeActions={handleActionsChange}
+      selectionOptions={value.selection}
+      onChangeSelection={handleSelectionChange}
+    />
+  );
+}

--- a/logstable/src/LogsTablePanel.test.tsx
+++ b/logstable/src/LogsTablePanel.test.tsx
@@ -11,11 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ChartsProvider, SnackbarProvider, testChartsTheme } from '@perses-dev/components';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { MOCK_LOGS_QUERY_RESULT, MOCK_LOGS_QUERY_DEFINITION, MOCK_LOGS_QUERY_RESULTS } from './test/mock-query-results';
+import {
+  ChartsProvider,
+  ItemActionsProvider,
+  SelectionProvider,
+  SnackbarProvider,
+  testChartsTheme,
+} from '@perses-dev/components';
+import { VariableProvider } from '@perses-dev/dashboards';
+import { TimeRangeProviderBasic } from '@perses-dev/plugin-system';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { LogsTablePanel } from './LogsTablePanel';
 import { LogsQueryData, LogsTableProps } from './model';
+import { MOCK_LOGS_QUERY_DEFINITION, MOCK_LOGS_QUERY_RESULT, MOCK_LOGS_QUERY_RESULTS } from './test/mock-query-results';
 
 // Mock clipboard API
 Object.assign(navigator, {
@@ -38,18 +47,28 @@ describe('LogsTablePanel', () => {
   // Helper to render the panel with some context set
   const renderPanel = (data: LogsQueryData | LogsQueryData[]): void => {
     render(
-      <SnackbarProvider>
-        <ChartsProvider chartsTheme={testChartsTheme}>
-          <LogsTablePanel
-            {...TEST_LOGS_TABLE_PROPS}
-            queryResults={
-              !Array.isArray(data)
-                ? [{ definition: MOCK_LOGS_QUERY_DEFINITION, data }]
-                : data.map((d) => ({ definition: MOCK_LOGS_QUERY_DEFINITION, data: d }))
-            }
-          />
-        </ChartsProvider>
-      </SnackbarProvider>
+      <QueryClientProvider client={new QueryClient()}>
+        <SnackbarProvider>
+          <TimeRangeProviderBasic initialTimeRange={{ pastDuration: '1m' }}>
+            <VariableProvider>
+              <SelectionProvider>
+                <ItemActionsProvider>
+                  <ChartsProvider chartsTheme={testChartsTheme}>
+                    <LogsTablePanel
+                      {...TEST_LOGS_TABLE_PROPS}
+                      queryResults={
+                        !Array.isArray(data)
+                          ? [{ definition: MOCK_LOGS_QUERY_DEFINITION, data }]
+                          : data.map((d) => ({ definition: MOCK_LOGS_QUERY_DEFINITION, data: d }))
+                      }
+                    />
+                  </ChartsProvider>
+                </ItemActionsProvider>
+              </SelectionProvider>
+            </VariableProvider>
+          </TimeRangeProviderBasic>
+        </SnackbarProvider>
+      </QueryClientProvider>
     );
   };
 

--- a/logstable/src/LogsTableSettingsEditor.tsx
+++ b/logstable/src/LogsTableSettingsEditor.tsx
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 import {
-  OptionsEditorGrid,
   OptionsEditorColumn,
+  OptionsEditorGrid,
   ThresholdsEditor,
   ThresholdsEditorProps,
 } from '@perses-dev/components';

--- a/logstable/src/components/LogRow/LogRow.tsx
+++ b/logstable/src/components/LogRow/LogRow.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { memo, useCallback, useState, useRef, useEffect } from 'react';
+import React, { memo, useCallback, useState, useRef, useEffect, ReactNode } from 'react';
 import {
   Box,
   Collapse,
@@ -48,6 +48,7 @@ interface LogRowProps {
   allowWrap?: boolean;
   isSelected?: boolean;
   onSelect?: (index: number, event: React.MouseEvent) => void;
+  itemActionButtons?: ReactNode[];
 }
 
 const DefaultLogRow: React.FC<LogRowProps> = ({
@@ -60,6 +61,7 @@ const DefaultLogRow: React.FC<LogRowProps> = ({
   allowWrap = false,
   isSelected = false,
   onSelect,
+  itemActionButtons,
 }) => {
   const theme = useTheme();
   const severityColor = useSeverityColor(log);
@@ -143,6 +145,8 @@ const DefaultLogRow: React.FC<LogRowProps> = ({
 
   if (!log) return null;
 
+  const hasRowActions = itemActionButtons && itemActionButtons.length > 0;
+
   return (
     <LogRowContainer
       severityColor={severityColor}
@@ -160,6 +164,7 @@ const DefaultLogRow: React.FC<LogRowProps> = ({
         onMouseDown={handleRowMouseDown}
         isExpandable={isExpandable}
         isHighlighted={Boolean(anchorEl)}
+        hasRowActions={hasRowActions}
         isSelected={isSelected}
       >
         {isExpandable && (
@@ -223,6 +228,20 @@ const DefaultLogRow: React.FC<LogRowProps> = ({
               )}
             </IconButton>
           </Tooltip>
+          {hasRowActions && (
+            <Box
+              sx={{
+                display: 'flex',
+                gap: '4px',
+                alignItems: 'center',
+                opacity: isHovered || Boolean(anchorEl) ? 1 : 0,
+                pointerEvents: isHovered || Boolean(anchorEl) ? 'auto' : 'none',
+                transition: 'opacity 0.08s ease',
+              }}
+            >
+              {itemActionButtons}
+            </Box>
+          )}
           <Menu
             anchorEl={anchorEl}
             open={Boolean(anchorEl)}

--- a/logstable/src/components/LogRow/LogsStyles.tsx
+++ b/logstable/src/components/LogRow/LogsStyles.tsx
@@ -24,11 +24,14 @@ export const LogRowContainer = styled(Box, {
 }));
 
 export const LogRowContent = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'isExpandable' && prop !== 'isHighlighted' && prop !== 'isSelected',
-})<{ isExpandable: boolean; isHighlighted?: boolean; isSelected?: boolean }>(
-  ({ theme, isExpandable, isHighlighted, isSelected }) => ({
+  shouldForwardProp: (prop) =>
+    prop !== 'isExpandable' && prop !== 'isHighlighted' && prop !== 'isSelected' && prop !== 'hasRowActions',
+})<{ isExpandable: boolean; isHighlighted?: boolean; isSelected?: boolean; hasRowActions?: boolean }>(
+  ({ theme, isExpandable, isHighlighted, isSelected, hasRowActions }) => ({
     display: 'grid',
-    gridTemplateColumns: isExpandable ? '16px minmax(160px, max-content) 1fr' : 'minmax(160px, max-content) 1fr',
+    gridTemplateColumns: isExpandable
+      ? `16px minmax(160px, max-content) 1fr ${hasRowActions ? 'min-content' : ''}`
+      : `minmax(160px, max-content) 1fr ${hasRowActions ? 'min-content' : ''}`,
     alignItems: 'flex-start',
     padding: '4px 8px',
     cursor: 'default',

--- a/logstable/src/model.ts
+++ b/logstable/src/model.ts
@@ -12,7 +12,13 @@
 // limitations under the License.
 
 import { LogData, ThresholdOptions } from '@perses-dev/core';
-import { PanelProps, LegendSpecOptions } from '@perses-dev/plugin-system';
+import {
+  PanelProps,
+  LegendSpecOptions,
+  SelectionOptions,
+  OptionsEditorProps,
+  ActionOptions,
+} from '@perses-dev/plugin-system';
 
 export type LogsTableProps = PanelProps<LogsTableOptions, LogsQueryData>;
 
@@ -27,4 +33,8 @@ export interface LogsTableOptions {
   enableDetails?: boolean;
   showTime?: boolean;
   showAll?: boolean;
+  selection?: SelectionOptions;
+  actions?: ActionOptions;
 }
+
+export type LogsTableSettingsEditorProps = OptionsEditorProps<LogsTableOptions>;


### PR DESCRIPTION
# Description

This PR adds the selection actions to the trace table

# Screenshots

<img width="1230" height="651" alt="Screenshot 2026-02-03 at 13 18 25" src="https://github.com/user-attachments/assets/4c10abe6-8672-4990-9c1f-1f6f9d8d31d4" />

<img width="1306" height="703" alt="Screenshot 2026-02-03 at 13 18 42" src="https://github.com/user-attachments/assets/f39ca359-c75f-44a2-8a76-2c7be331e418" />

<img width="1785" height="992" alt="Screenshot 2026-02-03 at 13 19 46" src="https://github.com/user-attachments/assets/6ed35723-4972-4f33-978c-790709584333" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
