### PR TITLE
[BUGFIX]: allow max without min value for HistogramChart

### DIFF
--- a/histogramchart/schemas/histogram.cue
+++ b/histogramchart/schemas/histogram.cue
@@ -21,7 +21,10 @@ kind: "HistogramChart"
 spec: close({
 	format?:     common.#format
 	min?:        number
-	max?:        number & >= min
+	max?:        number
+	if min != _|_ && max != _|_ {
+		max: >= min
+	}
 	thresholds?: common.#thresholds
 	logBase?:    2 | 10
 })

--- a/histogramchart/schemas/tests/valid/histogram_only_max.json
+++ b/histogramchart/schemas/tests/valid/histogram_only_max.json
@@ -1,0 +1,6 @@
+{
+  "kind": "HistogramChart",
+  "spec": {
+    "max": 10
+  }
+}


### PR DESCRIPTION
## Description:
Fix CUE validation error when specifying only max without min in HistogramChart panel spec.

## Problem
Setting only max value caused cue validation failure:
> spec.max: cannot reference optional field: min


## Solution
Use conditional constraint to validate max >= min only when both fields are present.