### PR TITLE
[ignore] fix retry system when publishing cue module

### DIFF
--- a/scripts/cue-publish/cue-publish.go
+++ b/scripts/cue-publish/cue-publish.go
@@ -66,16 +66,18 @@ func main() {
 	// Initial sleep duration between retries: random value between 1s and 10s
 	sleepBetweenRetries := (1 + time.Duration(rand.Int64N(9))) * time.Second
 	for attempt := 1; attempt <= retryMaxAttempts; attempt++ {
-		if err := command.Run("cue", "mod", "publish", version); err != nil {
-			logrus.WithError(err).Warnf("Attempt %d/%d: Error publishing the module, retrying...", attempt, retryMaxAttempts)
-			if attempt == retryMaxAttempts {
-				logrus.Fatal("Max retry attempts reached, failing the publish process")
-			}
-			// Wait for a few seconds before retrying
-			time.Sleep(sleepBetweenRetries)
-			// Increase the sleep duration for the next attempt with a random value to reduce collision risk with other jobs running in parallel.
-			sleepBetweenRetries = sleepBetweenRetries + (1+time.Duration(rand.Int64N(19)))*time.Second
+		// Wait for a few seconds immediately before the first attempt to reduce collision risk with other jobs running in parallel.
+		time.Sleep(sleepBetweenRetries)
+		err := command.Run("cue", "mod", "publish", version)
+		if err == nil {
+			break
 		}
+		if attempt == retryMaxAttempts {
+			logrus.Fatal("Max retry attempts reached, publish process failed")
+		}
+		logrus.WithError(err).Warnf("Attempt %d/%d: Error publishing the module, retrying...", attempt, retryMaxAttempts)
+		// Increase the sleep duration for the next attempt with a random value to reduce collision risk with other jobs running in parallel.
+		sleepBetweenRetries = sleepBetweenRetries + (1+time.Duration(rand.Int64N(19)))*time.Second
 	}
 	logrus.Infof("CUE module %s published successfully", module)
 }


### PR DESCRIPTION
instead of retrying, the current script is actually spamming 10 times more the cue registry.

Cuelang maintainers if you see that, I am truly sorry about that 