### PR TITLE
[FEATURE]: add CI e2e setup to plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,42 @@ jobs:
       - run: npm ci
       - run: npm run test
 
+  e2e:
+    name: "e2e tests"
+    needs: build # <--- CRITICAL: Wait for build to finish. PERSES_PLUGIN_ARCHIVE_PATHS accepts archive files only
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      - name: download plugin archives
+        uses: actions/download-artifact@v4 # <--- Download the artifacts to use the archive files
+        with:
+          name: archives
+          path: ./plugins/temp-archives
+      - name: flatten plugin archives # <--- Move all plugins archive into a single folder for simplicity
+        run: |
+          mkdir -p ./plugins/development-archives          
+          find ./plugins/temp-archives -name "*.tar.gz" -exec mv {} ./plugins/development-archives/ \;          
+          rm -rf ./plugins/temp-archives          
+          ls -R ./plugins/development-archives
+      - name: start dev env
+        uses: hoverkraft-tech/compose-action@v2.5.0
+        with:
+            compose-file: .github/workflows/docker-compose.ci.yml      
+      - uses: perses/github-actions@v0.11.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_npm: true
+          nvmrc_path: ".nvmrc"
+      - name: install dependencies
+        run: npm ci
+      - name: install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: e2e
+      - name: run e2e tests
+        run: npm run test:ci --prefix e2e -- src/tests
+          
+
   type-check:
     name: "type-check"
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-compose.ci.yml
+++ b/.github/workflows/docker-compose.ci.yml
@@ -1,0 +1,12 @@
+services:
+  perses:
+    image: persesdev/perses:main-2026-02-26-739dc289-distroless-debug
+    container_name: perses
+    network_mode: host
+    environment:
+      - PERSES_PLUGIN_ENABLE_DEV=true
+      - PERSES_PLUGIN_ARCHIVE_PATHS_0=/etc/perses/development-archives
+      - PERSES_PROVISIONING_FOLDERS_0=/etc/perses/provisioning
+    volumes:
+      - ../../plugins/development-archives:/etc/perses/development-archives
+      - ../../e2e/src/data:/etc/perses/provisioning

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,8 @@
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@perses-dev/plugins-e2e",
+  "version": "0.1.0",
+  "description": "e2e tests for plugins",
+  "private": true,
+  "scripts": {
+    "test:ci": "npx playwright test --workers=1 --reporter=github,list",
+    "test:install": "npx playwright install --with-deps",
+    "test:local": "npx playwright test --ui",
+    "build": "echo 'Skipping build for e2e tests'"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2",
+    "@types/node": "^25.2.3"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,39 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/tests',
+  fullyParallel: true,
+  retries: 0,
+  reporter: 'list',
+
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'off',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  expect: {
+    timeout: 10000,
+  },
+});

--- a/e2e/src/data/projects/e2e.json
+++ b/e2e/src/data/projects/e2e.json
@@ -1,0 +1,7 @@
+{
+  "kind": "Project",
+  "metadata": {
+    "name": "e2eproject"
+  },
+  "spec": {}
+}

--- a/e2e/src/tests/table/table.spec.ts
+++ b/e2e/src/tests/table/table.spec.ts
@@ -1,0 +1,21 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { test, expect } from '@playwright/test';
+
+/* WAS ONLY ADDED FOR DEMONSTRATIONS*/
+test.describe('table Plugin', () => {
+  test('ONLY FOR PR DEMONSTRATION', async () => {
+    expect(1).toBe(1);
+  });
+});

--- a/e2e/src/tests/tracetable/tracetable.spec.ts
+++ b/e2e/src/tests/tracetable/tracetable.spec.ts
@@ -1,0 +1,21 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { test, expect } from '@playwright/test';
+
+/* WAS ONLY ADDED FOR DEMONSTRATIONS*/
+test.describe('tacetable Plugin', () => {
+  test('ONLY FOR PR DEMONSTRATION', async () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "timeseriestable",
         "tracetable",
         "tracingganttchart",
-        "victorialogs"
+        "victorialogs",
+        "e2e"
       ],
       "devDependencies": {
         "@module-federation/rsbuild-plugin": "^0.21.6",
@@ -142,6 +143,14 @@
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0",
         "use-resize-observer": "^9.0.0"
+      }
+    },
+    "e2e": {
+      "name": "@perses-dev/plugins-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.58.2",
+        "@types/node": "^25.2.3"
       }
     },
     "flamechart": {
@@ -3879,6 +3888,10 @@
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
+    "node_modules/@perses-dev/plugins-e2e": {
+      "resolved": "e2e",
+      "link": true
+    },
     "node_modules/@perses-dev/prometheus-plugin": {
       "resolved": "prometheus",
       "link": true
@@ -3942,6 +3955,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5156,13 +5185,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
-      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -13066,6 +13095,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -15587,9 +15663,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "timeseriestable",
     "tracetable",
     "tracingganttchart",
-    "victorialogs"
+    "victorialogs",
+    "e2e"
   ],
   "peerDependencies": {
     "@types/react-dom": "^18.3.0",

--- a/scripts/golangci-lint/golangci-lint.go
+++ b/scripts/golangci-lint/golangci-lint.go
@@ -26,7 +26,7 @@ func main() {
 	var isError bool
 
 	for _, workspace := range npm.MustGetWorkspaces(".") {
-		schemasPath := filepath.Join(workspace,"schemas")
+		schemasPath := filepath.Join(workspace, "schemas")
 		if _, err := os.Stat(schemasPath); os.IsNotExist(err) {
 			// No schemas, skip go validation
 			logrus.Infof("skipping golangci-lint for %s (no schemas)", workspace)


### PR DESCRIPTION
Relates to https://github.com/perses/perses/issues/3799

## E2E setup
This change adds e2e set up into the plugin repo. Using the `PERSES_PLUGIN_ARCHIVE_PATHS` parameter we are able to inject the built plugins (archive files) into the running instance of Perses.  For more information please take a look at https://perses.dev/perses/docs/configuration/configuration/

⚠️  Use a recent tag. The mentioned config is pretty new!  I used the following tag,

> main-2026-02-26-739dc289-distroless-debug

> Check: https://hub.docker.com/r/persesdev/perses

## How to test this

- Edit a plugin 
- For example you can change its name from rsbuild.config
- And just push
- You can check the plugins endpoint and see that the substitute archive is in place
- You can use the following code to assure your change is also available from the tests

```typescript
/* WAS ONLY ADDED FOR DEMONSTRATIONS*/
test.describe('table Plugin', () => {
  test('ONLY FOR PR DEMONSTRATION', async ({ request }) => {
    const res = await request.get('http://localhost:8080/api/v1/plugins');
    expect(res.ok()).toBeTruthy();
    const plugins = await res.json();
    console.log('--- Current Perses Plugins ---');
    console.log(
      JSON.stringify(
        Array.from(plugins).map((p) => p.spec),
        null,
        2
      )
    );
  });
});
```

> http://localhost:8080/api/v1/plugins 

<img width="994" height="405" alt="image" src="https://github.com/user-attachments/assets/c0e43a09-36d0-4d31-827f-19c65ac25fcb" />

## Provisioning 

Provisioning was also set up to ease the testing process. **_The content doesn't matter at this point. The aim was only to make sure it is ready for the further steps._** 

<img width="1510" height="523" alt="image" src="https://github.com/user-attachments/assets/8564c399-c3da-4c1b-a126-88d0633dd1c4" />



# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
