### PR TITLE
[IGNORE] Skip Go linting for schemaless plugins

### DIFF
--- a/scripts/golangci-lint/golangci-lint.go
+++ b/scripts/golangci-lint/golangci-lint.go
@@ -16,6 +16,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/perses/perses/scripts/pkg/npm"
 	"github.com/sirupsen/logrus"
@@ -25,7 +26,7 @@ func main() {
 	var isError bool
 
 	for _, workspace := range npm.MustGetWorkspaces(".") {
-		schemasPath := workspace + "/schemas"
+		schemasPath := filepath.Join(workspace,"schemas")
 		if _, err := os.Stat(schemasPath); os.IsNotExist(err) {
 			// No schemas, skip go validation
 			logrus.Infof("skipping golangci-lint for %s (no schemas)", workspace)


### PR DESCRIPTION
# Description

Plugins like the LogExplorer (https://github.com/perses/plugins/pull/577) that only provide frontend components (Explore views) don't have a `schemas/` directory and therefore no Go files and should be skipped.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
