### PR TITLE
[IGNORE] scripts: add skip workspace script

### DIFF
--- a/scripts/build-archive/build-archive.go
+++ b/scripts/build-archive/build-archive.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/perses/perses/scripts/pkg/npm"
 	"github.com/perses/plugins/scripts/manifest"
+	"github.com/perses/plugins/scripts/npm"
 	"github.com/sirupsen/logrus"
 )
 

--- a/scripts/build-plugins/build-plugins.go
+++ b/scripts/build-plugins/build-plugins.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/perses/common/async"
 	"github.com/perses/perses/scripts/pkg/command"
-	"github.com/perses/perses/scripts/pkg/npm"
+	"github.com/perses/plugins/scripts/npm"
 	"github.com/perses/plugins/scripts/tag"
 	"github.com/sirupsen/logrus"
 )

--- a/scripts/bump-deps/bump-deps.go
+++ b/scripts/bump-deps/bump-deps.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 
 	"github.com/perses/perses/scripts/pkg/command"
-	"github.com/perses/perses/scripts/pkg/npm"
+	"github.com/perses/plugins/scripts/npm"
 	"github.com/sirupsen/logrus"
 )
 

--- a/scripts/golangci-lint/golangci-lint.go
+++ b/scripts/golangci-lint/golangci-lint.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/perses/perses/scripts/pkg/npm"
+	"github.com/perses/plugins/scripts/npm"
 	"github.com/sirupsen/logrus"
 )
 

--- a/scripts/lint-plugins/lint-plugins.go
+++ b/scripts/lint-plugins/lint-plugins.go
@@ -20,7 +20,8 @@ import (
 
 	"github.com/perses/common/async"
 	"github.com/perses/perses/scripts/pkg/command"
-	"github.com/perses/perses/scripts/pkg/npm"
+	"github.com/perses/plugins/scripts/npm"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/scripts/npm/npm.go
+++ b/scripts/npm/npm.go
@@ -1,0 +1,28 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package npm
+
+import (
+	"slices"
+
+	"github.com/perses/perses/scripts/pkg/npm"
+)
+
+func MustGetWorkspaces(dirPath string) []string {
+	excludedWorkspaces := []string{"e2e"}
+	workspaces := npm.MustGetWorkspaces(dirPath)
+	return slices.DeleteFunc(workspaces, func(w string) bool {
+		return slices.Contains(excludedWorkspaces, w)
+	})
+}

--- a/scripts/release/release.go
+++ b/scripts/release/release.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/perses/perses/scripts/pkg/command"
 	"github.com/perses/perses/scripts/pkg/npm"
+	localNPM "github.com/perses/plugins/scripts/npm"
 	"github.com/sirupsen/logrus"
 )
 
@@ -78,7 +79,7 @@ func main() {
 		release(*releaseSingleName, dryRun)
 		return
 	}
-	for _, workspace := range npm.MustGetWorkspaces(".") {
+	for _, workspace := range localNPM.MustGetWorkspaces(".") {
 		logrus.Infof("releasing %s", workspace)
 		release(workspace, dryRun)
 	}

--- a/scripts/test-schemas-plugins/test-schemas-plugins.go
+++ b/scripts/test-schemas-plugins/test-schemas-plugins.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/perses/common/async"
 	"github.com/perses/perses/scripts/pkg/command"
-	"github.com/perses/perses/scripts/pkg/npm"
+	"github.com/perses/plugins/scripts/npm"
 	"github.com/sirupsen/logrus"
 )
 

--- a/scripts/tidy-modules/tidy-modules.go
+++ b/scripts/tidy-modules/tidy-modules.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/perses/perses/scripts/pkg/npm"
+	"github.com/perses/plugins/scripts/npm"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3894

# Description

This change adds a simple script to check if the current workspace should be excluded. This will resolve the issue of go scripts for UI only worksapces. 

 
<img width="413" height="203" alt="image" src="https://github.com/user-attachments/assets/c6da858b-eeed-461b-a024-00eb21c63f3d" />


# Screenshots

<!-- If there are UI changes -->

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
