### PR TITLE
[ENHANCEMENT] Tempo: rearrange settings controls layout

### DIFF
--- a/tempo/src/components/AttributeFilters.tsx
+++ b/tempo/src/components/AttributeFilters.tsx
@@ -54,37 +54,49 @@ export function AttributeFilters(props: AttributeFiltersProps): ReactElement {
   );
 
   return (
-    <>
-      <StringAttributeFilter
-        label="Service Name"
-        options={serviceNameOptions ?? []}
-        value={filter.serviceName}
-        setValue={(x) => setFilter({ ...filter, serviceName: x })}
-      />
-      <StringAttributeFilter
-        label="Span Name"
-        options={spanNameOptions ?? []}
-        value={filter.spanName}
-        setValue={(x) => setFilter({ ...filter, spanName: x })}
-      />
-      <StringAttributeFilter
-        label="Status"
-        width={210}
-        options={statusOptions ?? []}
-        value={filter.status}
-        setValue={(x) => setFilter({ ...filter, status: x })}
-      />
-      <DurationAttributeFilter
-        label="Trace Duration"
-        value={filter.traceDuration}
-        setValue={(value) => setFilter({ ...filter, traceDuration: value })}
-      />
-      <CustomAttributesFilter
-        label="Custom Attributes"
-        value={filter.customMatchers}
-        setValue={(value) => setFilter({ ...filter, customMatchers: value })}
-      />
-    </>
+    <Stack direction="column" flex={1} gap={1}>
+      <Stack
+        direction="row"
+        flex={1}
+        gap={1}
+        sx={{
+          '& > *:nth-of-type(1)': { flex: 2 }, // Service Name
+          '& > *:nth-of-type(2)': { flex: 2 }, // Span Name
+          '& > *:nth-of-type(3)': { flex: 1 }, // Status
+        }}
+      >
+        <StringAttributeFilter
+          label="Service Name"
+          options={serviceNameOptions ?? []}
+          value={filter.serviceName}
+          setValue={(x) => setFilter({ ...filter, serviceName: x })}
+        />
+        <StringAttributeFilter
+          label="Span Name"
+          options={spanNameOptions ?? []}
+          value={filter.spanName}
+          setValue={(x) => setFilter({ ...filter, spanName: x })}
+        />
+        <StringAttributeFilter
+          label="Status"
+          options={statusOptions ?? []}
+          value={filter.status}
+          setValue={(x) => setFilter({ ...filter, status: x })}
+        />
+      </Stack>
+      <Stack direction="row" flex={1} gap={1}>
+        <DurationAttributeFilter
+          label="Trace Duration"
+          value={filter.traceDuration}
+          setValue={(value) => setFilter({ ...filter, traceDuration: value })}
+        />
+        <CustomAttributesFilter
+          label="Custom Attributes"
+          value={filter.customMatchers}
+          setValue={(value) => setFilter({ ...filter, customMatchers: value })}
+        />
+      </Stack>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
Closes https://github.com/perses/perses/issues/3912

# Description
This change rearranges the Tempo settings controls. The current structure is pretty cramped and hard to work with

# To be discussed
There is also a chance to move the status to the second row and have a dedicated 3rd row for the custom attributes. 

## Before

<img width="1317" height="654" alt="image" src="https://github.com/user-attachments/assets/2b310785-c81a-458d-b66d-3f98408eee85" />



## After
<img width="1525" height="625" alt="image" src="https://github.com/user-attachments/assets/2125b438-ba8b-4903-acdb-9fbf14441d44" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
