### PR TITLE
[BUGFIX] TimeSeriesChart: Empty query results should show "No Data" even with thresholds configured

### DIFF
--- a/timeserieschart/src/TimeSeriesChartPanel.tsx
+++ b/timeserieschart/src/TimeSeriesChartPanel.tsx
@@ -303,7 +303,8 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps): ReactElement 
       }
     }
 
-    if (thresholds && thresholds.steps) {
+    // map thresholds only if there is at least one time series to avoid displaying thresholds without any data
+    if (thresholds && thresholds.steps && timeChartData.length > 0) {
       // Convert how thresholds are defined in the panel spec to valid ECharts 'line' series.
       // These are styled with predefined colors and a dashed style to look different than series from query results.
       // Regular series are used instead of markLines since thresholds currently show in our React TimeSeriesTooltip.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
closes [TimeSeriesChart: Empty query results should show "No Data" even with thresholds configured](https://github.com/perses/perses/issues/1299)

Add thresholds to displayed time series only if there is at least one time series with actual data. 

# Screenshots
Before:
<img width="1844" height="693" alt="image" src="https://github.com/user-attachments/assets/6318c71a-fe11-40cd-83fd-f46345c8ce26" />

After:
<img width="1844" height="693" alt="image" src="https://github.com/user-attachments/assets/5ed04e0b-91d8-4506-9e44-1db4ee362a11" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
