### PR TITLE
[BUGFIX] GaugeChart: handle multiple queries + ignore if first query return nothing

### DIFF
--- a/gaugechart/src/GaugeChartPanel.tsx
+++ b/gaugechart/src/GaugeChartPanel.tsx
@@ -102,21 +102,19 @@ export function GaugeChartPanel(props: GaugeChartPanelProps): ReactElement | nul
   const gaugeData = useMemo((): GaugeSeries[] => {
     const seriesData: GaugeSeries[] = [];
 
-    if (!queryResults[0]?.data?.series?.length) {
-      return seriesData;
-    }
-
     if (!CalculationsMap[calculation]) {
       console.warn(`Invalid GaugeChart panel calculation ${calculation}, fallback to ${DEFAULT_CALCULATION}`);
     }
 
     const calculate = CalculationsMap[calculation] ?? CalculationsMap[DEFAULT_CALCULATION];
 
-    for (const timeSeries of queryResults[0].data.series) {
-      seriesData.push({
-        value: calculate(timeSeries.values),
-        label: showLegend ? (timeSeries.formattedName ?? '') : '',
-      });
+    for (const result of queryResults) {
+      for (const timeSeries of result.data.series) {
+        seriesData.push({
+          value: calculate(timeSeries.values),
+          label: showLegend ? (timeSeries.formattedName ?? '') : '',
+        });
+      }
     }
     return seriesData;
   }, [queryResults, calculation, showLegend]);


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Closes: https://github.com/perses/perses/issues/3930 and closes: https://github.com/perses/perses/issues/3465

Gauge chart is now correctly handling multiples queries

# Screenshots

<!-- If there are UI changes -->
BEFORE:
<img width="1080" height="1262" alt="image" src="https://github.com/user-attachments/assets/96775352-0272-4f49-a3b1-ddb317540a57" />

<img width="1081" height="1264" alt="image" src="https://github.com/user-attachments/assets/ab1095a2-868f-4e98-ad57-9c2b76aaa640" />


AFTER:
<img width="1081" height="1257" alt="image" src="https://github.com/user-attachments/assets/e95e504c-f560-4b13-8b1a-4829d84085a5" />

<img width="1079" height="1260" alt="image" src="https://github.com/user-attachments/assets/d81891af-fcb2-4313-95bf-461694e37707" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
