### PR TITLE
[IGNORE] prometheus: use the same fetch for GET and POST requests

### DIFF
--- a/prometheus/src/model/api-types.ts
+++ b/prometheus/src/model/api-types.ts
@@ -20,8 +20,8 @@ export type { DurationString };
 export interface SuccessResponse<T> {
   status: 'success';
   data: T;
-  rawResponse?: Response;
   warnings?: string[];
+  infos?: string[];
 }
 
 export interface ErrorResponse<T> {

--- a/prometheus/src/model/prometheus-client.ts
+++ b/prometheus/src/model/prometheus-client.ts
@@ -198,9 +198,9 @@ function fetchWithGet<T extends RequestParams<T>, TResponse>(
   params: T,
   queryOptions: QueryOptions
 ): Promise<TResponse> {
-  const { datasourceUrl, headers, queryParams } = queryOptions;
+  const { datasourceUrl, headers, queryParams, abortSignal: signal } = queryOptions;
   const url = `${datasourceUrl}${apiURI}${buildQueryString(queryParams, createSearchParams(params))}`;
-  return fetchJson<TResponse>(url, { method: 'GET', headers });
+  return fetchJson<TResponse>(url, { method: 'GET', headers, signal });
 }
 
 function fetchWithPost<T extends RequestParams<T>, TResponse>(
@@ -220,7 +220,7 @@ function fetchWithPost<T extends RequestParams<T>, TResponse>(
     signal,
     body: createSearchParams(params),
   };
-  return fetchResults<TResponse>(url, init);
+  return fetchJson<TResponse>(url, init);
 }
 
 // Request parameter values we know how to serialize
@@ -256,13 +256,4 @@ function createSearchParams<T extends RequestParams<T>>(params: T): URLSearchPar
     }
   }
   return searchParams;
-}
-
-/**
- * Fetch JSON and parse warnings for query inspector
- */
-export async function fetchResults<T>(...args: Parameters<typeof global.fetch>): Promise<T> {
-  const response = await fetch(...args);
-  const json: T = await response.json();
-  return { ...json, rawResponse: response };
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Align types to Prometheus API types (rawResponse) + use the same fetch for POST and GET requests

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
