### PR TITLE
[BUGFIX] TimeSeriesChart: Grafana migration: handle string value for `fillOpacity` params

### DIFF
--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -161,7 +161,11 @@ spec: {
 		visual: lineStyle: #lineStyleMapping[#lineStyle]
 	}
 
-	#fillOpacity: *#panel.fieldConfig.defaults.custom.fillOpacity | null
+	#fillOpacityRaw: *#panel.fieldConfig.defaults.custom.fillOpacity | null
+	#fillOpacity: [
+		if (#fillOpacityRaw & string) != _|_ {strconv.Atoi(#fillOpacityRaw)},
+		#fillOpacityRaw,
+	][0]
 	if #fillOpacity != null {
 		visual: areaOpacity: #fillOpacity / 100
 	}
@@ -202,7 +206,11 @@ spec: {
 					lineStyle: #lineStyleMapping[property.value.fill]
 				}
 				if property.id == "custom.fillOpacity" {
-					areaOpacity: property.value / 100
+					#queryFillOpacity: [
+						if (property.value & string) != _|_ {strconv.Atoi(property.value)},
+						property.value,
+					][0]
+					areaOpacity: #queryFillOpacity / 100
 				}
 			}
 		},

--- a/timeserieschart/schemas/migrate/tests/basic-with-logbase/input.json
+++ b/timeserieschart/schemas/migrate/tests/basic-with-logbase/input.json
@@ -14,7 +14,7 @@
         "barAlignment": 0,
         "barWidthFactor": 0.6,
         "drawStyle": "line",
-        "fillOpacity": 10,
+        "fillOpacity": "10",
         "gradientMode": "none",
         "hideFrom": {
           "legend": false,

--- a/timeserieschart/schemas/migrate/tests/multiple-overrides/input.json
+++ b/timeserieschart/schemas/migrate/tests/multiple-overrides/input.json
@@ -65,7 +65,7 @@
         "properties": [
           {
             "id": "custom.fillOpacity",
-            "value": 0
+            "value": "0"
           },
           {
             "id": "custom.lineWidth",


### PR DESCRIPTION

# Description

in Grafana the `fillOpacity` attributes of the timeseries plugin can have a string value & our migration script was not handling that. This PR fixes that.

# Screenshots

Fixes such error:

```
Message: bad request: unable to convert to Perses panel: spec.#querySettings.0.areaOpacity: invalid operands \"20\" and 100 to '/' (type string and int) StatusCode: 400"
```

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).