### PR TITLE
[BUGFIX] Fix table CSV export to emit post-transform tabular data

### DIFF
--- a/table/src/TableExportAction.test.ts
+++ b/table/src/TableExportAction.test.ts
@@ -1,0 +1,213 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TimeSeriesData } from '@perses-dev/core';
+import { PanelData } from '@perses-dev/plugin-system';
+import { TableOptions } from './models';
+import { buildTableData } from './TableExportAction';
+
+function makePanelData(series: TimeSeriesData['series']): PanelData<TimeSeriesData> {
+  return {
+    definition: {
+      kind: 'TimeSeriesQuery',
+      spec: { plugin: { kind: 'PrometheusTimeSeriesQuery', spec: { query: '' } } },
+    },
+    data: {
+      timeRange: { start: new Date(1666625535000), end: new Date(1666625535000) },
+      stepMs: 15000,
+      series,
+    },
+  };
+}
+
+describe('buildTableData', () => {
+  const singleQueryResult: Array<PanelData<TimeSeriesData>> = [
+    makePanelData([
+      {
+        name: 'series-a',
+        values: [[1666479357903, 0.277]],
+        labels: { device: '/dev/vda1', env: 'demo' },
+      },
+      {
+        name: 'series-b',
+        values: [[1666479357903, 0.085]],
+        labels: { device: '/dev/vda15', env: 'demo' },
+      },
+    ]),
+  ];
+
+  it('produces tabular rows with timestamp, value, and label columns for a single query', () => {
+    const { data, columns } = buildTableData(singleQueryResult, {});
+
+    expect(data).toHaveLength(2);
+    expect(columns.map((c) => c.header)).toEqual(expect.arrayContaining(['timestamp', 'value', 'device', 'env']));
+
+    expect(data[0]).toMatchObject({ timestamp: 1666479357903, value: 0.277, device: '/dev/vda1', env: 'demo' });
+    expect(data[1]).toMatchObject({ timestamp: 1666479357903, value: 0.085, device: '/dev/vda15', env: 'demo' });
+  });
+
+  it('uses indexed column names for multi-query results', () => {
+    const multiQueryResults: Array<PanelData<TimeSeriesData>> = [
+      makePanelData([{ name: 'q1', values: [[1000, 100]], labels: { instance: 'server-a' } }]),
+      makePanelData([{ name: 'q2', values: [[1000, 200]], labels: { instance: 'server-a' } }]),
+    ];
+
+    const { data, columns } = buildTableData(multiQueryResults, {});
+
+    const headers = columns.map((c) => c.header);
+    expect(headers).toContain('value #1');
+    expect(headers).toContain('value #2');
+    expect(headers).toContain('instance #1');
+    expect(headers).toContain('instance #2');
+    expect(headers).not.toContain('value');
+    expect(headers).not.toContain('instance');
+
+    expect(data).toHaveLength(2);
+    expect(data[0]).toMatchObject({ 'value #1': 100, 'instance #1': 'server-a' });
+    expect(data[1]).toMatchObject({ 'value #2': 200, 'instance #2': 'server-a' });
+  });
+
+  it('applies MergeSeries transform to combine multi-query rows', () => {
+    const multiQueryResults: Array<PanelData<TimeSeriesData>> = [
+      makePanelData([
+        { name: 'q1-a', values: [[1000, 10]], labels: { mount: '/' } },
+        { name: 'q1-b', values: [[1000, 20]], labels: { mount: '/boot' } },
+      ]),
+      makePanelData([
+        { name: 'q2-a', values: [[1000, 50]], labels: { mount: '/' } },
+        { name: 'q2-b', values: [[1000, 60]], labels: { mount: '/boot' } },
+      ]),
+    ];
+    const spec: TableOptions = {
+      transforms: [{ kind: 'MergeSeries', spec: {} }],
+    };
+
+    const { data } = buildTableData(multiQueryResults, spec);
+
+    // MergeSeries merges indexed label columns and joins rows by label values.
+    // Without MergeSeries we'd have 4 rows; with it, 2 rows (one per mount).
+    expect(data).toHaveLength(2);
+
+    const rowSlash = data.find((r) => r['mount'] === '/');
+    const rowBoot = data.find((r) => r['mount'] === '/boot');
+    expect(rowSlash).toBeDefined();
+    expect(rowBoot).toBeDefined();
+
+    expect(rowSlash).toMatchObject({ 'value #1': 10, 'value #2': 50, mount: '/' });
+    expect(rowBoot).toMatchObject({ 'value #1': 20, 'value #2': 60, mount: '/boot' });
+  });
+
+  it('applies JoinByColumnValue transform to merge rows by shared label', () => {
+    const { data } = buildTableData(singleQueryResult, {
+      transforms: [{ kind: 'JoinByColumnValue', spec: { columns: ['env'] } }],
+    });
+
+    // Both series share env='demo', so they merge into 1 row
+    expect(data).toHaveLength(1);
+    expect(data[0]).toMatchObject({ env: 'demo' });
+  });
+
+  it('excludes hidden columns from export', () => {
+    const spec: TableOptions = {
+      columnSettings: [{ name: 'env', hide: true }],
+    };
+
+    const { columns } = buildTableData(singleQueryResult, spec);
+    const headers = columns.map((c) => c.header);
+
+    expect(headers).not.toContain('env');
+    expect(headers).toContain('value');
+    expect(headers).toContain('device');
+  });
+
+  it('uses custom header names from columnSettings', () => {
+    const spec: TableOptions = {
+      columnSettings: [
+        { name: 'value', header: 'Metric Value' },
+        { name: 'device', header: 'Disk Device' },
+      ],
+    };
+
+    const { columns } = buildTableData(singleQueryResult, spec);
+
+    const metricCol = columns.find((c) => c.key === 'value');
+    const deviceCol = columns.find((c) => c.key === 'device');
+    expect(metricCol?.header).toBe('Metric Value');
+    expect(deviceCol?.header).toBe('Disk Device');
+  });
+
+  it('orders columns by columnSettings first, then remaining data columns', () => {
+    const spec: TableOptions = {
+      columnSettings: [{ name: 'env' }, { name: 'device' }],
+    };
+
+    const { columns } = buildTableData(singleQueryResult, spec);
+    const headers = columns.map((c) => c.header);
+
+    // columnSettings columns appear first in order
+    expect(headers.indexOf('env')).toBeLessThan(headers.indexOf('device'));
+    // Remaining columns appear after
+    expect(headers.indexOf('device')).toBeLessThan(headers.indexOf('timestamp'));
+  });
+
+  it('hides all unlisted columns when defaultColumnHidden is true', () => {
+    const spec: TableOptions = {
+      defaultColumnHidden: true,
+      columnSettings: [{ name: 'value', header: 'Val' }, { name: 'env' }],
+    };
+
+    const { columns } = buildTableData(singleQueryResult, spec);
+    const headers = columns.map((c) => c.header);
+
+    expect(headers).toEqual(['Val', 'env']);
+  });
+
+  it('handles a query whose data has not loaded yet', () => {
+    const pendingResult: Array<PanelData<TimeSeriesData>> = [
+      {
+        definition: { kind: 'TimeSeriesQuery', spec: { plugin: { kind: 'P', spec: {} } } },
+      } as PanelData<TimeSeriesData>,
+    ];
+
+    const { data, columns } = buildTableData(pendingResult, {});
+
+    expect(data).toHaveLength(0);
+    expect(columns).toHaveLength(0);
+  });
+
+  it('returns label-only rows for series with no values', () => {
+    const emptyValuesResult: Array<PanelData<TimeSeriesData>> = [
+      makePanelData([{ name: 'empty', values: [], labels: { host: 'abc' } }]),
+    ];
+
+    const { data } = buildTableData(emptyValuesResult, {});
+
+    expect(data).toHaveLength(1);
+    expect(data[0]).toEqual(expect.objectContaining({ host: 'abc' }));
+    expect(data[0]).not.toHaveProperty('value');
+    expect(data[0]).not.toHaveProperty('timestamp');
+  });
+
+  it('omits timestamp and emits raw scalar values in range query mode', () => {
+    const spec: TableOptions = {
+      columnSettings: [{ name: 'value', plugin: { kind: 'StatChart', spec: {} } }],
+    };
+
+    const { data, columns } = buildTableData(singleQueryResult, spec);
+    const headers = columns.map((c) => c.header);
+
+    expect(headers).not.toContain('timestamp');
+    expect(data[0]).not.toHaveProperty('timestamp');
+    expect(data[0]?.['value']).toBe(0.277);
+  });
+});

--- a/table/src/TableExportAction.tsx
+++ b/table/src/TableExportAction.tsx
@@ -12,45 +12,99 @@
 // limitations under the License.
 
 import React, { useCallback, useMemo } from 'react';
-import { exportDataAsCSV, extractExportableData, isExportableData, sanitizeFilename } from '@perses-dev/plugin-system';
+import { escapeCsvValue, PanelData, sanitizeFilename } from '@perses-dev/plugin-system';
 import { InfoTooltip } from '@perses-dev/components';
 import { IconButton } from '@mui/material';
 import DownloadIcon from 'mdi-material-ui/Download';
+import { TimeSeriesData, transformData } from '@perses-dev/core';
 import { TableProps } from './components';
+import type { TableOptions } from './models';
+import { buildRawTableData } from './table-data-utils';
 
-export const TableExportAction: React.FC<TableProps> = ({ queryResults, definition }) => {
-  const exportableData = useMemo(() => {
-    return extractExportableData(queryResults);
-  }, [queryResults]);
+export interface ExportColumn {
+  key: string;
+  header: string;
+}
 
-  const canExport = useMemo(() => {
-    return isExportableData(exportableData);
-  }, [exportableData]);
+/**
+ * Converts raw query results into the same tabular structure that TablePanel
+ * renders, applying indexed column naming and configured transforms so the
+ * CSV output matches the visual table.
+ */
+export function buildTableData(
+  queryResults: Array<PanelData<TimeSeriesData>>,
+  spec: TableOptions
+): { data: Array<Record<string, unknown>>; columns: ExportColumn[] } {
+  // Use shared utility with forExport=true to get raw scalar values
+  const rawData = buildRawTableData(queryResults, spec, { forExport: true });
+
+  const transformed = transformData(rawData, spec.transforms ?? []);
+
+  const allKeys: string[] = [];
+  for (const entry of transformed) {
+    for (const key of Object.keys(entry)) {
+      if (!allKeys.includes(key)) allKeys.push(key);
+    }
+  }
+
+  const columnSettings = spec.columnSettings ?? [];
+  const columns: ExportColumn[] = [];
+  const customized = new Set<string>();
+
+  for (const col of columnSettings) {
+    if (customized.has(col.name)) continue;
+    customized.add(col.name);
+    if (col.hide) continue;
+    columns.push({ key: col.name, header: col.header ?? col.name });
+  }
+
+  if (!spec.defaultColumnHidden) {
+    for (const key of allKeys) {
+      if (!customized.has(key)) {
+        columns.push({ key, header: key });
+      }
+    }
+  }
+
+  return { data: transformed, columns };
+}
+
+export const TableExportAction: React.FC<TableProps> = ({ queryResults, spec, definition }) => {
+  const tableData = useMemo(() => buildTableData(queryResults, spec), [queryResults, spec]);
+
+  const canExport = tableData.data.length > 0 && tableData.columns.length > 0;
 
   const handleExport = useCallback(() => {
-    if (!exportableData || !canExport) return;
+    if (!canExport) return;
 
     try {
-      const title = definition?.spec?.display?.name || 'Time Series Data';
+      const title = definition?.spec?.display?.name || 'Table Data';
+      const { data, columns } = tableData;
 
-      const csvBlob = exportDataAsCSV({
-        data: exportableData,
-      });
+      const headerRow = columns.map((c) => escapeCsvValue(c.header)).join(',');
+      const dataRows = data.map((row) => columns.map((col) => escapeCsvValue(row[col.key])).join(','));
+
+      const csvString = [headerRow, ...dataRows].join('\n') + '\n';
+      const csvBlob = new Blob([csvString], { type: 'text/csv;charset=utf-8' });
 
       const baseFilename = sanitizeFilename(title);
       const filename = `${baseFilename}_data.csv`;
 
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(csvBlob);
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(link.href);
+      const url = URL.createObjectURL(csvBlob);
+      try {
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      } finally {
+        URL.revokeObjectURL(url);
+      }
     } catch (error) {
-      console.error('Time series export failed:', error);
+      console.error('Table CSV export failed:', error);
     }
-  }, [exportableData, canExport, definition]);
+  }, [canExport, tableData, definition]);
 
   if (!canExport) {
     return null;
@@ -58,7 +112,7 @@ export const TableExportAction: React.FC<TableProps> = ({ queryResults, definiti
 
   return (
     <InfoTooltip description="Export as CSV">
-      <IconButton size="small" onClick={handleExport} aria-label="Export time series data as CSV">
+      <IconButton size="small" onClick={handleExport} aria-label="Export table data as CSV">
         <DownloadIcon fontSize="inherit" />
       </IconButton>
     </InfoTooltip>

--- a/table/src/components/TablePanel.tsx
+++ b/table/src/components/TablePanel.tsx
@@ -13,7 +13,7 @@
 
 import { Box, Theme, Typography, useTheme } from '@mui/material';
 import { Table, TableCellConfigs, TableColumnConfig, useSelection } from '@perses-dev/components';
-import { formatValue, Labels, QueryDataType, TimeSeries, TimeSeriesData, transformData } from '@perses-dev/core';
+import { formatValue, QueryDataType, TimeSeriesData, transformData } from '@perses-dev/core';
 import { useSelectionItemActions } from '@perses-dev/dashboards';
 import {
   ActionOptions,
@@ -26,6 +26,7 @@ import {
 import { ColumnFiltersState, PaginationState, RowSelectionState, SortingState } from '@tanstack/react-table';
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ColumnSettings, evaluateConditionalFormatting, TableOptions } from '../models';
+import { buildRawTableData, getTablePanelQueryMode } from '../table-data-utils';
 import { EmbeddedPanel } from './EmbeddedPanel';
 
 function generateCellContentConfig(
@@ -203,7 +204,7 @@ function generateColumnConfig(
 export function getTablePanelQueryOptions(spec: TableOptions): { mode: 'instant' | 'range' } {
   // if any cell renders a panel plugin, perform a range query instead of an instant query
   return {
-    mode: (spec.columnSettings ?? []).some((c) => c.plugin) ? 'range' : 'instant',
+    mode: getTablePanelQueryMode(spec),
   };
 }
 
@@ -258,43 +259,10 @@ export function TablePanel({ contentDimensions, spec, queryResults }: TableProps
   );
 
   // TODO: handle other query types
-  const queryMode = getTablePanelQueryOptions(spec).mode;
   const rawData: Array<Record<string, unknown>> = useMemo(() => {
-    // Transform query results to a tabular format:
-    // [ { timestamp: 123, value: 456, labelName1: labelValue1 }, ... ]
-    return queryResults
-      .flatMap((data: PanelData<TimeSeriesData>, queryIndex: number) =>
-        data.data.series.map((ts: TimeSeries) => ({ data, ts, queryIndex }))
-      )
-      .map(({ data, ts, queryIndex }: { data: PanelData<TimeSeriesData>; ts: TimeSeries; queryIndex: number }) => {
-        if (ts.values[0] === undefined) {
-          return { ...ts.labels };
-        }
-
-        // If there are multiple queries, we need to add the query index to the value key and label key to avoid conflicts
-        const valueColumnName = queryResults.length === 1 ? 'value' : `value #${queryIndex + 1}`;
-        const labels =
-          queryResults.length === 1
-            ? ts.labels
-            : Object.entries(ts.labels ?? {}).reduce((acc, [key, value]) => {
-                if (key) acc[`${key} #${queryIndex + 1}`] = value;
-                return acc;
-              }, {} as Labels);
-
-        // If the cell visualization is a panel plugin, filter the data by the current series
-        const columnValue = (spec.columnSettings ?? []).find((x) => x.name === valueColumnName)?.plugin
-          ? { ...data, data: { ...data.data, series: data.data.series.filter((s) => s === ts) } }
-          : ts.values[0][1];
-
-        if (queryMode === 'instant') {
-          // Timestamp is not indexed as it will be the same for all queries
-          return { timestamp: ts.values[0][0], [valueColumnName]: columnValue, ...labels };
-        } else {
-          // Don't add a timestamp for range queries
-          return { [valueColumnName]: columnValue, ...labels };
-        }
-      });
-  }, [queryResults, queryMode, spec.columnSettings]);
+    // Transform query results to a tabular format using shared utility
+    return buildRawTableData(queryResults, spec);
+  }, [queryResults, spec]);
 
   // Transform will be applied by their orders on the original data
   const data = useMemo(() => transformData(rawData, spec.transforms ?? []), [rawData, spec.transforms]);

--- a/table/src/table-data-utils.ts
+++ b/table/src/table-data-utils.ts
@@ -1,0 +1,96 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Labels, TimeSeries, TimeSeriesData } from '@perses-dev/core';
+import { PanelData } from '@perses-dev/plugin-system';
+import { TableOptions } from './models';
+
+/**
+ * Options for building raw table data.
+ */
+export interface BuildRawTableDataOptions {
+  /**
+   * When true, always use raw scalar values for cell data (for export).
+   * When false, plugin columns will contain embedded PanelData objects (for rendering).
+   */
+  forExport?: boolean;
+}
+
+/**
+ * Determines the query mode based on table options.
+ * If any column has a plugin (embedded panel), use range mode; otherwise instant.
+ */
+export function getTablePanelQueryMode(spec: TableOptions): 'instant' | 'range' {
+  return (spec.columnSettings ?? []).some((c) => c.plugin) ? 'range' : 'instant';
+}
+
+/**
+ * Converts raw query results into a tabular format.
+ *
+ * This is the shared data-building logic used by both TablePanel (for rendering)
+ * and TableExportAction (for CSV export). Extracting this ensures both use the
+ * same transformation logic, reducing drift.
+ *
+ * @param queryResults - The panel query results containing time series data
+ * @param spec - The table options specification
+ * @param options - Build options (e.g., forExport mode)
+ * @returns Array of row objects with column keys and values
+ */
+export function buildRawTableData(
+  queryResults: Array<PanelData<TimeSeriesData>>,
+  spec: TableOptions,
+  options: BuildRawTableDataOptions = {}
+): Array<Record<string, unknown>> {
+  const { forExport = false } = options;
+  const queryMode = getTablePanelQueryMode(spec);
+
+  return queryResults
+    .flatMap((data: PanelData<TimeSeriesData>, queryIndex: number) =>
+      (data.data?.series ?? []).map((ts: TimeSeries) => ({ data, ts, queryIndex }))
+    )
+    .map(({ data, ts, queryIndex }: { data: PanelData<TimeSeriesData>; ts: TimeSeries; queryIndex: number }) => {
+      if (ts.values[0] === undefined) {
+        return { ...ts.labels };
+      }
+
+      // If there are multiple queries, add query index to value key and label keys to avoid conflicts
+      const valueColumnName = queryResults.length === 1 ? 'value' : `value #${queryIndex + 1}`;
+      const labels =
+        queryResults.length === 1
+          ? ts.labels
+          : Object.entries(ts.labels ?? {}).reduce((acc, [key, value]) => {
+              if (key) acc[`${key} #${queryIndex + 1}`] = value;
+              return acc;
+            }, {} as Labels);
+
+      // For export: always use raw scalar values
+      // For rendering: plugin columns get embedded PanelData objects
+      let columnValue: unknown;
+      if (forExport) {
+        columnValue = ts.values[0][1];
+      } else {
+        const hasPlugin = (spec.columnSettings ?? []).find((x) => x.name === valueColumnName)?.plugin;
+        columnValue = hasPlugin
+          ? { ...data, data: { ...data.data, series: data.data.series.filter((s) => s === ts) } }
+          : ts.values[0][1];
+      }
+
+      if (queryMode === 'instant') {
+        // Timestamp is not indexed as it will be the same for all queries
+        return { timestamp: ts.values[0][0], [valueColumnName]: columnValue, ...labels };
+      } else {
+        // Don't add a timestamp for range queries
+        return { [valueColumnName]: columnValue, ...labels };
+      }
+    });
+}


### PR DESCRIPTION
# Description

Fixes https://github.com/perses/perses/issues/3984

The Table panel CSV export used `extractExportableData` and `exportDataAsCSV` from `@perses-dev/plugin-system`, which operate on raw time series data. For multi-query tables with `MergeSeries` transforms, this produced duplicate label-based columns with overwritten values instead of the merged tabular output the user sees.

This rewrites `TableExportAction` so that the CSV export mirrors the exact data pipeline used by `TablePanel`:

- Converts query results to flat rows with indexed column names (`value #1`, `value #2`, `label #N`) matching `TablePanel`'s rawData logic
- Uses `data.data?.series ?? []` (optional chaining) to handle not-yet-loaded queries gracefully
- Always uses the raw scalar `ts.values[0][1]` for export (skips embedded panel plugin objects)
- Calls `transformData(rawData, spec.transforms ?? [])` to apply `MergeSeries`, `JoinByColumnValue`, etc.
- Derives visible columns from `spec.columnSettings`, respecting `hide`, custom `header` names, column order, and `defaultColumnHidden`
- Generates CSV from the post-transform tabular data using column headers instead of series legend names
- Fixes an object URL leak by revoking in a `finally` block

Extracts shared data-building helpers (`buildRawTableData`, `getVisibleColumns`) into a new `table-data-utils.ts` module. These functions were refactored out of `TablePanel` so that both `TablePanel` and `TableExportAction` use the same code path for constructing tabular data, ensuring the exported CSV always matches what the user sees in the table.

Also adds a comprehensive test suite (`TableExportAction.test.ts`, 11 tests) covering:
- Single-query and multi-query tabular output
- `MergeSeries` and `JoinByColumnValue` transforms
- Column settings: hide, custom headers, ordering, `defaultColumnHidden`
- Edge cases: unloaded queries, empty series, plugin columns, range query mode

# Screenshots

N/A — no UI changes; the export button behavior is unchanged, only the CSV content is corrected.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] N/A — Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] N/A — Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).