### PR TITLE
[BUGFIX] PieChart: fix missing Calculation in Go SDK

### DIFF
--- a/piechart/sdk/go/options.go
+++ b/piechart/sdk/go/options.go
@@ -15,6 +15,13 @@ package pie
 
 import "github.com/perses/perses/go-sdk/common"
 
+func Calculation(calculation common.Calculation) Option {
+	return func(builder *Builder) error {
+		builder.Calculation = calculation
+		return nil
+	}
+}
+
 func WithLegend(legend Legend) Option {
 	return func(builder *Builder) error {
 		builder.Legend = &legend

--- a/piechart/sdk/go/pie.go
+++ b/piechart/sdk/go/pie.go
@@ -136,7 +136,11 @@ func create(options ...Option) (Builder, error) {
 		PluginSpec: PluginSpec{},
 	}
 
-	for _, opt := range options {
+	defaults := []Option{
+		Calculation(common.LastCalculation),
+	}
+
+	for _, opt := range append(defaults, options...) {
 		if err := opt(builder); err != nil {
 			return *builder, err
 		}


### PR DESCRIPTION

# Description

Piechart Go SDK is missing Calculation option similar to statpanel options that has Calculation set as default -> https://github.com/perses/plugins/blob/bd89fa12e4c0df616548110ef8127c70874570ef/statchart/sdk/go/stat.go#L48

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).