### PR TITLE
[FEATURE] add test connection button to prometheus plugin

### DIFF
--- a/prometheus/src/plugins/PrometheusDatasourceEditor.tsx
+++ b/prometheus/src/plugins/PrometheusDatasourceEditor.tsx
@@ -13,7 +13,7 @@
 
 import { Box, IconButton, TextField, Typography } from '@mui/material';
 import { QueryParamValues } from '@perses-dev/components';
-import { HTTPSettingsEditor } from '@perses-dev/plugin-system';
+import { HTTPSettingsEditor, DatasourceEditorProps } from '@perses-dev/plugin-system';
 import MinusIcon from 'mdi-material-ui/Minus';
 import PlusIcon from 'mdi-material-ui/Plus';
 import { ReactElement, useRef, useState } from 'react';
@@ -27,14 +27,10 @@ interface QueryParamEntry {
   value: string;
 }
 
-export interface PrometheusDatasourceEditorProps {
-  value: PrometheusDatasourceSpec;
-  onChange: (next: PrometheusDatasourceSpec) => void;
-  isReadonly?: boolean;
-}
+export type PrometheusDatasourceEditorProps = DatasourceEditorProps<PrometheusDatasourceSpec>;
 
 export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProps): ReactElement {
-  const { value, onChange, isReadonly } = props;
+  const { value, onChange, isReadonly, testConnection } = props;
 
   // Counter for generating unique IDs
   const nextIdRef = useRef(0);
@@ -171,6 +167,7 @@ export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProp
         isReadonly={isReadonly}
         initialSpecDirect={initialSpecDirect}
         initialSpecProxy={initialSpecProxy}
+        testConnection={testConnection}
       />
       <Typography variant="h5" mt={2} mb={1}>
         Query Parameters

--- a/prometheus/src/plugins/PrometheusDatasourceEditor.tsx
+++ b/prometheus/src/plugins/PrometheusDatasourceEditor.tsx
@@ -13,6 +13,7 @@
 
 import { Box, IconButton, TextField, Typography } from '@mui/material';
 import type { QueryParamValues } from '@perses-dev/components';
+import type { DatasourceEditorProps } from '@perses-dev/plugin-system';
 import { HTTPSettingsEditor } from '@perses-dev/plugin-system';
 import type { DurationString } from '@perses-dev/spec';
 import MinusIcon from 'mdi-material-ui/Minus';
@@ -30,14 +31,10 @@ interface QueryParamEntry {
   value: string;
 }
 
-export interface PrometheusDatasourceEditorProps {
-  value: PrometheusDatasourceSpec;
-  onChange: (next: PrometheusDatasourceSpec) => void;
-  isReadonly?: boolean;
-}
+export type PrometheusDatasourceEditorProps = DatasourceEditorProps<PrometheusDatasourceSpec>;
 
 export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProps): ReactElement {
-  const { value, onChange, isReadonly } = props;
+  const { value, onChange, isReadonly, testConnection } = props;
 
   // Counter for generating unique IDs
   const nextIdRef = useRef(0);
@@ -174,6 +171,7 @@ export function PrometheusDatasourceEditor(props: PrometheusDatasourceEditorProp
         isReadonly={isReadonly}
         initialSpecDirect={initialSpecDirect}
         initialSpecProxy={initialSpecProxy}
+        testConnection={testConnection}
       />
       <Typography variant="h5" mt={2} mb={1}>
         Query Parameters

--- a/prometheus/src/plugins/prometheus-datasource.tsx
+++ b/prometheus/src/plugins/prometheus-datasource.tsx
@@ -128,4 +128,5 @@ export const PrometheusDatasource: DatasourcePlugin<PrometheusDatasourceSpec, Pr
   getBuiltinVariableDefinitions,
   OptionsEditorComponent: PrometheusDatasourceEditor,
   createInitialOptions: () => ({ directUrl: '' }),
+  healthCheckPath: '/api/v1/status/buildinfo',
 };

--- a/prometheus/src/plugins/prometheus-datasource.tsx
+++ b/prometheus/src/plugins/prometheus-datasource.tsx
@@ -129,4 +129,5 @@ export const PrometheusDatasource: DatasourcePlugin<PrometheusDatasourceSpec, Pr
   getBuiltinVariableDefinitions,
   OptionsEditorComponent: PrometheusDatasourceEditor,
   createInitialOptions: () => ({ directUrl: '' }),
+  healthCheckPath: '/api/v1/status/buildinfo',
 };


### PR DESCRIPTION
Related pull requests (in order): 
1. https://github.com/perses/perses/pull/4007
2. https://github.com/perses/shared/pull/99
3. **[This one](https://github.com/perses/perses/pull/4008)**
4. https://github.com/perses/perses/pull/4302
5. **[This one](https://github.com/perses/plugins/pull/620)**

Related issue: 
https://github.com/perses/perses/issues/1542

# Description
Uses "/api/v1/status/buildinfo" instead of "/-/healthy" because from what I tested and found out, the config for CORS on prometheus side is applied on "/api/*" path. So by using "/-/healthy" the direct access test connection would not work.

# Screenshots
Edit: 


https://github.com/user-attachments/assets/2e996b66-3fdc-44ed-a104-2cdbe70e6476


# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
