### PR TITLE
[FEATURE] LogsTable: add Grafana migration script

### DIFF
--- a/logstable/schemas/migrate/migrate.cue
+++ b/logstable/schemas/migrate/migrate.cue
@@ -1,0 +1,29 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+#grafanaType: "logs"
+#panel:       _
+
+kind: "LogsTable"
+spec: {
+	if #panel.options.wrapLogMessage != _|_ {
+		allowWrap: #panel.options.wrapLogMessage
+	}
+	if #panel.options.showTime != _|_ {
+		showTime: #panel.options.showTime
+	}
+	#enableLogDetails: *#panel.options.enableLogDetails | true
+	enableDetails:     #enableLogDetails
+}

--- a/logstable/schemas/migrate/tests/basic/expected.json
+++ b/logstable/schemas/migrate/tests/basic/expected.json
@@ -1,0 +1,8 @@
+{
+  "kind": "LogsTable",
+  "spec": {
+    "allowWrap": true,
+    "enableDetails": true,
+    "showTime": true
+  }
+}

--- a/logstable/schemas/migrate/tests/basic/input.json
+++ b/logstable/schemas/migrate/tests/basic/input.json
@@ -1,0 +1,22 @@
+{
+  "datasource": {
+    "uid": "loki"
+  },
+  "options": {
+    "showLabels": false,
+    "showTime": true,
+    "sortOrder": "Descending",
+    "wrapLogMessage": true
+  },
+  "targets": [
+    {
+      "datasource": {
+        "uid": "loki"
+      },
+      "expr": "{pod_name=~\"$pod\"} |~ \"$search\"",
+      "refId": "A"
+    }
+  ],
+  "title": "Logs Panel",
+  "type": "logs"
+}

--- a/logstable/schemas/migrate/tests/details-disabled/expected.json
+++ b/logstable/schemas/migrate/tests/details-disabled/expected.json
@@ -1,0 +1,8 @@
+{
+  "kind": "LogsTable",
+  "spec": {
+    "allowWrap": false,
+    "enableDetails": false,
+    "showTime": false
+  }
+}

--- a/logstable/schemas/migrate/tests/details-disabled/input.json
+++ b/logstable/schemas/migrate/tests/details-disabled/input.json
@@ -1,0 +1,23 @@
+{
+  "datasource": {
+    "uid": "loki"
+  },
+  "options": {
+    "enableLogDetails": false,
+    "showLabels": false,
+    "showTime": false,
+    "sortOrder": "Descending",
+    "wrapLogMessage": false
+  },
+  "targets": [
+    {
+      "datasource": {
+        "uid": "loki"
+      },
+      "expr": "{job=\"nginx\"}",
+      "refId": "A"
+    }
+  ],
+  "title": "Logs",
+  "type": "logs"
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Add a Grafana migration script (`migrate.cue`) for the LogsTable plugin, enabling automatic conversion of Grafana `logs` panels to Perses `LogsTable` panels via `percli migrate`.

The migration maps the following Grafana panel options to LogsTable spec fields:
- `options.wrapLogMessage` to `allowWrap`
- `options.showTime` to `showTime`
- `options.enableLogDetails` to `enableDetails` (defaults to `true` if absent)

Options without a LogsTable equivalent (`showLabels`, `sortOrder`, `dedupStrategy`) are not migrated.

>[!NOTE]
>This PR covers panel migration only. Query migration for Loki targets is not included: The Prometheus query migration script currently matches any target with an `expr` field (including Loki targets) due to a greedy catch-all, and `percli` has no way to prioritize a more specific match as far as I can tell.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
