### PR TITLE
[BUGFIX] TimeSeriesChart: don't fail migration on undefined refId

### DIFF
--- a/timeserieschart/schemas/migrate/migrate.cue
+++ b/timeserieschart/schemas/migrate/migrate.cue
@@ -196,8 +196,8 @@ spec: {
 			for override in (*#panel.fieldConfig.overrides | [])
 			if (override.matcher.id == "byName" || override.matcher.id == "byRegexp" || override.matcher.id == "byFrameRefID") && override.matcher.options != _|_
 			for property in override.properties
-			if (override.matcher.id == "byName" || override.matcher.id == "byRegexp") && (target.legendFormat == override.matcher.options || target.legendFormat =~ strings.Trim(override.matcher.options, "/")) ||
-				(override.matcher.id == "byFrameRefID" && target.refId == override.matcher.options) {
+			if (override.matcher.id == "byName" || override.matcher.id == "byRegexp") && ((*target.legendFormat | null) == override.matcher.options || (*target.legendFormat | null) =~ strings.Trim(override.matcher.options, "/")) ||
+				(override.matcher.id == "byFrameRefID" && (*target.refId | null) == override.matcher.options) {
 				if property.id == "color" if (*property.value.fixedColor | null) != null {
 					colorMode:  "fixed"
 					colorValue: *commonMigrate.#mapping.color[property.value.fixedColor] | property.value.fixedColor

--- a/timeserieschart/schemas/migrate/tests/undefined-refId/expected.json
+++ b/timeserieschart/schemas/migrate/tests/undefined-refId/expected.json
@@ -1,0 +1,23 @@
+{
+  "kind": "TimeSeriesChart",
+  "spec": {
+   "legend": {
+     "mode": "table",
+      "position": "bottom",
+      "values": [
+        "first",
+        "min",
+        "max",
+        "last"
+      ]
+    },
+    "visual": {
+      "connectNulls": false
+    },
+    "yAxis": {
+      "format": {
+        "unit": "decimal"
+      }
+    }
+  }
+}

--- a/timeserieschart/schemas/migrate/tests/undefined-refId/input.json
+++ b/timeserieschart/schemas/migrate/tests/undefined-refId/input.json
@@ -1,0 +1,73 @@
+{
+  "datasource": {
+    "type": "datasource",
+    "uid": "$Datasource"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "custom": {
+        "spanNulls": false
+      },
+      "unit": "none"
+    },
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byRegexp",
+          "options": "sum"
+        },
+        "properties": [
+          {
+            "id": "custom.axisPlacement",
+            "value": "right"
+          },
+          {
+            "id": "custom.axisLabel",
+            "value": "sum"
+          }
+        ]
+      }
+    ]
+  },
+  "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 19
+  },
+  "id": 50,
+  "options": {
+    "legend": {
+      "calcs": [
+        "first",
+        "min",
+        "max",
+        "last"
+      ],
+      "displayMode": "table",
+      "placement": "bottom",
+      "showLegend": true,
+      "sortBy": "Max",
+      "sortDesc": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "pluginVersion": "v10.1.0",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$Datasource"
+      },
+      "expr": "node_filesystem_files{fstype!=\"\",mountpoint=\"/run\"} - node_filesystem_files_free{fstype!=\"\",mountpoint=\"/run\"}",
+      "format": "time_series",
+      "intervalFactor": 2,
+      "legendFormat": "{{instance}}"
+    }
+  ],
+  "title": "inodes count in /run",
+  "type": "timeseries"
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Closes https://github.com/perses/perses/issues/3983.
The fix consist in adding "fallback to null" for the refId attribute, just like we have in most places. - more context about why we are doing this [here](https://github.com/perses/perses/issues/3983#issuecomment-4201649540).

NB: I applied the same logic for the `legendFormat` attribute too, just in case..

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).