### PR TITLE
[BUGFIX] Table: don't fail migration on transform duplicates

### DIFF
--- a/table/schemas/migrate/migrate.cue
+++ b/table/schemas/migrate/migrate.cue
@@ -59,16 +59,34 @@ spec: {
 		}
 
 		// Retrieve the settings defined in transformations
-		_columnSettingsFromTansform: {
+		// We collect possible values first, then resolve to the last one to mimic Grafana precedence.
+		_columnSettingsFromTransformRaw: {
 			for transformation in (*#panel.transformations | []) if transformation.id == "organize" {
 				for columnName, columnIndex in (*transformation.options.indexByName | {}) {
-					"\({_renameAnonymousFields & {#var: columnName}}.output)": index: columnIndex
+					"\({_renameAnonymousFields & {#var: columnName}}.output)": indexes: "\(columnIndex)": true
 				}
 				for columnName, hidden in (*transformation.options.excludeByName | {}) {
-					"\({_renameAnonymousFields & {#var: columnName}}.output)": hide: hidden
+					"\({_renameAnonymousFields & {#var: columnName}}.output)": hides: "\(hidden)": true
 				}
 				for columnName, displayName in (*transformation.options.renameByName | {}) {
-					"\({_renameAnonymousFields & {#var: columnName}}.output)": header: displayName
+					"\({_renameAnonymousFields & {#var: columnName}}.output)": headers: "\(displayName)": true
+				}
+			}
+		}
+		_columnSettingsFromTransform: {
+			for name, settings in _columnSettingsFromTransformRaw {
+				"\(name)": {
+					if settings.indexes != _|_ if len(settings.indexes) > 0 {
+						_index: {_getLastKey & {#map: settings.indexes}}.output
+						index: strconv.Atoi(_index)
+					}
+					if settings.hides != _|_ if len(settings.hides) > 0 {
+						_hide: {_getLastKey & {#map: settings.hides}}.output
+						hide: _hide == "true"
+					}
+					if settings.headers != _|_ if len(settings.headers) > 0 {
+						header: {_getLastKey & {#map: settings.headers}}.output
+					}
 				}
 			}
 		}
@@ -78,7 +96,7 @@ spec: {
 			#var: string
 			output: [
 				// Check if the column was renamed by a transform
-				for k, v in _columnSettingsFromTansform if #var == (*v.header | null) {k},
+				for k, v in _columnSettingsFromTransform if #var == (*v.header | null) {k},
 				{_renameAnonymousFields & {#var: this.#var}}.output,
 			][0]
 		}
@@ -131,7 +149,7 @@ spec: {
 					}
 				}
 			}
-			for name, settings in _columnSettingsFromTansform {
+			for name, settings in _columnSettingsFromTransform {
 				"\(name)": [
 					// We have to hande potential name conflicts due to the overrides.
 					// In Grafana field overrides take precedence over the organize transformations.

--- a/table/schemas/migrate/tests/conflicting-rename-using-organize/expected.json
+++ b/table/schemas/migrate/tests/conflicting-rename-using-organize/expected.json
@@ -1,0 +1,12 @@
+{
+  "kind": "Table",
+  "spec": {
+    "columnSettings": [
+      {
+        "header": "Instance",
+        "name": "instance"
+      }
+    ],
+    "density": "compact"
+  }
+}

--- a/table/schemas/migrate/tests/conflicting-rename-using-organize/input.json
+++ b/table/schemas/migrate/tests/conflicting-rename-using-organize/input.json
@@ -1,0 +1,30 @@
+{
+  "type": "table",
+  "options": {
+    "cellHeight": "sm"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "mappings": []
+    },
+    "overrides": []
+  },
+  "transformations": [
+    {
+      "id": "organize",
+      "options": {
+        "renameByName": {
+          "instance": "instance"
+        }
+      }
+    },
+    {
+      "id": "organize",
+      "options": {
+        "renameByName": {
+          "instance": "Instance"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Closes https://github.com/perses/perses/issues/4009.

The fix follows the same logic as we have for other attributes of the Table panel = gather (conflicting) possibilities first & then pick the last one encountered.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
