### PR TITLE
[ENHANCEMENT] Table: add DataLink support to Go SDK

### DIFF
--- a/docs/table/go-sdk.md
+++ b/docs/table/go-sdk.md
@@ -53,11 +53,18 @@ table.WithColumnSettings([]table.ColumnSettings{
 			Unit:          &common.DecimalUnit,
 			DecimalPlaces: 2,
 		},
+		DataLink: &table.DataLink{
+			URL:        "http://example.com/details/${__data.fields[\"metric_name\"]}",
+			OpenNewTab: true,
+			Title:      "View details",
+		},
 	},
 })
 ```
 
 Configure individual columns. Available align options: `LeftAlign`, `CenterAlign`, `RightAlign`. Available sort options: `AscSort`, `DescSort`.
+
+The `DataLink` field allows adding a clickable link to cells in the column. It supports variable substitution in the URL (e.g., `${__data.fields["column_name"]}`).
 
 ### WithCellSettings
 

--- a/docs/table/model.md
+++ b/docs/table/model.md
@@ -26,6 +26,15 @@ enableSorting: <boolean> # Optional
 sort: <enum = "asc" | "desc"> # Optional
 width: <anyOf = number | "auto"> # Optional
 hide: <boolean> # Optional
+dataLink: <Data Link specification> # Optional
+```
+
+## Data Link specification
+
+```yaml
+url: <string> # Required. Supports variable substitution (e.g., ${__data.fields["column_name"]})
+title: <string> # Optional
+openNewTab: <boolean> # Required
 ```
 
 ## Cell Settings specification

--- a/table/sdk/go/table.go
+++ b/table/sdk/go/table.go
@@ -46,6 +46,12 @@ const (
 	DescSort Sort = "desc"
 )
 
+type DataLink struct {
+	URL        string `json:"url" yaml:"url"`
+	Title      string `json:"title,omitempty" yaml:"title,omitempty"`
+	OpenNewTab bool   `json:"openNewTab" yaml:"openNewTab"`
+}
+
 type ColumnSettings struct {
 	Name              string         `json:"name" yaml:"name"`
 	Header            string         `json:"header,omitempty" yaml:"header,omitempty"`
@@ -58,6 +64,7 @@ type ColumnSettings struct {
 	Width             float64        `json:"width,omitempty" yaml:"width,omitempty"`
 	Hide              bool           `json:"hide,omitempty" yaml:"hide,omitempty"`
 	CellSettings      []CellSettings `json:"cellSettings,omitempty" yaml:"cellSettings,omitempty"`
+	DataLink          *DataLink      `json:"dataLink,omitempty" yaml:"dataLink,omitempty"`
 }
 
 type ValueConditionSpec struct {


### PR DESCRIPTION
The CUE schema and TypeScript types already supported dataLink on column settings, but the Go SDK was missing it. Add DataLink struct and field to ColumnSettings so Go clients can configure per-column links programmatically.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
