### PR TITLE
[BUGFIX] PrometheusTimeSeriesQuery: Grafana migration: don't match non-prom queries when `type` is set

### DIFF
--- a/prometheus/schemas/prometheus-time-series-query/migrate/migrate.cue
+++ b/prometheus/schemas/prometheus-time-series-query/migrate/migrate.cue
@@ -14,13 +14,14 @@
 package migrate
 
 #target: {
-	// /!\ Best-effort conversion logic that may wrongly convert not-prometheus queries to PrometheusTimeSeriesQuery:
-	// Ideally we should rely on datasource.type = "prometheus" to identify prometheus queries. But in some cases,
-	// this information is not be available. Thus the condition relies on the presence of the "expr" field, that
-	// likely indicates that this is a prometheus query.
 	datasource?: {
-		uid: string
+		type?: "prometheus"
+		uid:   string
 	}
+	// /!\ Best-effort conversion logic that may wrongly convert not-prometheus queries to PrometheusTimeSeriesQuery:
+	// Ideally we should only rely on datasource.type = "prometheus" to identify prometheus queries. But in some cases,
+	// this information is not present. Thus, in addition to the check on the optional type above, the below condition
+	// relies on the presence of the "expr" field, that likely indicates that this is a prometheus query.
 	expr:          string
 	legendFormat?: string
 	interval?:     string

--- a/prometheus/schemas/prometheus-time-series-query/migrate/tests/legend-format/input.json
+++ b/prometheus/schemas/prometheus-time-series-query/migrate/tests/legend-format/input.json
@@ -1,5 +1,6 @@
 {
   "datasource": {
+    "type": "prometheus",
     "uid": "${datasource}"
   },
   "editorMode": "code",


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Closes https://github.com/perses/perses/issues/4013.

This PR reduces the "greediness" of the PrometheusTimeSeriesQuery migration logic by ensuring it's not matched when the datasource's `type` is explicitly set with another value than "prometheus". It doesn't change the current behavior when `type` is not set.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
