### PR TITLE
[FEATURE] Loki: add query migration script for log queries

### DIFF
--- a/loki/schemas/queries/loki-log-query/migrate/migrate.cue
+++ b/loki/schemas/queries/loki-log-query/migrate/migrate.cue
@@ -1,0 +1,34 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+#target: {
+	datasource: {
+		type: "loki"
+		...
+	}
+	expr: string
+	...
+}
+
+kind: "LokiLogQuery"
+spec: {
+	if #target.datasource.uid != _|_ {
+		datasource: {
+			kind: "LokiDatasource"
+			name: #target.datasource.uid
+		}
+	}
+	query: #target.expr
+}

--- a/loki/schemas/queries/loki-log-query/migrate/tests/basic/expected.json
+++ b/loki/schemas/queries/loki-log-query/migrate/tests/basic/expected.json
@@ -1,0 +1,10 @@
+{
+  "kind": "LokiLogQuery",
+  "spec": {
+    "datasource": {
+      "kind": "LokiDatasource",
+      "name": "loki"
+    },
+    "query": "{container=\"nginx\"}"
+  }
+}

--- a/loki/schemas/queries/loki-log-query/migrate/tests/basic/input.json
+++ b/loki/schemas/queries/loki-log-query/migrate/tests/basic/input.json
@@ -1,0 +1,8 @@
+{
+  "datasource": {
+    "type": "loki",
+    "uid": "loki"
+  },
+  "expr": "{container=\"nginx\"}",
+  "refId": "A"
+}

--- a/loki/schemas/queries/loki-log-query/migrate/tests/no-uid/expected.json
+++ b/loki/schemas/queries/loki-log-query/migrate/tests/no-uid/expected.json
@@ -1,0 +1,6 @@
+{
+  "kind": "LokiLogQuery",
+  "spec": {
+    "query": "{job=\"nginx\"} |= \"error\""
+  }
+}

--- a/loki/schemas/queries/loki-log-query/migrate/tests/no-uid/input.json
+++ b/loki/schemas/queries/loki-log-query/migrate/tests/no-uid/input.json
@@ -1,0 +1,7 @@
+{
+  "datasource": {
+    "type": "loki"
+  },
+  "expr": "{job=\"nginx\"} |= \"error\"",
+  "refId": "A"
+}

--- a/loki/schemas/queries/loki-log-query/migrate/tests/with-pipe-filter/expected.json
+++ b/loki/schemas/queries/loki-log-query/migrate/tests/with-pipe-filter/expected.json
@@ -1,0 +1,10 @@
+{
+  "kind": "LokiLogQuery",
+  "spec": {
+    "datasource": {
+      "kind": "LokiDatasource",
+      "name": "loki"
+    },
+    "query": "{pod_name=~\"$pod\"} |~ \"$search\""
+  }
+}

--- a/loki/schemas/queries/loki-log-query/migrate/tests/with-pipe-filter/input.json
+++ b/loki/schemas/queries/loki-log-query/migrate/tests/with-pipe-filter/input.json
@@ -1,0 +1,8 @@
+{
+  "datasource": {
+    "type": "loki",
+    "uid": "loki"
+  },
+  "expr": "{pod_name=~\"$pod\"} |~ \"$search\"",
+  "refId": "A"
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Add a Grafana migration script for Loki log queries (`loki-log-query`), enabling `percli migrate` to convert Grafana Loki targets to `LokiLogQuery`.

The script matches targets where `datasource.type` is `"loki"` and maps
- `expr` to `query`
- `datasource.uid` to datasource reference with `kind: LokiDatasource`

> [!NOTE]
> This PR covers panel targets with an explicit `datasource.type: "loki"`. Targets without type info may still be caught by the Prometheus migration script (https://github.com/perses/plugins/pull/632). The Prometheus migration still matches targets which have `expr` set but no explicit `type` set to Loki.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- n/a