### PR TITLE
[BUGFIX] TracingGanttChart: fix attribute pane resizing

### DIFF
--- a/tracingganttchart/src/TracingGanttChart/GanttTable/ResizableDivider.tsx
+++ b/tracingganttchart/src/TracingGanttChart/GanttTable/ResizableDivider.tsx
@@ -36,8 +36,12 @@ export function ResizableDivider(props: ResizableDividerProps): ReactElement {
   const handleMouseMove = useEvent((e: MouseEvent) => {
     if (!parentRef.current) return;
 
-    const offsetX = e.clientX - parentRef.current.getBoundingClientRect().left + spacing;
-    const leftPercent = offsetX / parentRef.current.getBoundingClientRect().width;
+    const parentRect = parentRef.current.getBoundingClientRect();
+
+    // The parent can be a flex row, for example: [leftPercent] [gap] [divider] [gap] [1-leftPercent].
+    // Without considering spacing, leftPercent would be wrong because it ignores the flex gap between the divider and the element.
+    const offsetX = e.clientX - parentRect.left + spacing;
+    const leftPercent = offsetX / parentRect.width;
 
     if (0.05 <= leftPercent && leftPercent <= 0.95) {
       onMove(leftPercent);
@@ -81,6 +85,7 @@ export function ResizableDivider(props: ResizableDividerProps): ReactElement {
 const ResizableDividerBox = styled(Box)(({ theme }) => ({
   position: 'relative',
   width: '1px',
+  minWidth: '1px',
   height: '100%',
   backgroundColor: theme.palette.divider,
   cursor: 'col-resize',

--- a/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TracingGanttChart.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { ReactElement, useMemo, useRef, useState } from 'react';
-import { Box, Stack, useTheme } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { otlptracev1 } from '@perses-dev/core';
 import { CustomLinks, TracingGanttChartOptions } from '../gantt-chart-model';
 import { MiniGanttChart } from './MiniGanttChart/MiniGanttChart';
@@ -39,7 +39,6 @@ export interface TracingGanttChartProps {
 export function TracingGanttChart(props: TracingGanttChartProps): ReactElement {
   const { options, customLinks, trace: otlpTrace } = props;
 
-  const theme = useTheme();
   const trace = useMemo(() => {
     try {
       return getTraceModel(otlpTrace);
@@ -60,6 +59,7 @@ export function TracingGanttChart(props: TracingGanttChartProps): ReactElement {
   // setTableWidth() is only called by <ResizableDivider />
   const [tableWidth, setTableWidth] = useState<number>(0.82);
   const gap = 2;
+  const spacing = ganttChart.current ? parseFloat(getComputedStyle(ganttChart.current).columnGap) || 0 : 0;
 
   return (
     <Stack ref={ganttChart} direction="row" sx={{ height: '100%', minHeight: '240px', gap }}>
@@ -79,8 +79,14 @@ export function TracingGanttChart(props: TracingGanttChartProps): ReactElement {
       </Stack>
       {selectedSpan && (
         <>
-          <ResizableDivider parentRef={ganttChart} spacing={parseInt(theme.spacing(gap))} onMove={setTableWidth} />
-          <Box style={{ width: `${(1 - tableWidth) * 100}%` }} sx={{ overflow: 'auto' }}>
+          <ResizableDivider parentRef={ganttChart} spacing={spacing} onMove={setTableWidth} />
+          <Box
+            style={{
+              width: `${(1 - tableWidth) * 100}%`,
+              minWidth: `${(1 - tableWidth) * 100}%`,
+            }}
+            sx={{ overflow: 'auto' }}
+          >
             <DetailPane
               customLinks={customLinks}
               trace={trace}


### PR DESCRIPTION
# Description

`theme.spacing(2)` returns `calc(2 * var(--mui-spacing))` when MUI is configured to use CSS variables, which broke the logic to determine the spacing in pixels.

It always worked in the Perses UI (which does not enable MUI CSS vars), but breaks when embedded in another application if MUI is used with `cssVariables: true`.

This PR uses `getComputedStyle()` instead, to get the resolved values for the gap. Additionally, I added `minWidth`, otherwise the flexbox may not apply the entire `width` value to the DOM.

# Screenshots

Resizing of the attribute panel did not work when using MUI with `cssVariables: true`, now it works.

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
