### PR TITLE
[BUGFIX] pyroscope: add timerange to all queries

### DIFF
--- a/pyroscope/src/model/pyroscope-client.ts
+++ b/pyroscope/src/model/pyroscope-client.ts
@@ -47,7 +47,11 @@ export interface PyroscopeClient extends DatasourceClient {
     headers: RequestHeaders,
     body: Record<string, string | number>
   ): Promise<SearchLabelValuesResponse>;
-  searchServices(params: SearchLabelValuesParameters, headers: RequestHeaders): Promise<SearchLabelValuesResponse>;
+  searchServices(
+    params: SearchLabelValuesParameters,
+    headers: RequestHeaders,
+    body: Record<string, string | number>
+  ): Promise<SearchLabelValuesResponse>;
 }
 
 export interface QueryOptions {
@@ -165,12 +169,13 @@ export function searchLabelValues(
  */
 export function searchServices(
   params: SearchLabelValuesParameters,
-  queryOptions: QueryOptions
+  queryOptions: QueryOptions,
+  body: Record<string, string | number>
 ): Promise<SearchLabelValuesResponse> {
   return fetchWithPost<SearchLabelValuesParameters, SearchLabelValuesResponse>(
     '/querier.v1.QuerierService/LabelValues',
     params,
     queryOptions,
-    { name: 'service_name' }
+    { name: 'service_name', ...body }
   );
 }

--- a/pyroscope/src/plugins/pyroscope-datasource.tsx
+++ b/pyroscope/src/plugins/pyroscope-datasource.tsx
@@ -49,7 +49,8 @@ const createClient: DatasourcePlugin<PyroscopeDatasourceSpec, PyroscopeClient>['
       searchLabelNames(params, { datasourceUrl, headers: headers ?? specHeaders }, body),
     searchLabelValues: (params, headers, body) =>
       searchLabelValues(params, { datasourceUrl, headers: headers ?? specHeaders }, body),
-    searchServices: (params, headers) => searchServices(params, { datasourceUrl, headers: headers ?? specHeaders }),
+    searchServices: (params, headers, body) =>
+      searchServices(params, { datasourceUrl, headers: headers ?? specHeaders }, body),
   };
 };
 

--- a/pyroscope/src/utils/use-query.ts
+++ b/pyroscope/src/utils/use-query.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useDatasourceClient } from '@perses-dev/plugin-system';
+import { useDatasourceClient, useTimeRange } from '@perses-dev/plugin-system';
 import { DatasourceSelector, StatusError } from '@perses-dev/core';
 
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
@@ -21,6 +21,7 @@ import {
   SearchProfileTypesResponse,
   PyroscopeClient,
 } from '../model';
+import { getUnixTimeRange } from '../plugins';
 
 export function useLabelNames(datasource: DatasourceSelector): UseQueryResult<SearchLabelNamesResponse, StatusError> {
   const { data: client } = useDatasourceClient<PyroscopeClient>(datasource);
@@ -39,12 +40,18 @@ export function useLabelValues(
   labelName: string
 ): UseQueryResult<SearchLabelValuesResponse, StatusError> {
   const { data: client } = useDatasourceClient<PyroscopeClient>(datasource);
+  const { absoluteTimeRange } = useTimeRange();
+  const { start, end } = getUnixTimeRange(absoluteTimeRange);
 
   return useQuery<SearchLabelValuesResponse, StatusError>({
     enabled: !!client,
     queryKey: ['searchLabelValues', labelName, 'datasource', datasource],
     queryFn: async () => {
-      return await client!.searchLabelValues({}, { 'content-type': 'application/json' }, { name: labelName });
+      return await client!.searchLabelValues(
+        {},
+        { 'content-type': 'application/json' },
+        { name: labelName, from: start, until: end }
+      );
     },
   });
 }
@@ -53,24 +60,28 @@ export function useProfileTypes(
   datasource: DatasourceSelector
 ): UseQueryResult<SearchProfileTypesResponse, StatusError> {
   const { data: client } = useDatasourceClient<PyroscopeClient>(datasource);
+  const { absoluteTimeRange } = useTimeRange();
+  const { start, end } = getUnixTimeRange(absoluteTimeRange);
 
   return useQuery<SearchProfileTypesResponse, StatusError>({
     enabled: !!client,
     queryKey: ['searchProfileTypes', 'datasource', datasource],
     queryFn: async () => {
-      return await client!.searchProfileTypes({}, { 'content-type': 'application/json' }, {});
+      return await client!.searchProfileTypes({}, { 'content-type': 'application/json' }, { from: start, until: end });
     },
   });
 }
 
 export function useServices(datasource: DatasourceSelector): UseQueryResult<SearchLabelValuesResponse, StatusError> {
   const { data: client } = useDatasourceClient<PyroscopeClient>(datasource);
+  const { absoluteTimeRange } = useTimeRange();
+  const { start, end } = getUnixTimeRange(absoluteTimeRange);
 
   return useQuery<SearchLabelValuesResponse, StatusError>({
     enabled: !!client,
     queryKey: ['searchServices', 'datasource', datasource],
     queryFn: async () => {
-      return await client!.searchServices({}, { 'content-type': 'application/json' });
+      return await client!.searchServices({}, { 'content-type': 'application/json' }, { from: start, until: end });
     },
   });
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
When upgrading to Pyroscope v2, some changes has been made to endpoint payload and time range is now mandatory.
Adding it for queries missing it.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
