### PR TITLE
[BUGFIX] Fix ClickHouse time range interpolation and time series rend…

### DIFF
--- a/clickhouse/src/model/click-house-client.test.ts
+++ b/clickhouse/src/model/click-house-client.test.ts
@@ -1,0 +1,60 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { formatClickHouseDateTime, query, replaceTimeRangePlaceholders } from './click-house-client';
+
+describe('ClickHouse client', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should replace time range placeholders', () => {
+    expect(
+      replaceTimeRangePlaceholders(
+        "SELECT * FROM logs WHERE timestamp BETWEEN '{start}' AND '{end}'",
+        '2025-01-01 00:00:00',
+        '2025-01-02 00:00:00'
+      )
+    ).toEqual("SELECT * FROM logs WHERE timestamp BETWEEN '2025-01-01 00:00:00' AND '2025-01-02 00:00:00'");
+  });
+
+  it('should format time range dates for ClickHouse SQL literals', () => {
+    expect(formatClickHouseDateTime(new Date('2025-01-01T00:00:00.000Z'))).toBe('2025-01-01 00:00:00');
+  });
+
+  it('should send interpolated query to ClickHouse', async () => {
+    const fetchMock = jest.fn<Promise<Pick<Response, 'ok' | 'json'>>, [string, RequestInit?]>(async () => ({
+      ok: true,
+      json: jest.fn(async () => ({ data: [] })),
+    }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await query(
+      {
+        query: "SELECT * FROM logs WHERE timestamp BETWEEN '{start}' AND '{end}'",
+        start: '2025-01-01 00:00:00',
+        end: '2025-01-02 00:00:00',
+      },
+      {
+        datasourceUrl: 'http://clickhouse.example.com',
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl] = fetchMock.mock.calls[0]!;
+    const url = new URL(calledUrl);
+    expect(url.searchParams.get('query')).toBe(
+      "SELECT * FROM logs WHERE timestamp BETWEEN '2025-01-01 00:00:00' AND '2025-01-02 00:00:00' FORMAT JSON"
+    );
+  });
+});

--- a/clickhouse/src/model/click-house-client.ts
+++ b/clickhouse/src/model/click-house-client.ts
@@ -15,6 +15,8 @@ import { RequestHeaders } from '@perses-dev/core';
 
 export interface ClickHouseQueryParams {
   query: string;
+  start?: string;
+  end?: string;
   database?: string;
 }
 
@@ -32,6 +34,17 @@ export interface ClickHouseClient {
   query: (params: { start: string; end: string; query: string }) => Promise<ClickHouseQueryResponse>;
 }
 
+export function replaceTimeRangePlaceholders(query: string, start?: string, end?: string): string {
+  return query.replaceAll('{start}', start ?? '{start}').replaceAll('{end}', end ?? '{end}');
+}
+
+export function formatClickHouseDateTime(date: Date): string {
+  return date
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.\d{3}Z$/, '');
+}
+
 export async function query(
   params: ClickHouseQueryParams,
   queryOptions: ClickHouseQueryOptions
@@ -43,7 +56,7 @@ export async function query(
     throw new Error('No query provided in params');
   }
 
-  let finalQuery = params.query.trim();
+  let finalQuery = replaceTimeRangePlaceholders(params.query.trim(), params.start, params.end);
   if (!finalQuery.toUpperCase().includes('FORMAT')) {
     finalQuery += ' FORMAT JSON';
   }

--- a/clickhouse/src/model/click-house-client.ts
+++ b/clickhouse/src/model/click-house-client.ts
@@ -15,6 +15,8 @@ import { RequestHeaders } from '@perses-dev/client';
 
 export interface ClickHouseQueryParams {
   query: string;
+  start?: string;
+  end?: string;
   database?: string;
 }
 
@@ -32,6 +34,17 @@ export interface ClickHouseClient {
   query: (params: { start: string; end: string; query: string }) => Promise<ClickHouseQueryResponse>;
 }
 
+export function replaceTimeRangePlaceholders(query: string, start?: string, end?: string): string {
+  return query.replaceAll('{start}', start ?? '{start}').replaceAll('{end}', end ?? '{end}');
+}
+
+export function formatClickHouseDateTime(date: Date): string {
+  return date
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.\d{3}Z$/, '');
+}
+
 export async function query(
   params: ClickHouseQueryParams,
   queryOptions: ClickHouseQueryOptions
@@ -43,7 +56,7 @@ export async function query(
     throw new Error('No query provided in params');
   }
 
-  let finalQuery = params.query.trim();
+  let finalQuery = replaceTimeRangePlaceholders(params.query.trim(), params.start, params.end);
   if (!finalQuery.toUpperCase().includes('FORMAT')) {
     finalQuery += ' FORMAT JSON';
   }

--- a/clickhouse/src/model/click-house-data-types.ts
+++ b/clickhouse/src/model/click-house-data-types.ts
@@ -19,5 +19,5 @@ export interface ClickHouseTimeSeriesData extends TimeSeriesData {
 
 export interface TimeSeriesEntry {
   time: string;
-  log_count: number | string;
+  [key: string]: number | string | null | undefined;
 }

--- a/clickhouse/src/queries/click-house-log-query/click-house-log-query-types.test.ts
+++ b/clickhouse/src/queries/click-house-log-query/click-house-log-query-types.test.ts
@@ -47,8 +47,8 @@ const createStubContext = (): ClickHouseQueryContext => {
       setSavedDatasources: jest.fn(),
     },
     timeRange: {
-      end: new Date('01-01-2025'),
-      start: new Date('01-02-2025'),
+      end: new Date('2025-01-02T00:00:00.000Z'),
+      start: new Date('2025-01-01T00:00:00.000Z'),
     },
     variableState: {},
   };
@@ -70,5 +70,24 @@ describe('ClickHouseLogQuery', () => {
   it('should create initial options with empty query', () => {
     const initialOptions = ClickHouseLogQuery.createInitialOptions();
     expect(initialOptions).toEqual({ query: '' });
+  });
+
+  it('should run query with interpolated time range', async () => {
+    const response = await ClickHouseLogQuery.getLogData(
+      {
+        query: "SELECT * FROM application_logs WHERE timestamp >= '{start}' AND timestamp <= '{end}'",
+      },
+      createStubContext()
+    );
+
+    expect(clickhouseStubClient.query).toHaveBeenCalledWith({
+      start: '2025-01-01 00:00:00',
+      end: '2025-01-02 00:00:00',
+      query:
+        "SELECT * FROM application_logs WHERE timestamp >= '2025-01-01 00:00:00' AND timestamp <= '2025-01-02 00:00:00'",
+    });
+    expect(response.metadata?.executedQueryString).toBe(
+      "SELECT * FROM application_logs WHERE timestamp >= '2025-01-01 00:00:00' AND timestamp <= '2025-01-02 00:00:00'"
+    );
   });
 });

--- a/clickhouse/src/queries/click-house-log-query/click-house-log-query-types.test.ts
+++ b/clickhouse/src/queries/click-house-log-query/click-house-log-query-types.test.ts
@@ -47,8 +47,8 @@ const createStubContext = (): LogQueryContext => {
       setSavedDatasources: jest.fn(),
     },
     timeRange: {
-      end: new Date('01-01-2025'),
-      start: new Date('01-02-2025'),
+      end: new Date('2025-01-02T00:00:00.000Z'),
+      start: new Date('2025-01-01T00:00:00.000Z'),
     },
     variableState: {},
     refreshKey: '',
@@ -71,5 +71,24 @@ describe('ClickHouseLogQuery', () => {
   it('should create initial options with empty query', () => {
     const initialOptions = ClickHouseLogQuery.createInitialOptions();
     expect(initialOptions).toEqual({ query: '' });
+  });
+
+  it('should run query with interpolated time range', async () => {
+    const response = await ClickHouseLogQuery.getLogData(
+      {
+        query: "SELECT * FROM application_logs WHERE timestamp >= '{start}' AND timestamp <= '{end}'",
+      },
+      createStubContext()
+    );
+
+    expect(clickhouseStubClient.query).toHaveBeenCalledWith({
+      start: '2025-01-01 00:00:00',
+      end: '2025-01-02 00:00:00',
+      query:
+        "SELECT * FROM application_logs WHERE timestamp >= '2025-01-01 00:00:00' AND timestamp <= '2025-01-02 00:00:00'",
+    });
+    expect(response.metadata?.executedQueryString).toBe(
+      "SELECT * FROM application_logs WHERE timestamp >= '2025-01-01 00:00:00' AND timestamp <= '2025-01-02 00:00:00'"
+    );
   });
 });

--- a/clickhouse/src/queries/click-house-log-query/get-click-house-log-data.ts
+++ b/clickhouse/src/queries/click-house-log-query/get-click-house-log-data.ts
@@ -13,7 +13,12 @@
 
 import { replaceVariables } from '@perses-dev/plugin-system';
 import { LogEntry, LogData } from '@perses-dev/core';
-import { ClickHouseClient, ClickHouseQueryResponse } from '../../model/click-house-client';
+import {
+  ClickHouseClient,
+  ClickHouseQueryResponse,
+  formatClickHouseDateTime,
+  replaceTimeRangePlaceholders,
+} from '../../model/click-house-client';
 import { DEFAULT_DATASOURCE } from '../constants';
 import { ClickHouseLogQuerySpec } from './click-house-log-query-types';
 import { LogQueryPlugin } from './log-query-plugin-interface';
@@ -83,18 +88,21 @@ export const getClickHouseLogData: LogQueryPlugin<ClickHouseLogQuerySpec>['getLo
   )) as ClickHouseClient;
 
   const { start, end } = context.timeRange;
+  const startTime = formatClickHouseDateTime(start);
+  const endTime = formatClickHouseDateTime(end);
+  const executedQueryString = replaceTimeRangePlaceholders(query, startTime, endTime);
 
   const response: ClickHouseQueryResponse = await client.query({
-    start: start.getTime().toString(),
-    end: end.getTime().toString(),
-    query,
+    start: startTime,
+    end: endTime,
+    query: executedQueryString,
   });
 
   return {
     timeRange: { start, end },
     logs: convertStreamsToLogs(response.data as LogEntry[]),
     metadata: {
-      executedQueryString: query,
+      executedQueryString,
     },
   };
 };

--- a/clickhouse/src/queries/click-house-log-query/get-click-house-log-data.ts
+++ b/clickhouse/src/queries/click-house-log-query/get-click-house-log-data.ts
@@ -13,7 +13,12 @@
 
 import { replaceVariables, LogQueryPlugin } from '@perses-dev/plugin-system';
 import { LogData, LogEntry } from '@perses-dev/spec';
-import { ClickHouseClient, ClickHouseQueryResponse } from '../../model/click-house-client';
+import {
+  ClickHouseClient,
+  ClickHouseQueryResponse,
+  formatClickHouseDateTime,
+  replaceTimeRangePlaceholders,
+} from '../../model/click-house-client';
 import { DEFAULT_DATASOURCE } from '../constants';
 import { ClickHouseLogQuerySpec } from './click-house-log-query-types';
 
@@ -82,18 +87,21 @@ export const getClickHouseLogData: LogQueryPlugin<ClickHouseLogQuerySpec>['getLo
   )) as ClickHouseClient;
 
   const { start, end } = context.timeRange;
+  const startTime = formatClickHouseDateTime(start);
+  const endTime = formatClickHouseDateTime(end);
+  const executedQueryString = replaceTimeRangePlaceholders(query, startTime, endTime);
 
   const response: ClickHouseQueryResponse = await client.query({
-    start: start.getTime().toString(),
-    end: end.getTime().toString(),
-    query,
+    start: startTime,
+    end: endTime,
+    query: executedQueryString,
   });
 
   return {
     timeRange: { start, end },
     logs: convertStreamsToLogs(response.data as LogEntry[]),
     metadata: {
-      executedQueryString: query,
+      executedQueryString,
     },
   };
 };

--- a/clickhouse/src/queries/click-house-time-series-query/click-house-query-types.test.ts
+++ b/clickhouse/src/queries/click-house-time-series-query/click-house-query-types.test.ts
@@ -32,8 +32,8 @@ clickhouseStubClient.query = jest.fn(async () => {
   const stubResponse: ClickHouseQueryResponse = {
     status: 'success',
     data: [
-      { time: '2025-09-09 05:18:00', log_count: '277' },
-      { time: '2025-09-09 05:19:00', log_count: '156102' },
+      { time: '2025-09-09 05:18:00', avg_cpu: '2.5', max_memory: 277, service: 'api' },
+      { time: '2025-09-09 05:19:00', avg_cpu: '3.5', max_memory: 156102, service: 'api' },
     ],
   };
   return stubResponse as ClickHouseQueryResponse;
@@ -65,8 +65,8 @@ const createStubContext = (): TimeSeriesQueryContext => {
       setSavedDatasources: jest.fn(),
     },
     timeRange: {
-      end: new Date('01-01-2025'),
-      start: new Date('01-02-2025'),
+      end: new Date('2025-01-02T00:00:00.000Z'),
+      start: new Date('2025-01-01T00:00:00.000Z'),
     },
     variableState: {},
   };
@@ -90,11 +90,92 @@ describe('ClickHouseTimeSeriesQuery', () => {
     expect(initialOptions).toEqual({ query: '' });
   });
 
-  it('should run query and return ClickHouse data only', async () => {
-    const client = getDatasourceClient();
-    const resp = await client.query('SELECT count(*) FROM otel_logs');
-    expect(resp.data.length).toBeGreaterThan(0);
-    expect(resp.data[0]).toHaveProperty('time');
-    expect(resp.data[0]).toHaveProperty('log_count');
+  it('should run query with interpolated time range and return one series per numeric column', async () => {
+    const response = await ClickHouseTimeSeriesQuery.getTimeSeriesData(
+      {
+        query:
+          "SELECT toStartOfMinute(timestamp) as time, avg(cpu_usage) as avg_cpu, max(memory_usage) as max_memory FROM system_metrics WHERE timestamp BETWEEN '{start}' AND '{end}' GROUP BY time ORDER BY time",
+      },
+      createStubContext()
+    );
+
+    expect(clickhouseStubClient.query).toHaveBeenCalledWith({
+      start: '2025-01-01 00:00:00',
+      end: '2025-01-02 00:00:00',
+      query:
+        "SELECT toStartOfMinute(timestamp) as time, avg(cpu_usage) as avg_cpu, max(memory_usage) as max_memory FROM system_metrics WHERE timestamp BETWEEN '2025-01-01 00:00:00' AND '2025-01-02 00:00:00' GROUP BY time ORDER BY time",
+    });
+    expect(response.series).toEqual([
+      {
+        name: 'avg_cpu',
+        values: [
+          [new Date('2025-09-09 05:18:00').getTime(), 2.5],
+          [new Date('2025-09-09 05:19:00').getTime(), 3.5],
+        ],
+      },
+      {
+        name: 'max_memory',
+        values: [
+          [new Date('2025-09-09 05:18:00').getTime(), 277],
+          [new Date('2025-09-09 05:19:00').getTime(), 156102],
+        ],
+      },
+    ]);
+    expect(response.stepMs).toBe(60 * 1000);
+    expect(response.metadata?.executedQueryString).toBe(
+      "SELECT toStartOfMinute(timestamp) as time, avg(cpu_usage) as avg_cpu, max(memory_usage) as max_memory FROM system_metrics WHERE timestamp BETWEEN '2025-01-01 00:00:00' AND '2025-01-02 00:00:00' GROUP BY time ORDER BY time"
+    );
+  });
+
+  it('should infer daily query step from returned timestamps', async () => {
+    (clickhouseStubClient.query as jest.Mock).mockResolvedValueOnce({
+      status: 'success',
+      data: [
+        { time: '2026-01-01 22:00:00', flights: 80 },
+        { time: '2026-01-02 22:00:00', flights: 56 },
+        { time: '2026-01-03 22:00:00', flights: 32 },
+      ],
+    });
+
+    const response = await ClickHouseTimeSeriesQuery.getTimeSeriesData(
+      {
+        query:
+          "SELECT toStartOfDay(timestamp) as time, sum(flights_count) as flights FROM flight WHERE timestamp BETWEEN '{start}' AND '{end}' GROUP BY time ORDER BY time",
+      },
+      createStubContext()
+    );
+
+    expect(response.stepMs).toBe(24 * 60 * 60 * 1000);
+    expect(response.series).toEqual([
+      {
+        name: 'flights',
+        values: [
+          [new Date('2026-01-01 22:00:00').getTime(), 80],
+          [new Date('2026-01-02 22:00:00').getTime(), 56],
+          [new Date('2026-01-03 22:00:00').getTime(), 32],
+        ],
+      },
+    ]);
+  });
+
+  it('should keep timezone daily buckets daily across daylight saving time changes', async () => {
+    (clickhouseStubClient.query as jest.Mock).mockResolvedValueOnce({
+      status: 'success',
+      data: [
+        { time: '2026-03-28 22:00:00', flights: 80 },
+        { time: '2026-03-29 21:00:00', flights: 56 },
+        { time: '2026-03-30 21:00:00', flights: 32 },
+      ],
+    });
+
+    const response = await ClickHouseTimeSeriesQuery.getTimeSeriesData(
+      {
+        query:
+          "SELECT toStartOfDay(timestamp) as time, sum(flights_count) as flights FROM flight WHERE timestamp BETWEEN '{start}' AND '{end}' GROUP BY time ORDER BY time",
+      },
+      createStubContext()
+    );
+
+    expect(response.stepMs).toBe(24 * 60 * 60 * 1000);
   });
 });

--- a/clickhouse/src/queries/click-house-time-series-query/get-click-house-data.ts
+++ b/clickhouse/src/queries/click-house-time-series-query/get-click-house-data.ts
@@ -15,8 +15,15 @@ import { TimeSeries } from '@perses-dev/core';
 import { TimeSeriesQueryPlugin, replaceVariables } from '@perses-dev/plugin-system';
 import { DEFAULT_DATASOURCE } from '../constants';
 import { TimeSeriesEntry } from '../../model/click-house-data-types';
-import { ClickHouseClient, ClickHouseQueryResponse } from '../../model/click-house-client';
+import {
+  ClickHouseClient,
+  ClickHouseQueryResponse,
+  formatClickHouseDateTime,
+  replaceTimeRangePlaceholders,
+} from '../../model/click-house-client';
 import { ClickHouseTimeSeriesQuerySpec, DatasourceQueryResponse } from './click-house-query-types';
+
+const DEFAULT_STEP_MS = 30 * 1000;
 
 function buildTimeSeries(response?: DatasourceQueryResponse): TimeSeries[] {
   const data = response?.data as TimeSeriesEntry[];
@@ -24,18 +31,75 @@ function buildTimeSeries(response?: DatasourceQueryResponse): TimeSeries[] {
     return [];
   }
 
-  const values: Array<[number, number]> = data.map((row: TimeSeriesEntry) => {
-    const timestamp = new Date(row.time).getTime();
-    const value = Number(row.log_count);
-    return [timestamp, value];
-  });
+  const metricNames = Object.keys(data[0] ?? {}).filter((key) => key !== 'time');
 
-  return [
-    {
-      name: 'log_count',
-      values,
-    },
-  ];
+  return metricNames
+    .map((metricName) => {
+      const values: Array<[number, number | null]> = data.map((row: TimeSeriesEntry) => {
+        const timestamp = new Date(row.time).getTime();
+        const value = toTimeSeriesValue(row[metricName]);
+        return [timestamp, value];
+      });
+
+      return {
+        name: metricName,
+        values,
+      };
+    })
+    .filter((series) => series.values.some(([, value]) => value !== null));
+}
+
+function toTimeSeriesValue(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+function inferStepMs(response?: DatasourceQueryResponse): number {
+  const data = response?.data as TimeSeriesEntry[];
+  if (!response || !data || data.length < 2) {
+    return DEFAULT_STEP_MS;
+  }
+
+  const timestamps = data
+    .map((row: TimeSeriesEntry) => new Date(row.time).getTime())
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+
+  if (timestamps.length < 2) {
+    return DEFAULT_STEP_MS;
+  }
+
+  const deltas: number[] = [];
+  for (let i = 1; i < timestamps.length; i++) {
+    const previous = timestamps[i - 1];
+    const current = timestamps[i];
+    if (previous === undefined || current === undefined || current <= previous) {
+      continue;
+    }
+    deltas.push(current - previous);
+  }
+
+  if (deltas.length === 0) {
+    return DEFAULT_STEP_MS;
+  }
+
+  const deltaCounts = new Map<number, number>();
+  for (const delta of deltas) {
+    deltaCounts.set(delta, (deltaCounts.get(delta) ?? 0) + 1);
+  }
+
+  const inferredStep = Array.from(deltaCounts.entries()).sort(([deltaA, countA], [deltaB, countB]) => {
+    if (countA !== countB) {
+      return countB - countA;
+    }
+    return deltaB - deltaA;
+  })[0]?.[0];
+
+  return inferredStep ?? DEFAULT_STEP_MS;
 }
 
 export const getTimeSeriesData: TimeSeriesQueryPlugin<ClickHouseTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
@@ -53,19 +117,22 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<ClickHouseTimeSeriesQueryS
   )) as ClickHouseClient;
 
   const { start, end } = context.timeRange;
+  const startTime = formatClickHouseDateTime(start);
+  const endTime = formatClickHouseDateTime(end);
+  const executedQueryString = replaceTimeRangePlaceholders(query, startTime, endTime);
 
   const response: ClickHouseQueryResponse = await client.query({
-    start: start.getTime().toString(),
-    end: end.getTime().toString(),
-    query,
+    start: startTime,
+    end: endTime,
+    query: executedQueryString,
   });
 
   return {
     series: buildTimeSeries(response),
     timeRange: { start, end },
-    stepMs: 30 * 1000,
+    stepMs: inferStepMs(response),
     metadata: {
-      executedQueryString: query,
+      executedQueryString,
     },
   };
 };

--- a/clickhouse/src/queries/click-house-time-series-query/get-click-house-data.ts
+++ b/clickhouse/src/queries/click-house-time-series-query/get-click-house-data.ts
@@ -15,8 +15,15 @@ import { TimeSeriesQueryPlugin, replaceVariables } from '@perses-dev/plugin-syst
 import { TimeSeries } from '@perses-dev/spec';
 import { DEFAULT_DATASOURCE } from '../constants';
 import { TimeSeriesEntry } from '../../model/click-house-data-types';
-import { ClickHouseClient, ClickHouseQueryResponse } from '../../model/click-house-client';
+import {
+  ClickHouseClient,
+  ClickHouseQueryResponse,
+  formatClickHouseDateTime,
+  replaceTimeRangePlaceholders,
+} from '../../model/click-house-client';
 import { ClickHouseTimeSeriesQuerySpec, DatasourceQueryResponse } from './click-house-query-types';
+
+const DEFAULT_STEP_MS = 30 * 1000;
 
 function buildTimeSeries(response?: DatasourceQueryResponse): TimeSeries[] {
   const data = response?.data as TimeSeriesEntry[];
@@ -24,18 +31,75 @@ function buildTimeSeries(response?: DatasourceQueryResponse): TimeSeries[] {
     return [];
   }
 
-  const values: Array<[number, number]> = data.map((row: TimeSeriesEntry) => {
-    const timestamp = new Date(row.time).getTime();
-    const value = Number(row.log_count);
-    return [timestamp, value];
-  });
+  const metricNames = Object.keys(data[0] ?? {}).filter((key) => key !== 'time');
 
-  return [
-    {
-      name: 'log_count',
-      values,
-    },
-  ];
+  return metricNames
+    .map((metricName) => {
+      const values: Array<[number, number | null]> = data.map((row: TimeSeriesEntry) => {
+        const timestamp = new Date(row.time).getTime();
+        const value = toTimeSeriesValue(row[metricName]);
+        return [timestamp, value];
+      });
+
+      return {
+        name: metricName,
+        values,
+      };
+    })
+    .filter((series) => series.values.some(([, value]) => value !== null));
+}
+
+function toTimeSeriesValue(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+function inferStepMs(response?: DatasourceQueryResponse): number {
+  const data = response?.data as TimeSeriesEntry[];
+  if (!response || !data || data.length < 2) {
+    return DEFAULT_STEP_MS;
+  }
+
+  const timestamps = data
+    .map((row: TimeSeriesEntry) => new Date(row.time).getTime())
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+
+  if (timestamps.length < 2) {
+    return DEFAULT_STEP_MS;
+  }
+
+  const deltas: number[] = [];
+  for (let i = 1; i < timestamps.length; i++) {
+    const previous = timestamps[i - 1];
+    const current = timestamps[i];
+    if (previous === undefined || current === undefined || current <= previous) {
+      continue;
+    }
+    deltas.push(current - previous);
+  }
+
+  if (deltas.length === 0) {
+    return DEFAULT_STEP_MS;
+  }
+
+  const deltaCounts = new Map<number, number>();
+  for (const delta of deltas) {
+    deltaCounts.set(delta, (deltaCounts.get(delta) ?? 0) + 1);
+  }
+
+  const inferredStep = Array.from(deltaCounts.entries()).sort(([deltaA, countA], [deltaB, countB]) => {
+    if (countA !== countB) {
+      return countB - countA;
+    }
+    return deltaB - deltaA;
+  })[0]?.[0];
+
+  return inferredStep ?? DEFAULT_STEP_MS;
 }
 
 export const getTimeSeriesData: TimeSeriesQueryPlugin<ClickHouseTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
@@ -53,19 +117,22 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<ClickHouseTimeSeriesQueryS
   )) as ClickHouseClient;
 
   const { start, end } = context.timeRange;
+  const startTime = formatClickHouseDateTime(start);
+  const endTime = formatClickHouseDateTime(end);
+  const executedQueryString = replaceTimeRangePlaceholders(query, startTime, endTime);
 
   const response: ClickHouseQueryResponse = await client.query({
-    start: start.getTime().toString(),
-    end: end.getTime().toString(),
-    query,
+    start: startTime,
+    end: endTime,
+    query: executedQueryString,
   });
 
   return {
     series: buildTimeSeries(response),
     timeRange: { start, end },
-    stepMs: 30 * 1000,
+    stepMs: inferStepMs(response),
     metadata: {
-      executedQueryString: query,
+      executedQueryString,
     },
   };
 };


### PR DESCRIPTION
# Description

Fixes ClickHouse query handling so documented `{start}` and `{end}` placeholders are interpolated before queries are sent to ClickHouse.

Also fixes time series conversion to:
- support arbitrary numeric result columns instead of only `log_count`
- ignore non-numeric columns
- infer `stepMs` from returned timestamps so aggregated queries such as daily buckets render correctly in line charts

Previously, daily ClickHouse data could export correctly as CSV and render as bars, but appear blank as a line chart because the plugin always returned `stepMs = 30s`, causing the TimeSeriesChart to fill daily
series with many null points.

# Screenshots

<img width="769" height="260" alt="зображення" src="https://github.com/user-attachments/assets/2b23713d-b042-4442-993a-1f16da348b49" />

<img width="1069" height="281" alt="зображення" src="https://github.com/user-attachments/assets/746ac665-981b-44a1-9846-30345e8d7bcf" />

<img width="424" height="69" alt="зображення" src="https://github.com/user-attachments/assets/1b69eb45-88a7-4d42-ab72-53224e8e4ac1" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
