### PR TITLE
[FEATURE] LogsTable: add support for ansi colors in logs

### DIFF
--- a/logstable/jest.config.ts
+++ b/logstable/jest.config.ts
@@ -18,6 +18,7 @@ const jestConfig: Config.InitialOptions = {
   ...shared,
 
   setupFilesAfterEnv: [...(shared.setupFilesAfterEnv ?? []), '<rootDir>/src/setup-tests.ts'],
+  transformIgnorePatterns: ['node_modules/(?!(lodash-es|yaml|ansi_up))'],
 };
 
 export default jestConfig;

--- a/logstable/package.json
+++ b/logstable/package.json
@@ -23,6 +23,10 @@
   "main": "lib/cjs/index.js",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
+  "dependencies": {
+    "ansi_up": "^6.0.0",
+    "dompurify": "^3.2.3"
+  },
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",

--- a/logstable/src/components/LogRow/LogDetailsTable.tsx
+++ b/logstable/src/components/LogRow/LogDetailsTable.tsx
@@ -11,9 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Table, TableBody, TableRow, TableCell, useTheme, alpha } from '@mui/material';
 import { Labels } from '@perses-dev/core';
+import './ansiColors.css';
+import { ansiToSanitizedHtml } from '../../utils/ansi';
+
+const AnsiValue: React.FC<{ value: string }> = ({ value }) => {
+  const ansiHtml = useMemo(() => ansiToSanitizedHtml(value), [value]);
+  if (ansiHtml) {
+    return <span dangerouslySetInnerHTML={{ __html: ansiHtml }} />;
+  }
+  return <>{value}</>;
+};
 
 interface LogDetailsTableProps {
   log: Labels;
@@ -60,7 +70,7 @@ export const LogDetailsTable: React.FC<LogDetailsTableProps> = ({ log }) => {
                 width: '67%',
               }}
             >
-              {value !== undefined && value !== null && value !== '' ? value : '--'}
+              {value !== undefined && value !== null && value !== '' ? <AnsiValue value={value} /> : '--'}
             </TableCell>
           </TableRow>
         ))}

--- a/logstable/src/components/LogRow/LogRow.test.tsx
+++ b/logstable/src/components/LogRow/LogRow.test.tsx
@@ -127,4 +127,24 @@ describe('LogRow', () => {
 
     expect(onSelect).toHaveBeenCalledWith(0, expect.objectContaining({ type: 'mousedown' }));
   });
+
+  describe('ANSI rendering', () => {
+    it('should render ANSI colored log text as HTML', () => {
+      const ansiLog: LogEntry = {
+        timestamp: 1767225600,
+        line: '\x1b[31mERROR\x1b[0m connection refused',
+        labels: { level: 'error' },
+      };
+      render(<LogRow log={ansiLog} index={0} isExpanded={false} onToggle={jest.fn()} />);
+      const errorSpan = document.querySelector('.ansi-red-fg');
+      expect(errorSpan).toBeInTheDocument();
+      expect(errorSpan).toHaveTextContent('ERROR');
+    });
+
+    it('should render plain log text without dangerouslySetInnerHTML', () => {
+      renderLogRow(); // uses existing mockLog with plain text 'foo bar baz'
+      expect(screen.getByText('foo bar baz')).toBeInTheDocument();
+      expect(document.querySelector('[class*="ansi-"]')).toBeNull();
+    });
+  });
 });

--- a/logstable/src/components/LogRow/LogRow.tsx
+++ b/logstable/src/components/LogRow/LogRow.tsx
@@ -11,30 +11,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { memo, useCallback, useState, useRef, useEffect, ReactNode } from 'react';
 import {
   Box,
   Collapse,
-  useTheme,
   IconButton,
-  Tooltip,
-  Menu,
-  MenuItem,
   ListItemIcon,
   ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+  useTheme,
 } from '@mui/material';
-import ChevronRight from 'mdi-material-ui/ChevronRight';
-import ContentCopy from 'mdi-material-ui/ContentCopy';
-import ChevronDown from 'mdi-material-ui/ChevronDown';
-import FormatQuoteClose from 'mdi-material-ui/FormatQuoteClose';
-import CodeJson from 'mdi-material-ui/CodeJson';
-import Check from 'mdi-material-ui/Check';
 import { LogEntry } from '@perses-dev/core';
+import Check from 'mdi-material-ui/Check';
+import ChevronDown from 'mdi-material-ui/ChevronDown';
+import ChevronRight from 'mdi-material-ui/ChevronRight';
+import CodeJson from 'mdi-material-ui/CodeJson';
+import ContentCopy from 'mdi-material-ui/ContentCopy';
+import FormatQuoteClose from 'mdi-material-ui/FormatQuoteClose';
+import React, { memo, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ansiToSanitizedHtml } from '../../utils/ansi';
+import { formatLogAsJson, formatLogEntry, formatLogMessage } from '../../utils/copyHelpers';
 import { useSeverityColor } from '../hooks/useSeverity';
-import { formatLogEntry, formatLogMessage, formatLogAsJson } from '../../utils/copyHelpers';
-import { LogTimestamp } from './LogTimestamp';
-import { LogRowContainer, LogRowContent, ExpandButton, LogText } from './LogsStyles';
 import { LogDetailsTable } from './LogDetailsTable';
+import { LogTimestamp } from './LogTimestamp';
+import { ExpandButton, LogRowContainer, LogRowContent, LogText } from './LogsStyles';
+import './ansiColors.css';
 
 const COPY_SUCCESS_DURATION_MS = 1500;
 
@@ -65,6 +67,7 @@ const DefaultLogRow: React.FC<LogRowProps> = ({
 }) => {
   const theme = useTheme();
   const severityColor = useSeverityColor(log);
+  const ansiHtml = useMemo(() => (log ? ansiToSanitizedHtml(log.line) : null), [log]);
   const [isHovered, setIsHovered] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [copySuccess, setCopySuccess] = useState(false);
@@ -194,9 +197,13 @@ const DefaultLogRow: React.FC<LogRowProps> = ({
             alignItems: 'center',
           }}
         >
-          <LogText variant="body2" allowWrap={allowWrap}>
-            {log.line}
-          </LogText>
+          {ansiHtml ? (
+            <LogText variant="body2" allowWrap={allowWrap} dangerouslySetInnerHTML={{ __html: ansiHtml }} />
+          ) : (
+            <LogText variant="body2" allowWrap={allowWrap}>
+              {log.line}
+            </LogText>
+          )}
           <Tooltip title={copySuccess ? 'Copied!' : 'Copy options'}>
             <IconButton
               size="small"

--- a/logstable/src/components/LogRow/ansiColors.css
+++ b/logstable/src/components/LogRow/ansiColors.css
@@ -1,0 +1,93 @@
+/* Light mode defaults */
+:root {
+  --ansi-black:          #000000;
+  --ansi-red:            #cc0000;
+  --ansi-green:          #00aa00;
+  --ansi-yellow:         #aa5500;
+  --ansi-blue:           #0000aa;
+  --ansi-magenta:        #aa00aa;
+  --ansi-cyan:           #00aaaa;
+  --ansi-white:          #aaaaaa;
+  --ansi-bright-black:   #555555;
+  --ansi-bright-red:     #ff5555;
+  --ansi-bright-green:   #55ff55;
+  --ansi-bright-yellow:  #ffff55;
+  --ansi-bright-blue:    #5555ff;
+  --ansi-bright-magenta: #ff55ff;
+  --ansi-bright-cyan:    #55ffff;
+  --ansi-bright-white:   #ffffff;
+}
+
+/* Dark mode overrides — MUI sets [data-mui-color-scheme="dark"] on the root,
+   falling back to OS preference via prefers-color-scheme */
+[data-mui-color-scheme="dark"],
+.dark-mode {
+  --ansi-black:          #555555;
+  --ansi-red:            #ff6b6b;
+  --ansi-green:          #69db7c;
+  --ansi-yellow:         #ffd43b;
+  --ansi-blue:           #74c0fc;
+  --ansi-magenta:        #da77f2;
+  --ansi-cyan:           #66d9e8;
+  --ansi-white:          #ffffff;
+  --ansi-bright-black:   #888888;
+  --ansi-bright-red:     #ff8787;
+  --ansi-bright-green:   #8ce99a;
+  --ansi-bright-yellow:  #ffe066;
+  --ansi-bright-blue:    #a5d8ff;
+  --ansi-bright-magenta: #e599f7;
+  --ansi-bright-cyan:    #99e9f2;
+  --ansi-bright-white:   #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-mui-color-scheme="light"]) {
+    --ansi-black:          #555555;
+    --ansi-red:            #ff6b6b;
+    --ansi-green:          #69db7c;
+    --ansi-yellow:         #ffd43b;
+    --ansi-blue:           #74c0fc;
+    --ansi-magenta:        #da77f2;
+    --ansi-cyan:           #66d9e8;
+    --ansi-white:          #ffffff;
+    --ansi-bright-black:   #888888;
+    --ansi-bright-red:     #ff8787;
+    --ansi-bright-green:   #8ce99a;
+    --ansi-bright-yellow:  #ffe066;
+    --ansi-bright-blue:    #a5d8ff;
+    --ansi-bright-magenta: #e599f7;
+    --ansi-bright-cyan:    #99e9f2;
+    --ansi-bright-white:   #ffffff;
+  }
+}
+
+/* Foreground colors */
+.ansi-black-fg          { color: var(--ansi-black); }
+.ansi-red-fg            { color: var(--ansi-red); }
+.ansi-green-fg          { color: var(--ansi-green); }
+.ansi-yellow-fg         { color: var(--ansi-yellow); }
+.ansi-blue-fg           { color: var(--ansi-blue); }
+.ansi-magenta-fg        { color: var(--ansi-magenta); }
+.ansi-cyan-fg           { color: var(--ansi-cyan); }
+.ansi-white-fg          { color: var(--ansi-white); }
+.ansi-bright-black-fg   { color: var(--ansi-bright-black); }
+.ansi-bright-red-fg     { color: var(--ansi-bright-red); }
+.ansi-bright-green-fg   { color: var(--ansi-bright-green); }
+.ansi-bright-yellow-fg  { color: var(--ansi-bright-yellow); }
+.ansi-bright-blue-fg    { color: var(--ansi-bright-blue); }
+.ansi-bright-magenta-fg { color: var(--ansi-bright-magenta); }
+.ansi-bright-cyan-fg    { color: var(--ansi-bright-cyan); }
+.ansi-bright-white-fg   { color: var(--ansi-bright-white); }
+
+/* Background colors */
+.ansi-black-bg          { background-color: var(--ansi-black); }
+.ansi-red-bg            { background-color: var(--ansi-red); }
+.ansi-green-bg          { background-color: var(--ansi-green); }
+.ansi-yellow-bg         { background-color: var(--ansi-yellow); }
+.ansi-blue-bg           { background-color: var(--ansi-blue); }
+.ansi-magenta-bg        { background-color: var(--ansi-magenta); }
+.ansi-cyan-bg           { background-color: var(--ansi-cyan); }
+.ansi-white-bg          { background-color: var(--ansi-white); }
+
+/* Text decoration */
+.ansi-bold              { font-weight: bold; }

--- a/logstable/src/utils/ansi.test.ts
+++ b/logstable/src/utils/ansi.test.ts
@@ -1,0 +1,145 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ansiToSanitizedHtml, stripAnsi } from './ansi';
+
+describe('ansi utilities', () => {
+  describe('ansiToSanitizedHtml', () => {
+    it('should return null for plain text without ANSI codes', () => {
+      expect(ansiToSanitizedHtml('hello world')).toBeNull();
+    });
+
+    it('should convert red ANSI color to HTML with class', () => {
+      const input = '\x1b[31mERROR\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      expect(result).toContain('ansi-red-fg');
+      expect(result).toContain('ERROR');
+    });
+
+    it('should strip <script> tags for XSS prevention', () => {
+      const input = '\x1b[31m<script>alert("xss")</script>ERROR\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      expect(result).not.toContain('<script>');
+      expect(result).toContain('ERROR');
+    });
+
+    it('should handle multiple colors on one line', () => {
+      const input = '\x1b[31mERROR\x1b[0m \x1b[32mrecovered\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      expect(result).toContain('ansi-red-fg');
+      expect(result).toContain('ansi-green-fg');
+      expect(result).toContain('ERROR');
+      expect(result).toContain('recovered');
+    });
+
+    it('should handle bright color codes', () => {
+      const input = '\x1b[91mtext\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      expect(result).toContain('ansi-bright-red-fg');
+      expect(result).toContain('text');
+    });
+
+    it('should handle 256-color codes with inline style', () => {
+      const input = '\x1b[38;5;196mtext\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      expect(result).toContain('style');
+      expect(result).toContain('text');
+    });
+
+    it('should handle background color', () => {
+      const input = '\x1b[41mhighlighted\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      expect(result).toContain('ansi-red-bg');
+      expect(result).toContain('highlighted');
+    });
+
+    it('should handle bold text', () => {
+      const input = '\x1b[1mIMPORTANT\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      expect(result).toContain('font-weight:bold');
+      expect(result).toContain('IMPORTANT');
+    });
+
+    it('should preserve plain text mixed with ANSI colored text', () => {
+      const input = 'plain \x1b[31mred\x1b[0m plain';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      expect(result).toContain('plain');
+      expect(result).toContain('ansi-red-fg');
+      expect(result).toContain('red');
+    });
+
+    it('should strip event handler XSS via onerror', () => {
+      const input = '\x1b[31m<img src=x onerror="alert(1)">\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      // ansi_up escapes < and > so no actual <img> tag is rendered
+      expect(result).not.toContain('<img');
+      // The content is HTML-escaped, so it is safe text, not executable
+      expect(result).toContain('&lt;img');
+    });
+
+    it('should strip malicious javascript href XSS', () => {
+      const input = '\x1b[31m<a href="javascript:alert(1)">click</a>\x1b[0m';
+      const result = ansiToSanitizedHtml(input);
+      expect(result).not.toBeNull();
+      // ansi_up escapes < and > so no actual <a> tag is rendered
+      expect(result).not.toContain('<a ');
+      expect(result).not.toContain('</a>');
+      // The content is HTML-escaped, so it is safe text, not executable
+      expect(result).toContain('&lt;a');
+    });
+
+    it('should return null for empty string', () => {
+      expect(ansiToSanitizedHtml('')).toBeNull();
+    });
+
+    it('should handle a lone reset code gracefully', () => {
+      const result = ansiToSanitizedHtml('\x1b[0m');
+      // Should not crash; result is either null or empty/minimal HTML
+      if (result !== null) {
+        expect(typeof result).toBe('string');
+      }
+    });
+  });
+
+  describe('stripAnsi', () => {
+    it('should remove ANSI codes from text', () => {
+      const input = '\x1b[31mERROR\x1b[0m something went wrong';
+      expect(stripAnsi(input)).toBe('ERROR something went wrong');
+    });
+
+    it('should return plain text unchanged', () => {
+      expect(stripAnsi('hello world')).toBe('hello world');
+    });
+
+    it('should strip multiple ANSI codes including bold and color', () => {
+      expect(stripAnsi('\x1b[1m\x1b[31mBOLD RED\x1b[0m')).toBe('BOLD RED');
+    });
+
+    it('should strip 256-color codes', () => {
+      expect(stripAnsi('\x1b[38;5;196mtext\x1b[0m')).toBe('text');
+    });
+
+    it('should preserve non-ANSI special characters', () => {
+      expect(stripAnsi('hello [world] {test}')).toBe('hello [world] {test}');
+    });
+  });
+});

--- a/logstable/src/utils/ansi.ts
+++ b/logstable/src/utils/ansi.ts
@@ -1,0 +1,38 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AnsiUp } from 'ansi_up';
+import DOMPurify from 'dompurify';
+
+const ansiUp = new AnsiUp();
+ansiUp.use_classes = true;
+
+const ESC = String.fromCharCode(27);
+const ANSI_REGEX = new RegExp(ESC + '\\[[0-9;]*m');
+
+export function ansiToSanitizedHtml(text: string): string | null {
+  if (!ANSI_REGEX.test(text)) {
+    return null;
+  }
+  const html = ansiUp.ansi_to_html(text);
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ['span'],
+    ALLOWED_ATTR: ['class', 'style'],
+  });
+}
+
+const ANSI_STRIP_REGEX = new RegExp(ESC + '\\[[0-9;]*m', 'g');
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_STRIP_REGEX, '');
+}

--- a/logstable/src/utils/copyHelpers.test.ts
+++ b/logstable/src/utils/copyHelpers.test.ts
@@ -117,4 +117,37 @@ describe('copyHelpers', () => {
       expect(result).not.toContain('\n');
     });
   });
+
+  describe('ANSI stripping', () => {
+    it('should strip ANSI codes from log message when copying', () => {
+      const ansiLog: LogEntry = {
+        timestamp: 1767225600,
+        line: '\x1b[31mERROR\x1b[0m connection refused',
+        labels: {},
+      };
+      expect(formatLogMessage(ansiLog)).toBe('ERROR connection refused');
+    });
+
+    it('should strip ANSI codes from full log entry when copying', () => {
+      const ansiLog: LogEntry = {
+        timestamp: 1767225600,
+        line: '\x1b[32mINFO\x1b[0m server started',
+        labels: { level: 'info' },
+      };
+      const result = formatLogEntry(ansiLog);
+      expect(result).not.toContain('\x1b[');
+      expect(result).toContain('INFO server started');
+    });
+
+    it('should preserve ANSI codes in JSON format', () => {
+      const ansiLog: LogEntry = {
+        timestamp: 1767225600,
+        line: '\x1b[31mERROR\x1b[0m',
+        labels: {},
+      };
+      const result = formatLogAsJson(ansiLog);
+      const parsed = JSON.parse(result);
+      expect(parsed.line).toBe('\x1b[31mERROR\x1b[0m');
+    });
+  });
 });

--- a/logstable/src/utils/copyHelpers.ts
+++ b/logstable/src/utils/copyHelpers.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import { LogEntry } from '@perses-dev/core';
+import { stripAnsi } from './ansi';
 
 /**
  * Formats a timestamp for display in copied text
@@ -44,14 +45,15 @@ export function formatLabels(labels: Record<string, string>): string {
 export function formatLogEntry(log: LogEntry): string {
   const timestamp = formatTimestamp(log.timestamp);
   const labels = formatLabels(log.labels || {});
-  return labels ? `${timestamp} ${labels} ${log.line}` : `${timestamp} ${log.line}`;
+  const cleanLine = stripAnsi(log.line);
+  return labels ? `${timestamp} ${labels} ${cleanLine}` : `${timestamp} ${cleanLine}`;
 }
 
 /**
  * Formats just the log message text (no timestamp or labels)
  */
 export function formatLogMessage(log: LogEntry): string {
-  return log.line;
+  return stripAnsi(log.line);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,6 +254,10 @@
     "logstable": {
       "name": "@perses-dev/logs-table-plugin",
       "version": "0.2.1",
+      "dependencies": {
+        "ansi_up": "^6.0.0",
+        "dompurify": "^3.2.3"
+      },
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -6913,6 +6917,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/ansi_up": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-6.0.6.tgz",
+      "integrity": "sha512-yIa1x3Ecf8jWP4UWEunNjqNX6gzE4vg2gGz+xqRGY+TBSucnYp6RRdPV4brmtg6bQ1ljD48mZ5iGSEj7QEpRKA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",


### PR DESCRIPTION
# Description

Adds support for ansi coloring inside the logs table messages and details

closes: https://github.com/perses/perses/issues/4028

# Screenshots

<img width="905" height="271" alt="Screenshot 2026-05-05 at 09 16 56" src="https://github.com/user-attachments/assets/2e68d171-55aa-4e3b-924d-f29412afa08f" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
