### PR TITLE
[BUGFIX] parse text errors from Loki api to display errors correctly

### DIFF
--- a/loki/src/model/loki-client.ts
+++ b/loki/src/model/loki-client.ts
@@ -76,6 +76,16 @@ export interface LokiClient {
   ) => Promise<LokiIndexStatsResponse>;
 }
 
+async function handleErrorResponse(response: Response): Promise<void> {
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    const errorJson = await response.json();
+    throw new Error(`Loki query_range error: ${response.status} ${response.statusText} - ${JSON.stringify(errorJson)}`);
+  }
+  const errorText = await response.text();
+  throw new Error(`Loki query_range error: ${response.status} ${response.statusText} - ${errorText}`);
+}
+
 export async function query(params: LokiQueryParams, options: LokiApiOptions): Promise<LokiQueryResponse> {
   const url = buildUrl('/loki/api/v1/query', options.datasourceUrl);
   url.searchParams.append('query', params.query);
@@ -90,6 +100,11 @@ export async function query(params: LokiQueryParams, options: LokiApiOptions): P
       ...options.headers,
     },
   });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
   return response.json();
 }
 
@@ -145,6 +160,11 @@ export async function queryRange(
       ...options.headers,
     },
   });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
   return response.json();
 }
 
@@ -164,6 +184,11 @@ export async function labels(
       ...options.headers,
     },
   });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
   return response.json();
 }
 
@@ -184,6 +209,11 @@ export async function labelValues(
       ...options.headers,
     },
   });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
   return response.json();
 }
 
@@ -205,6 +235,11 @@ export async function series(
       ...options.headers,
     },
   });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
   return response.json();
 }
 
@@ -223,6 +258,11 @@ export async function volume(params: LokiVolumeParams, options: LokiApiOptions):
       ...options.headers,
     },
   });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
   return response.json();
 }
 
@@ -241,6 +281,11 @@ export async function volumeRange(params: LokiVolumeParams, options: LokiApiOpti
       ...options.headers,
     },
   });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
   return response.json();
 }
 
@@ -262,5 +307,10 @@ export async function indexStats(
       ...options.headers,
     },
   });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
   return response.json();
 }


### PR DESCRIPTION
# Description

Errors in the Loki API are returned as plain text, this PR fixes the error parsing to display errors correctly

# Screenshots

Before:
<img width="927" height="370" alt="Screenshot 2026-05-05 at 09 24 29" src="https://github.com/user-attachments/assets/f15ac407-a6fd-4a24-94d9-eab4d054e5fe" />

After:
<img width="925" height="332" alt="Screenshot 2026-05-05 at 09 25 00" src="https://github.com/user-attachments/assets/e419cd0f-9539-4b40-bb58-c022606ae528" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
