### PR TITLE
[BUGFIX] table go-sdk: fix Density constant values

### DIFF
--- a/table/sdk/go/table.go
+++ b/table/sdk/go/table.go
@@ -27,8 +27,9 @@ const PluginKind = "Table"
 type Density string
 
 const (
-	CompactDensity  Density = "auto"
-	StandardDensity Density = "always"
+	CompactDensity     Density = "compact"
+	StandardDensity    Density = "standard"
+	ComfortableDensity Density = "comfortable"
 )
 
 type Align string


### PR DESCRIPTION
# Description

The `Density` constants in the table plugin's Go SDK held values the cue schema rejects (`"auto"`, `"always"`), so any dashboard built with `table.WithDensity(table.CompactDensity)` or `table.StandardDensity` failed to load against the schema's [`"compact" | "standard" | "comfortable"`](https://github.com/perses/plugins/blob/c37625a836fbf56d837e0842603d6daa7552ba4f/table/schemas/table.cue#L24) disjunction. Aligned the constants with the schema and added the missing `ComfortableDensity`.

Investigated and authored with Claude Code.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
