### PR TITLE
[ENHANCEMENT] Improve table migration: handle column overrides and fix Value column naming

### DIFF
--- a/table/schemas/migrate/migrate.cue
+++ b/table/schemas/migrate/migrate.cue
@@ -24,12 +24,22 @@ import (
 #grafanaType: "table" | "table-old"
 #panel:       _
 
+// Build "Value #X" → "value #N" mapping from the targets array.
+// In Grafana, multi-query table panels name value columns by refId (e.g. "Value #A", "Value #B").
+// In Perses, the equivalent columns are named by 1-based query index (e.g. "value #1", "value #2").
+_valueColumnRenameMap: {
+	for i, target in (*#panel.targets | []) if target.refId != _|_ {
+		"Value #\(target.refId)": "value #\(i+1)"
+	}
+}
+
 // Function to rename anonymous fields that Perses names differently than Grafana
 _renameAnonymousFields: {
 	#var: string
 	output: [
 		if #var == "Time" {"timestamp"},
 		if #var == "Value" {"value"},
+		if (*_valueColumnRenameMap[#var] | null) != null {_valueColumnRenameMap[#var]},
 		#var,
 	][0]
 }
@@ -124,6 +134,19 @@ spec: {
 							}
 						}
 					}
+					if property.id == "unit" {
+						"\({_reuseMatchingName & {#var: override.matcher.options}}.output)": units: "\(property.value)": true
+					}
+					if property.id == "noValue" {
+						"\({_reuseMatchingName & {#var: override.matcher.options}}.output)": noValues: "\(property.value)": true
+					}
+					if property.id == "mappings" {
+						for mapping in property.value if mapping.type == "value" {
+							for key, option in mapping.options {
+								"\({_reuseMatchingName & {#var: override.matcher.options}}.output)": valueMappings: "\(key)": option
+							}
+						}
+					}
 					// NB: enrich this part when this is done https://github.com/perses/perses/issues/2852
 				}
 			}
@@ -146,6 +169,44 @@ spec: {
 					}
 					if settings.dataLinks != _|_ {
 						dataLink: {_getLastValue & {#map: settings.dataLinks}}.output
+					}
+
+					// Unit override → format (only emit if unit is recognized by Perses)
+					if settings.units != _|_ if len(settings.units) > 0 {
+						_unitStr: {_getLastKey & {#map: settings.units}}.output
+						_resolvedUnit: *commonMigrate.#mapping.unit[_unitStr] | null
+						if _resolvedUnit != null {
+							format: unit: _resolvedUnit
+						}
+					}
+
+					// noValue + valueMappings → cellSettings
+					_noValueEntries: [
+						if settings.noValues != _|_ if len(settings.noValues) > 0 {{
+							condition: {
+								kind: "Misc"
+								spec: value: "null"
+							}
+							text: {_getLastKey & {#map: settings.noValues}}.output
+						}},
+					]
+					_mappingEntries: [
+						for key, option in (*settings.valueMappings | {}) {{
+							condition: {
+								kind: "Value"
+								spec: value: key
+							}
+							if option.text != _|_ {
+								text: option.text
+							}
+							if option.color != _|_ {
+								backgroundColor: *commonMigrate.#mapping.color[option.color] | option.color
+							}
+						}},
+					]
+					_columnCellSettings: list.Concat([_noValueEntries, _mappingEntries])
+					if len(_columnCellSettings) > 0 {
+						cellSettings: _columnCellSettings
 					}
 				}
 			}

--- a/table/schemas/migrate/tests/unit-mappings-novalue-from-overrides/expected.json
+++ b/table/schemas/migrate/tests/unit-mappings-novalue-from-overrides/expected.json
@@ -1,0 +1,73 @@
+{
+  "kind": "Table",
+  "spec": {
+    "columnSettings": [
+      {
+        "cellSettings": [
+          {
+            "condition": {
+              "kind": "Misc",
+              "spec": {
+                "value": "null"
+              }
+            },
+            "text": "False"
+          },
+          {
+            "condition": {
+              "kind": "Value",
+              "spec": {
+                "value": "0"
+              }
+            },
+            "text": "False"
+          },
+          {
+            "condition": {
+              "kind": "Value",
+              "spec": {
+                "value": "1"
+              }
+            },
+            "text": "True"
+          }
+        ],
+        "header": "Enabled",
+        "name": "value #3"
+      },
+      {
+        "cellSettings": [
+          {
+            "condition": {
+              "kind": "Misc",
+              "spec": {
+                "value": "null"
+              }
+            },
+            "text": "0 B"
+          }
+        ],
+        "header": "Memory",
+        "name": "value #2"
+      },
+      {
+        "format": {
+          "unit": "percent"
+        },
+        "header": "CPU %",
+        "name": "value #1"
+      },
+      {
+        "hide": true,
+        "name": "timestamp"
+      }
+    ],
+    "density": "compact",
+    "transforms": [
+      {
+        "kind": "MergeSeries",
+        "spec": {}
+      }
+    ]
+  }
+}

--- a/table/schemas/migrate/tests/unit-mappings-novalue-from-overrides/input.json
+++ b/table/schemas/migrate/tests/unit-mappings-novalue-from-overrides/input.json
@@ -1,0 +1,158 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "thresholds"
+      },
+      "custom": {
+        "align": "auto",
+        "cellOptions": {
+          "type": "auto"
+        },
+        "inspect": false
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      }
+    },
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "CPU %"
+        },
+        "properties": [
+          {
+            "id": "unit",
+            "value": "percent"
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Memory"
+        },
+        "properties": [
+          {
+            "id": "unit",
+            "value": "decgbytes"
+          },
+          {
+            "id": "noValue",
+            "value": "0 B"
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "Enabled"
+        },
+        "properties": [
+          {
+            "id": "mappings",
+            "value": [
+              {
+                "options": {
+                  "0": {
+                    "text": "False"
+                  },
+                  "1": {
+                    "text": "True"
+                  }
+                },
+                "type": "value"
+              }
+            ]
+          },
+          {
+            "id": "noValue",
+            "value": "False"
+          }
+        ]
+      }
+    ]
+  },
+  "gridPos": {
+    "h": 20,
+    "w": 24,
+    "x": 0,
+    "y": 0
+  },
+  "id": 2,
+  "options": {
+    "cellHeight": "sm",
+    "showHeader": true
+  },
+  "pluginVersion": "10.1.8",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "expr": "node_cpu_usage_percent{job=\"node\"}",
+      "format": "table",
+      "instant": true,
+      "refId": "A"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "expr": "node_memory_total_bytes{job=\"node\"}",
+      "format": "table",
+      "instant": true,
+      "refId": "B"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "expr": "node_feature_enabled{job=\"node\"}",
+      "format": "table",
+      "instant": true,
+      "refId": "C"
+    }
+  ],
+  "title": "Table with overrides",
+  "transformations": [
+    {
+      "id": "merge",
+      "options": {}
+    },
+    {
+      "id": "organize",
+      "options": {
+        "excludeByName": {
+          "Time": true
+        },
+        "indexByName": {
+          "Value #A": 2,
+          "Value #B": 1,
+          "Value #C": 0
+        },
+        "renameByName": {
+          "Value #A": "CPU %",
+          "Value #B": "Memory",
+          "Value #C": "Enabled"
+        }
+      }
+    }
+  ],
+  "type": "table"
+}

--- a/table/schemas/migrate/tests/value-column-refid-rename/expected.json
+++ b/table/schemas/migrate/tests/value-column-refid-rename/expected.json
@@ -1,0 +1,30 @@
+{
+  "kind": "Table",
+  "spec": {
+    "columnSettings": [
+      {
+        "header": "Third Metric",
+        "name": "value #3"
+      },
+      {
+        "header": "First Metric",
+        "name": "value #1"
+      },
+      {
+        "hide": true,
+        "name": "timestamp"
+      },
+      {
+        "hide": true,
+        "name": "value #2"
+      }
+    ],
+    "density": "compact",
+    "transforms": [
+      {
+        "kind": "MergeSeries",
+        "spec": {}
+      }
+    ]
+  }
+}

--- a/table/schemas/migrate/tests/value-column-refid-rename/input.json
+++ b/table/schemas/migrate/tests/value-column-refid-rename/input.json
@@ -1,0 +1,100 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "thresholds"
+      },
+      "custom": {
+        "align": "auto",
+        "cellOptions": {
+          "type": "auto"
+        },
+        "inspect": false
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 0
+  },
+  "id": 1,
+  "options": {
+    "cellHeight": "sm",
+    "showHeader": true
+  },
+  "pluginVersion": "10.1.8",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "expr": "metric_a",
+      "format": "table",
+      "instant": true,
+      "refId": "A"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "expr": "metric_b",
+      "format": "table",
+      "instant": true,
+      "refId": "B"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "expr": "metric_c",
+      "format": "table",
+      "instant": true,
+      "refId": "C"
+    }
+  ],
+  "title": "Multi-query table with refId rename",
+  "transformations": [
+    {
+      "id": "merge",
+      "options": {}
+    },
+    {
+      "id": "organize",
+      "options": {
+        "excludeByName": {
+          "Time": true,
+          "Value #B": true
+        },
+        "indexByName": {
+          "Value #A": 1,
+          "Value #C": 0
+        },
+        "renameByName": {
+          "Value #A": "First Metric",
+          "Value #C": "Third Metric"
+        }
+      }
+    }
+  ],
+  "type": "table"
+}


### PR DESCRIPTION
# Description

Improves the Grafana-to-Perses table migration CUE script to handle previously-unsupported field override properties and fixes the `Value #X` → `value #N` column naming mismatch.

Fixes https://github.com/perses/perses/issues/4063

## Problem

When migrating a Grafana table panel with multiple queries and column overrides, several issues occurred:
1. **Column naming mismatch** — Grafana names multi-query value columns by refId (`Value #A`, `Value #B`), but Perses uses 1-based query index (`value #1`, `value #2`). The migrated column settings didn't match actual rendered column names, making them ineffective.
2. **Missing column overrides** — Grafana field overrides for `unit`, `mappings`, and `noValue` were completely ignored during migration, resulting in:
   - No unit formatting on columns (e.g., percent)
   - No value mappings (e.g., `0` → `"False"`, `1` → `"True"`)
   - No fallback text for null values

## Changes

### 1. Fix Value column naming (refId → index)
Builds a mapping from the `targets` array to convert Grafana's refId-based naming to Perses's index-based naming automatically:
- `Value #A` → `value #1` (first query)
- `Value #B` → `value #2` (second query)
- ....

### 2. Handle `unit` override → per-column `format`
Grafana field overrides with `"id": "unit"` are now converted to `format: {unit: "..."}` on the corresponding column setting. Only units recognized by Perses are emitted (e.g., `percent`, `bytes`, `seconds`). Unrecognized Grafana-specific units (e.g., `decgbytes`, `dectbytes`) are skipped.

### 3. Handle `mappings` override → per-column `cellSettings`
Grafana field overrides with `"id": "mappings"` (value-type) are now converted to column-level `cellSettings` entries with `Value` conditions.

### 4. Handle `noValue` override → per-column `cellSettings`
Grafana field overrides with `"id": "noValue"` are now converted to a `cellSettings` entry with a `Misc` condition for `"null"`, displaying the specified fallback text when a cell has no value.

I have added couple of tests for these changes. All the existing 23 tests are passing as well.

## Limitations
- Grafana units without a Perses equivalent (`decgbytes`, `dectbytes`, `kbytes`, `mbytes`, `gbytes`, `tbytes`) are not migrated.  These columns are left unformatted. A future Perses enhancement could add support for these scaled byte units.
- The `JoinByColumnValue` transform cannot be inferred automatically from Grafana's `merge` transformation (which works implicitly). Users may need to add this manually after migration for multi-query tables.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
