### PR TITLE
[ENHANCEMENT] TraceTable: enable word wrap on spans and start time columns

### DIFF
--- a/tracetable/src/DataTable.tsx
+++ b/tracetable/src/DataTable.tsx
@@ -156,7 +156,7 @@ export function DataTable(props: DataTableProps): ReactElement {
         headerAlign: 'left',
         align: 'left',
         flex: 2,
-        minWidth: 145,
+        minWidth: 90,
         display: 'flex',
         valueGetter: (_, trace): number =>
           Object.values(trace.serviceStats).reduce((acc, val) => acc + val.spanCount, 0),
@@ -168,19 +168,18 @@ export function DataTable(props: DataTableProps): ReactElement {
             totalErrorCount += stats.errorCount ?? 0;
           }
           return (
-            <>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1, my: 1 }}>
               <Typography display="inline">{totalSpanCount} spans</Typography>
               {totalErrorCount > 0 && (
                 <Chip
                   label={`${totalErrorCount} error${totalErrorCount === 1 ? '' : 's'}`}
-                  sx={{ marginLeft: '5px' }}
                   icon={<InformationIcon />}
                   variant="outlined"
                   size="small"
                   color="error"
                 />
               )}
-            </>
+            </Box>
           );
         },
       },
@@ -205,8 +204,8 @@ export function DataTable(props: DataTableProps): ReactElement {
         type: 'number',
         headerAlign: 'left',
         align: 'left',
-        flex: 3,
-        minWidth: 240,
+        flex: 2,
+        minWidth: 110,
         display: 'flex',
         renderCell: ({ row }): ReactElement => (
           <Tooltip title={UTC_DATE_FORMATTER(new Date(row.startTimeUnixMs))} placement="top" arrow>


### PR DESCRIPTION
# Description

Reduce the min width of the _Spans_ and _Start time_ columns to enable word wrapping. This is important when the table has a small width (see screenshots).

# Screenshots

Before:
<img width="400" alt="Before" src="https://github.com/user-attachments/assets/813838e6-5f35-426b-84dc-3ddb3e090f6b" />

After:
<img width="400" alt="After" src="https://github.com/user-attachments/assets/9bb5fa9c-fb88-4638-8af0-92108c52c3fe" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
