### PR TITLE
Prepare tempo release v0.58.0-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,9 +6176,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17468,7 +17468,7 @@
     },
     "tempo": {
       "name": "@perses-dev/tempo-plugin",
-      "version": "0.57.1",
+      "version": "0.58.0-beta.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.0",
         "@grafana/lezer-traceql": "^0.0.25",

--- a/tempo/package.json
+++ b/tempo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tempo-plugin",
-  "version": "0.57.1",
+  "version": "0.58.0-beta.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepare the tempo plugin v0.58.0-beta.0 release.

closes: https://github.com/perses/perses/issues/4070