### PR TITLE
fix(markdown): add npm license metadata

### DIFF
--- a/markdown/package.json
+++ b/markdown/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@perses-dev/markdown-plugin",
   "version": "0.12.0-beta.0",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add npm license metadata to `@perses-dev/markdown-plugin`.
- Use `Apache-2.0`, matching the repository LICENSE.

## Validation
- `node -e "const p=require('./markdown/package.json'); if(p.name!=='@perses-dev/markdown-plugin') throw new Error('wrong package'); if(p.license!=='Apache-2.0') throw new Error('missing license'); console.log(JSON.stringify({name:p.name,version:p.version,license:p.license}))"`
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts ./markdown`