### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "perses-plugins",
   "description": "Monorepo for the Perses plugins",
   "version": "0.1.0",
+  "bugs": {
+    "url": "https://github.com/perses/plugins/issues"
+  },
   "scripts": {
     "dev": "turbo run dev --concurrency 20",
     "build": "turbo run build",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.