### PR TITLE
ci(plugins): remove docker ecosystem from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,4 @@ updates:
       actions:
         patterns:
           - "*"
-  - package-ecosystem: "docker"
-    directories:
-      - "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      docker:
-        patterns:
-          - "*"
+


### PR DESCRIPTION
No Dockerfiles exist in this repo, so Dependabot errors when scanning / for Docker dependencies. Remove the docker ecosystem entry since it cannot produce any updates.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
