### PR TITLE
[ENHANCEMENT] TraceTable: use timezone setting from TimeRangeSelector

### DIFF
--- a/tracetable/src/DataTable.tsx
+++ b/tracetable/src/DataTable.tsx
@@ -15,7 +15,7 @@ import { Avatar, Box, Chip, Link, Tooltip, Typography, useTheme } from '@mui/mat
 import { PanelData, replaceVariablesInString, useAllVariableValues, useRouterContext } from '@perses-dev/plugin-system';
 import { useSelectionItemActions } from '@perses-dev/dashboards';
 import InformationIcon from 'mdi-material-ui/Information';
-import { useChartsTheme, useSelection } from '@perses-dev/components';
+import { useChartsTheme, useSelection, useTimeZone } from '@perses-dev/components';
 import { DataGrid, GridColDef, GridRowSelectionModel } from '@mui/x-data-grid';
 import { ReactElement, ReactNode, useCallback, useMemo } from 'react';
 import {
@@ -29,14 +29,19 @@ import {
 import { getServiceColor } from './utils/utils';
 import { TraceTableOptions } from './trace-table-model';
 
-const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'long',
-  timeStyle: 'medium',
-}).format;
-const UTC_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'long',
-  timeStyle: 'long',
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  fractionalSecondDigits: 3,
+};
+const dateFormatterUTC = new Intl.DateTimeFormat(undefined, {
+  ...DATE_FORMAT_OPTIONS,
   timeZone: 'UTC',
+  timeZoneName: 'short',
 }).format;
 
 export type TraceLink = (params: { query: QueryDefinition; traceId: string }) => string;
@@ -55,6 +60,12 @@ export function DataTable(props: DataTableProps): ReactElement {
   const muiTheme = useTheme();
   const chartsTheme = useChartsTheme();
   const variableValues = useAllVariableValues();
+  const { dateFormatOptionsWithUserTimeZone } = useTimeZone();
+
+  const dateFormatter = useMemo(() => {
+    const dateFormatOptions = dateFormatOptionsWithUserTimeZone(DATE_FORMAT_OPTIONS);
+    return new Intl.DateTimeFormat(undefined, dateFormatOptions).format;
+  }, [dateFormatOptionsWithUserTimeZone]);
 
   const selectionEnabled = options.selection?.enabled ?? false;
   const { selectionMap, setSelection, clearSelection } = useSelection<Row, string>();
@@ -208,9 +219,9 @@ export function DataTable(props: DataTableProps): ReactElement {
         minWidth: 110,
         display: 'flex',
         renderCell: ({ row }): ReactElement => (
-          <Tooltip title={UTC_DATE_FORMATTER(new Date(row.startTimeUnixMs))} placement="top" arrow>
-            <Typography display="inline" key={`st-${row.traceId}`}>
-              {DATE_FORMATTER(new Date(row.startTimeUnixMs))}
+          <Tooltip title={dateFormatterUTC(row.startTimeUnixMs)} placement="top" arrow>
+            <Typography component="span" key={`st-${row.traceId}`}>
+              {dateFormatter(row.startTimeUnixMs)}
             </Typography>
           </Tooltip>
         ),
@@ -229,7 +240,7 @@ export function DataTable(props: DataTableProps): ReactElement {
           ]
         : []),
     ],
-    [serviceColorGenerator, actionsList, getItemActionButtons]
+    [serviceColorGenerator, actionsList, getItemActionButtons, dateFormatter]
   );
 
   return (

--- a/tracetable/src/TraceTablePanel.test.tsx
+++ b/tracetable/src/TraceTablePanel.test.tsx
@@ -63,6 +63,6 @@ describe('TraceTablePanel', () => {
     expect(lastRow).toHaveTextContent('2 errors'); // span count
     expect(lastRow).toHaveTextContent('100ms'); // duration
     // TODO IMPORTANT: https://github.com/perses/perses/issues/4090
-    expect(lastRow).toHaveTextContent('December 18, 2023 at 4:07:25 PM'); // start time
+    expect(lastRow).toHaveTextContent('December 18, 2023 at 4:07:25.000 PM'); // start time
   });
 });


### PR DESCRIPTION
# Description

tracetable: use timezone setting from TimeRangeSelector instead of local time

# Screenshots

No UI changes, except that the timezone from the TimeRangeSelector is respected.

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
