### PR TITLE
[ENHANCEMENT] TracingGanttChart: show UTC time on hover

### DIFF
--- a/tracingganttchart/src/TracingGanttChart/TraceHeaderBar.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TraceHeaderBar.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { IconButton, Stack, Typography } from '@mui/material';
+import { IconButton, Stack, Tooltip, Typography } from '@mui/material';
 import MagnifyIcon from 'mdi-material-ui/Magnify';
 import { ReactElement, useMemo, useState } from 'react';
 import { useTimeZone } from '@perses-dev/components';
@@ -27,8 +27,12 @@ const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   minute: 'numeric',
   second: 'numeric',
   fractionalSecondDigits: 3,
-  timeZoneName: 'short',
 };
+const dateFormatterUTC = new Intl.DateTimeFormat(undefined, {
+  ...DATE_FORMAT_OPTIONS,
+  timeZone: 'UTC',
+  timeZoneName: 'short',
+}).format;
 
 export interface TraceHeaderBarProps {
   trace: Trace;
@@ -41,7 +45,7 @@ export function TraceHeaderBar(props: TraceHeaderBarProps): ReactElement {
   const { dateFormatOptionsWithUserTimeZone } = useTimeZone();
   const dateFormatter = useMemo(() => {
     const dateFormatOptions = dateFormatOptionsWithUserTimeZone(DATE_FORMAT_OPTIONS);
-    return new Intl.DateTimeFormat(undefined, dateFormatOptions);
+    return new Intl.DateTimeFormat(undefined, dateFormatOptions).format;
   }, [dateFormatOptionsWithUserTimeZone]);
   const [showSearch, setShowSearch] = useState(false);
 
@@ -64,7 +68,10 @@ export function TraceHeaderBar(props: TraceHeaderBarProps): ReactElement {
         </Stack>
         <Typography variant="h4">
           <Typography component="span" sx={{ px: 1 }}>
-            <strong>Start:</strong> {dateFormatter.format(trace.startTimeUnixMs)}
+            <strong>Start:</strong>{' '}
+            <Tooltip title={dateFormatterUTC(trace.startTimeUnixMs)} placement="top" arrow>
+              <Typography component="span">{dateFormatter(trace.startTimeUnixMs)}</Typography>
+            </Tooltip>
           </Typography>
           <Typography component="span" sx={{ px: 1 }}>
             <strong>Trace ID:</strong> {rootSpan.traceId}


### PR DESCRIPTION
# Description

TracingGanttChart: show UTC time in tooltip when hovering over the start time

# Screenshots

Example with America/Merida timezone (and German locale):
<img width="1288" height="196" alt="image" src="https://github.com/user-attachments/assets/83c31790-38b5-4f86-b144-ab8bf1931ac6" />


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
