### PR TITLE
[BUGFIX] set shortValues according to the unit

### DIFF
--- a/barchart/src/BarChartOptionsEditorSettings.tsx
+++ b/barchart/src/BarChartOptionsEditorSettings.tsx
@@ -26,6 +26,7 @@ import {
   FormatControlsProps,
   FormatOptions,
   isPercentUnit,
+  isUnitWithShortValues,
   ModeOption,
   ModeSelector,
   ModeSelectorProps,
@@ -44,6 +45,7 @@ import {
 } from '@perses-dev/plugin-system';
 import { produce } from 'immer';
 import merge from 'lodash/merge';
+import omit from 'lodash/omit';
 import { MouseEventHandler, ReactElement } from 'react';
 import {
   BarChartOptions,
@@ -106,7 +108,11 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
   };
 
   // ensures decimalPlaces defaults to correct value
-  const format = merge({}, DEFAULT_FORMAT, value.format);
+  const format = merge(
+    {},
+    !value.format || isUnitWithShortValues(value.format) ? DEFAULT_FORMAT : omit(DEFAULT_FORMAT, ['shortValues']),
+    value.format
+  );
   const groupBy = value.groupBy ?? DEFAULT_GROUP_BY;
   const isStacked = value.isStacked ?? DEFAULT_IS_STACKED;
 

--- a/piechart/src/PieChartOptionsEditorSettings.tsx
+++ b/piechart/src/PieChartOptionsEditorSettings.tsx
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 import merge from 'lodash/merge';
+import omit from 'lodash/omit';
 import {
   CalculationSelector,
   CalculationSelectorProps,
@@ -37,6 +38,7 @@ import {
   useChartsTheme,
   FormatOptions,
   isPercentUnit,
+  isUnitWithShortValues,
 } from '@perses-dev/components';
 import {
   Button,
@@ -125,7 +127,11 @@ export function PieChartOptionsEditorSettings(props: PieChartOptionsEditorProps)
   };
 
   // ensures decimalPlaces defaults to correct value
-  const format = merge({}, DEFAULT_FORMAT, value.format);
+  const format = merge(
+    {},
+    !value.format || isUnitWithShortValues(value.format) ? DEFAULT_FORMAT : omit(DEFAULT_FORMAT, ['shortValues']),
+    value.format
+  );
 
   type ColorScheme = 'default' | 'theme' | 'gradient';
 


### PR DESCRIPTION
fixes https://github.com/perses/perses/issues/4186

# Description
Not all format options include `shortValues`. So, `shortValues` is not a default property of the `formatOptions` object.

<img width="1369" height="831" alt="image" src="https://github.com/user-attachments/assets/0463cb90-8176-4890-9ca9-9ed78e378579" />

 


# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
