### PR TITLE
[ENHANCEMENT] TracingGanttChart: make trace header bar responsive

### DIFF
--- a/tracingganttchart/src/TracingGanttChart/TraceHeaderBar.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TraceHeaderBar.tsx
@@ -56,7 +56,7 @@ export function TraceHeaderBar(props: TraceHeaderBarProps): ReactElement {
 
   return (
     <Stack direction="column" sx={{ gap: 1 }}>
-      <Stack direction="row" sx={{ justifyContent: 'space-between' }}>
+      <Stack direction="row" sx={{ gap: 1, justifyContent: 'space-between', flexWrap: 'wrap' }}>
         <Stack direction="row" sx={{ gap: 1, alignItems: 'center' }}>
           <Typography variant="h3">
             {rootSpan.resource.serviceName}: {rootSpan.name} (
@@ -66,17 +66,17 @@ export function TraceHeaderBar(props: TraceHeaderBarProps): ReactElement {
             <MagnifyIcon fontSize="small" />
           </IconButton>
         </Stack>
-        <Typography variant="h4">
-          <Typography component="span" sx={{ px: 1 }}>
+        <Stack direction="row" sx={{ rowGap: 1, columnGap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
+          <Typography component="span">
             <strong>Start:</strong>{' '}
             <Tooltip title={dateFormatterUTC(trace.startTimeUnixMs)} placement="top" arrow>
               <Typography component="span">{dateFormatter(trace.startTimeUnixMs)}</Typography>
             </Tooltip>
           </Typography>
-          <Typography component="span" sx={{ px: 1 }}>
+          <Typography component="span">
             <strong>Trace ID:</strong> {rootSpan.traceId}
           </Typography>
-        </Typography>
+        </Stack>
       </Stack>
       {showSearch && <SearchBar search={search} />}
     </Stack>

--- a/tracingganttchart/src/TracingGanttChart/TraceHeaderBar.tsx
+++ b/tracingganttchart/src/TracingGanttChart/TraceHeaderBar.tsx
@@ -67,13 +67,13 @@ export function TraceHeaderBar(props: TraceHeaderBarProps): ReactElement {
           </IconButton>
         </Stack>
         <Stack direction="row" sx={{ rowGap: 1, columnGap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
-          <Typography component="span">
+          <Typography variant="h4" sx={{ fontWeight: 'normal' }}>
             <strong>Start:</strong>{' '}
             <Tooltip title={dateFormatterUTC(trace.startTimeUnixMs)} placement="top" arrow>
               <Typography component="span">{dateFormatter(trace.startTimeUnixMs)}</Typography>
             </Tooltip>
           </Typography>
-          <Typography component="span">
+          <Typography variant="h4" sx={{ fontWeight: 'normal' }}>
             <strong>Trace ID:</strong> {rootSpan.traceId}
           </Typography>
         </Stack>


### PR DESCRIPTION
# Description

Make trace header bar responsive for smaller chart sizes.

# Screenshots

Before:

https://github.com/user-attachments/assets/88bc8abc-2a17-4de9-94e5-a72e8ef2ec63

After:

https://github.com/user-attachments/assets/7d5a1b71-dad4-405c-b760-60cec899211d

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
