### PR TITLE
[BUGFIX]: Remove selectedMode from timeseries series config

### DIFF
--- a/timeserieschart/src/utils/data-transform.ts
+++ b/timeserieschart/src/utils/data-transform.ts
@@ -130,13 +130,6 @@ export function getTimeSeries(
         type: visual.lineStyle,
       },
     },
-    selectedMode: 'single',
-    select: {
-      itemStyle: {
-        borderColor: paletteColor,
-        borderWidth: pointRadius + 0.5,
-      },
-    },
     blur: {
       lineStyle: {
         width: lineWidth,


### PR DESCRIPTION
Related to https://github.com/perses/shared/pull/195

# Description

Part of the tooltip hover fix for stacked and grouped charts. 
Removes selectedMode: 'single' and its properties from the timeseries series config. These options enabled eCharts' built-in selection state, which conflicted with the new emphasis/downplay logic and caused  highlight markers on series that were no longer hovered.

# Screenshots


https://github.com/user-attachments/assets/bf6cfa05-eba4-4b22-9a51-ae3000af36aa



# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
