### PR TITLE
[BUGFIX] pyroscope: fix timerange

### DIFF
--- a/pyroscope/schemas/pyroscope-profile-query/query.cue
+++ b/pyroscope/schemas/pyroscope-profile-query/query.cue
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"strings"
 	ds "github.com/perses/plugins/pyroscope/schemas/datasource:model"
 )
 
@@ -21,7 +22,7 @@ kind: "PyroscopeProfileQuery"
 spec: close({
 	ds.#selector
 	maxNodes?:   number
-	profileType: string
+	profileType: strings.MinRunes(1)
 	filters?: [...{
 		labelName:  string
 		labelValue: string

--- a/pyroscope/src/components/Service.tsx
+++ b/pyroscope/src/components/Service.tsx
@@ -24,7 +24,6 @@ export interface ServiceProps {
 
 export function Service(props: ServiceProps): ReactElement {
   const { datasource, value, onChange } = props;
-
   const { data: servicesOptions, isLoading: isServicesOptionsLoading } = useServices(datasource);
 
   function handleServiceChange(_event: SyntheticEvent, newValue: string | null): void {

--- a/pyroscope/src/components/Service.tsx
+++ b/pyroscope/src/components/Service.tsx
@@ -22,8 +22,7 @@ export interface ServiceProps {
   onChange?(value: string): void;
 }
 
-export function Service(props: ServiceProps): ReactElement {
-  const { datasource, value, onChange } = props;
+export function Service({ datasource, value, onChange }: ServiceProps): ReactElement {
   const { data: servicesOptions, isLoading: isServicesOptionsLoading } = useServices(datasource);
 
   function handleServiceChange(_event: SyntheticEvent, newValue: string | null): void {

--- a/pyroscope/src/explore/PyroscopeExplorer.tsx
+++ b/pyroscope/src/explore/PyroscopeExplorer.tsx
@@ -11,12 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Stack } from '@mui/material';
+import { Alert, Box, Stack } from '@mui/material';
 import { ReactElement, useState } from 'react';
 import { DataQueriesProvider, MultiQueryEditor } from '@perses-dev/plugin-system';
 import { Panel } from '@perses-dev/dashboards';
 import { useExplorerManagerContext } from '@perses-dev/explore';
 import { QueryDefinition } from '@perses-dev/spec';
+import { isProfileQueryComplete, PyroscopeProfileQuerySpec } from '../model';
 
 interface ProfilesExplorerQueryParams {
   queries?: QueryDefinition[];
@@ -53,6 +54,11 @@ export function PyroscopeExplorer(): ReactElement {
 
   const [queryDefinitions, setQueryDefinitions] = useState<QueryDefinition[]>(queries);
 
+  // A profile query is only executable once a service and a profile type are selected.
+  const hasIncompleteQuery = queries.some(
+    (query) => !isProfileQueryComplete((query.spec?.plugin?.spec ?? {}) as Partial<PyroscopeProfileQuerySpec>)
+  );
+
   return (
     <Stack gap={2} sx={{ width: '100%' }}>
       <MultiQueryEditor
@@ -61,11 +67,17 @@ export function PyroscopeExplorer(): ReactElement {
         queries={queryDefinitions}
         onQueryRun={() => setData({ queries: queryDefinitions })}
       />
-      <DataQueriesProvider definitions={queries}>
-        <Box height={980}>
-          <FlameGraphPanel queries={queries} />
-        </Box>
-      </DataQueriesProvider>
+      {hasIncompleteQuery ? (
+        <Alert severity="warning">
+          The query is not complete. Please select a service and a profile type to run the query.
+        </Alert>
+      ) : (
+        <DataQueriesProvider definitions={queries}>
+          <Box height={980}>
+            <FlameGraphPanel queries={queries} />
+          </Box>
+        </DataQueriesProvider>
+      )}
     </Stack>
   );
 }

--- a/pyroscope/src/model/profile-query-model.ts
+++ b/pyroscope/src/model/profile-query-model.ts
@@ -23,3 +23,13 @@ export interface PyroscopeProfileQuerySpec {
   filters?: LabelFilter[];
   service?: string;
 }
+
+/**
+ * A Pyroscope profile query needs at least a service and a profile type to be executable.
+ * When either is missing, the query is considered incomplete and should not be run.
+ */
+export function isProfileQueryComplete(
+  spec: Partial<Pick<PyroscopeProfileQuerySpec, 'service' | 'profileType'>>
+): boolean {
+  return !!spec.service && !!spec.profileType;
+}

--- a/pyroscope/src/plugins/pyroscope-profile-query/PyroscopeProfileQueryEditor.tsx
+++ b/pyroscope/src/plugins/pyroscope-profile-query/PyroscopeProfileQueryEditor.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DatasourceSelect, DatasourceSelectProps } from '@perses-dev/plugin-system';
+import { DatasourceSelect, DatasourceSelectProps, useDatasourceSelectValueToSelector } from '@perses-dev/plugin-system';
 import { useId } from '@perses-dev/components';
 import { produce } from 'immer';
 import { FormControl, InputLabel, Stack, TextField, useTheme } from '@mui/material';
@@ -21,6 +21,7 @@ import {
   isDefaultPyroscopeSelector,
   isPyroscopeDatasourceSelector,
   PYROSCOPE_DATASOURCE_KIND,
+  PyroscopeDatasourceSelector,
 } from '../../model';
 import { ProfileTypeSelector, Service, Filters } from '../../components';
 import {
@@ -34,7 +35,11 @@ import {
 export function PyroscopeProfileQueryEditor(props: ProfileQueryEditorProps): ReactElement {
   const { onChange, value } = props;
   const { datasource } = value;
-  const selectedDatasource = datasource ?? DEFAULT_PYROSCOPE;
+  const datasourceSelectValue = datasource ?? DEFAULT_PYROSCOPE;
+  const selectedDatasource = useDatasourceSelectValueToSelector(
+    datasourceSelectValue,
+    PYROSCOPE_DATASOURCE_KIND
+  ) as PyroscopeDatasourceSelector;
   const datasourceSelectLabelID = useId('pyroscope-datasource-label');
 
   const { maxNodes, handleMaxNodesChange, maxNodesHasError } = useMaxNodesState(props);
@@ -67,7 +72,7 @@ export function PyroscopeProfileQueryEditor(props: ProfileQueryEditorProps): Rea
         </InputLabel>
         <DatasourceSelect
           datasourcePluginKind={PYROSCOPE_DATASOURCE_KIND}
-          value={selectedDatasource}
+          value={datasourceSelectValue}
           onChange={handleDatasourceChange}
           labelId={datasourceSelectLabelID}
           label="Pyroscope Datasource"

--- a/pyroscope/src/plugins/pyroscope-profile-query/get-profile-data.ts
+++ b/pyroscope/src/plugins/pyroscope-profile-query/get-profile-data.ts
@@ -14,9 +14,14 @@
 import { ProfileQueryPlugin } from '@perses-dev/plugin-system';
 import { getUnixTime } from 'date-fns';
 import { AbsoluteTimeRange, ProfileData, StackTrace } from '@perses-dev/spec';
-import { PyroscopeProfileQuerySpec, PYROSCOPE_DATASOURCE_KIND, PyroscopeDatasourceSelector } from '../../model';
-import { PyroscopeClient } from '../../model/pyroscope-client';
-import { SearchProfilesParameters, SearchProfilesResponse } from '../../model/api-types';
+import {
+  PyroscopeProfileQuerySpec,
+  PYROSCOPE_DATASOURCE_KIND,
+  PyroscopeDatasourceSelector,
+  PyroscopeClient,
+  SearchProfilesParameters,
+  SearchProfilesResponse,
+} from '../../model';
 import { computeFilterExpr } from '../../utils/types';
 
 export function getUnixTimeRange(timeRange: AbsoluteTimeRange): { start: number; end: number } {

--- a/pyroscope/src/utils/use-query.ts
+++ b/pyroscope/src/utils/use-query.ts
@@ -26,12 +26,18 @@ import { getUnixTimeRange } from '../plugins';
 
 export function useLabelNames(datasource: DatasourceSelector): UseQueryResult<SearchLabelNamesResponse, StatusError> {
   const { data: client } = useDatasourceClient<PyroscopeClient>(datasource);
+  const { absoluteTimeRange } = useTimeRange();
+  const { start, end } = getUnixTimeRange(absoluteTimeRange);
 
   return useQuery<SearchLabelNamesResponse, StatusError>({
     enabled: !!client,
     queryKey: ['searchLabelNames', 'datasource', datasource],
     queryFn: async () => {
-      return await client!.searchLabelNames({}, { 'content-type': 'application/json' }, {});
+      return await client!.searchLabelNames(
+        {},
+        { 'content-type': 'application/json' },
+        { start: start * 1000, end: end * 1000 }
+      );
     },
   });
 }
@@ -51,7 +57,7 @@ export function useLabelValues(
       return await client!.searchLabelValues(
         {},
         { 'content-type': 'application/json' },
-        { name: labelName, from: start, until: end }
+        { name: labelName, start: start * 1000, end: end * 1000 }
       );
     },
   });
@@ -68,7 +74,11 @@ export function useProfileTypes(
     enabled: !!client,
     queryKey: ['searchProfileTypes', 'datasource', datasource],
     queryFn: async () => {
-      return await client!.searchProfileTypes({}, { 'content-type': 'application/json' }, { from: start, until: end });
+      return await client!.searchProfileTypes(
+        {},
+        { 'content-type': 'application/json' },
+        { start: start * 1000, end: end * 1000 }
+      );
     },
   });
 }
@@ -82,7 +92,11 @@ export function useServices(datasource: DatasourceSelector): UseQueryResult<Sear
     enabled: !!client,
     queryKey: ['searchServices', 'datasource', datasource],
     queryFn: async () => {
-      return await client!.searchServices({}, { 'content-type': 'application/json' }, { from: start, until: end });
+      return await client!.searchServices(
+        {},
+        { 'content-type': 'application/json' },
+        { start: start * 1000, end: end * 1000 }
+      );
     },
   });
 }

--- a/pyroscope/src/utils/use-query.ts
+++ b/pyroscope/src/utils/use-query.ts
@@ -31,7 +31,7 @@ export function useLabelNames(datasource: DatasourceSelector): UseQueryResult<Se
 
   return useQuery<SearchLabelNamesResponse, StatusError>({
     enabled: !!client,
-    queryKey: ['searchLabelNames', 'datasource', datasource],
+    queryKey: ['searchLabelNames', client],
     queryFn: async () => {
       return await client!.searchLabelNames(
         {},
@@ -52,7 +52,7 @@ export function useLabelValues(
 
   return useQuery<SearchLabelValuesResponse, StatusError>({
     enabled: !!client,
-    queryKey: ['searchLabelValues', labelName, 'datasource', datasource],
+    queryKey: ['searchLabelValues', labelName, client],
     queryFn: async () => {
       return await client!.searchLabelValues(
         {},
@@ -72,7 +72,7 @@ export function useProfileTypes(
 
   return useQuery<SearchProfileTypesResponse, StatusError>({
     enabled: !!client,
-    queryKey: ['searchProfileTypes', 'datasource', datasource],
+    queryKey: ['searchProfileTypes', client],
     queryFn: async () => {
       return await client!.searchProfileTypes(
         {},
@@ -90,7 +90,7 @@ export function useServices(datasource: DatasourceSelector): UseQueryResult<Sear
 
   return useQuery<SearchLabelValuesResponse, StatusError>({
     enabled: !!client,
-    queryKey: ['searchServices', 'datasource', datasource],
+    queryKey: ['searchServices', client],
     queryFn: async () => {
       return await client!.searchServices(
         {},

--- a/pyroscope/src/utils/use-query.ts
+++ b/pyroscope/src/utils/use-query.ts
@@ -24,6 +24,9 @@ import {
 } from '../model';
 import { getUnixTimeRange } from '../plugins';
 
+// Pyroscope need timestamp in milliseconds, but the time range from Perses is in seconds.
+const MILLISECONDS = 1_000;
+
 export function useLabelNames(datasource: DatasourceSelector): UseQueryResult<SearchLabelNamesResponse, StatusError> {
   const { data: client } = useDatasourceClient<PyroscopeClient>(datasource);
   const { absoluteTimeRange } = useTimeRange();
@@ -36,7 +39,7 @@ export function useLabelNames(datasource: DatasourceSelector): UseQueryResult<Se
       return await client!.searchLabelNames(
         {},
         { 'content-type': 'application/json' },
-        { start: start * 1000, end: end * 1000 }
+        { start: start * MILLISECONDS, end: end * MILLISECONDS }
       );
     },
   });
@@ -57,7 +60,7 @@ export function useLabelValues(
       return await client!.searchLabelValues(
         {},
         { 'content-type': 'application/json' },
-        { name: labelName, start: start * 1000, end: end * 1000 }
+        { name: labelName, start: start * MILLISECONDS, end: end * MILLISECONDS }
       );
     },
   });
@@ -77,7 +80,7 @@ export function useProfileTypes(
       return await client!.searchProfileTypes(
         {},
         { 'content-type': 'application/json' },
-        { start: start * 1000, end: end * 1000 }
+        { start: start * MILLISECONDS, end: end * MILLISECONDS }
       );
     },
   });
@@ -95,7 +98,7 @@ export function useServices(datasource: DatasourceSelector): UseQueryResult<Sear
       return await client!.searchServices(
         {},
         { 'content-type': 'application/json' },
-        { start: start * 1000, end: end * 1000 }
+        { start: start * MILLISECONDS, end: end * MILLISECONDS }
       );
     },
   });


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
Fix pyroscope timerange query params: https://github.com/grafana/pyroscope/blob/254c6885170b4ac35d3c8933ffdbfd2f955fade2/api/types/v1/types.proto#L64

Improving the display on the way too. When changing datasource, input options were not updated, because client is "enabled", but on old spec so the query is executed but with wrong data. That why I put client as useQuery key instead of datasource selector. I would prefer to use datasource name as key, but it may need more work.

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
