### PR TITLE
[DOC] Table: fix format modifier syntax in dynamic links example

### DIFF
--- a/docs/table/README.md
+++ b/docs/table/README.md
@@ -44,7 +44,7 @@ Perses supports formatting modifiers to control how values are embedded into lin
 For example,
 
 ```
-${__data.fields["column_name:csv"]}
+${__data.fields["column_name"]:csv}
 ```
 
 The following interpolations are supported by Perses
@@ -65,7 +65,11 @@ The following interpolations are supported by Perses
   - text
   - queryparam
 
+Cell values embedded into links are URL encoded by default. Use the `raw` format to skip encoding for complete URLs:
 
+```
+${__data.fields["url"]:raw}
+```
 
 ## Transformations
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

The format example puts the modifier inside the field name quotes, so the parser reads a field named `column_name:csv` and the link renders empty. Fixed, and documented `raw` for cell values that are already complete URLs (perses/perses#4229).

# Screenshots

<!-- If there are UI changes -->

N/a, docs only

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
