### PR TITLE
[BUGFIX] Table: use last data point instead of first in buildRawTableData

### DIFF
--- a/table/src/table-data-utils.ts
+++ b/table/src/table-data-utils.ts
@@ -59,7 +59,10 @@ export function buildRawTableData(
       (data.data?.series ?? []).map((ts: TimeSeries) => ({ data, ts, queryIndex }))
     )
     .map(({ data, ts, queryIndex }: { data: PanelData<TimeSeriesData>; ts: TimeSeries; queryIndex: number }) => {
-      if (ts.values[0] === undefined) {
+      // Pick the last (most recent) data point. For range responses the last
+      // value covers the window ending at the selected time range's end.
+      const lastPoint = ts.values[ts.values.length - 1];
+      if (lastPoint === undefined) {
         return { ...ts.labels };
       }
 
@@ -77,19 +80,17 @@ export function buildRawTableData(
       // For rendering: plugin columns get embedded PanelData objects
       let columnValue: unknown;
       if (forExport) {
-        columnValue = ts.values[0][1];
+        columnValue = lastPoint[1];
       } else {
         const hasPlugin = (spec.columnSettings ?? []).find((x) => x.name === valueColumnName)?.plugin;
         columnValue = hasPlugin
           ? { ...data, data: { ...data.data, series: data.data.series.filter((s) => s === ts) } }
-          : ts.values[0][1];
+          : lastPoint[1];
       }
 
       if (queryMode === 'instant') {
-        // Timestamp is not indexed as it will be the same for all queries
-        return { timestamp: ts.values[0][0], [valueColumnName]: columnValue, ...labels };
+        return { timestamp: lastPoint[0], [valueColumnName]: columnValue, ...labels };
       } else {
-        // Don't add a timestamp for range queries
         return { [valueColumnName]: columnValue, ...labels };
       }
     });


### PR DESCRIPTION
buildRawTableData() hardcodes ts.values[0] — always picking the first data point from range query results. When a datasource plugin sends query_range despite the table requesting instant mode, the first step covers a stale time window while the last step is current. StatChart panels (using calculation: last) show correct values; the table does not.

Fix: use ts.values[ts.values.length - 1] instead of ts.values[0] for value extraction, timestamp, and CSV export. Also add a guard for empty values arrays.

Ref: perses/perses#4270

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
