### PR TITLE
[BUGFIX] Loki: dispatch to instant query when context.mode is instant

### DIFF
--- a/loki/src/queries/loki-time-series-query/get-loki-time-series-data.ts
+++ b/loki/src/queries/loki-time-series-query/get-loki-time-series-data.ts
@@ -14,8 +14,8 @@
 import { TimeSeriesQueryPlugin, replaceVariables } from '@perses-dev/plugin-system';
 import { milliseconds } from 'date-fns';
 import { DurationString, parseDurationString, TimeSeries } from '@perses-dev/spec';
-import { LokiClient } from '../../model/loki-client';
-import { LokiMatrixResult } from '../../model/loki-client-types';
+import { LokiClient, toUnixSeconds } from '../../model/loki-client';
+import { LokiMatrixResult, LokiVectorResult } from '../../model/loki-client-types';
 import { DEFAULT_DATASOURCE } from '../constants';
 import { LokiTimeSeriesQuerySpec } from './loki-time-series-query-types';
 
@@ -88,6 +88,19 @@ function convertMatrixToTimeSeries(matrix: LokiMatrixResult[]): TimeSeries[] {
   });
 }
 
+function convertVectorToTimeSeries(vector: LokiVectorResult[]): TimeSeries[] {
+  return vector.map((series) => {
+    const name = Object.entries(series.metric)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(', ');
+    return {
+      name,
+      values: [[Number(series.value[0]) * 1000, Number(series.value[1])]],
+      labels: series.metric,
+    };
+  });
+}
+
 export const getLokiTimeSeriesData: TimeSeriesQueryPlugin<LokiTimeSeriesQuerySpec>['getTimeSeriesData'] = async (
   spec,
   context
@@ -107,7 +120,27 @@ export const getLokiTimeSeriesData: TimeSeriesQueryPlugin<LokiTimeSeriesQuerySpe
 
   const { start, end } = context.timeRange;
 
-  // Calculate proper step using similar logic to Prometheus
+  if (context.mode === 'instant') {
+    const response = await client.query({ query, time: toUnixSeconds(end) });
+
+    if (response.data.resultType === 'vector') {
+      return {
+        series: convertVectorToTimeSeries(response.data.result as LokiVectorResult[]),
+        timeRange: { start, end },
+        stepMs: DEFAULT_MIN_STEP_SECONDS * 1000,
+        metadata: { executedQueryString: query },
+      };
+    }
+
+    return {
+      series: [],
+      timeRange: { start, end },
+      stepMs: DEFAULT_MIN_STEP_SECONDS * 1000,
+      metadata: { notices: [{ type: 'warning', message: "log streams are not supported in 'instant' mode" }] },
+    };
+  }
+
+  // Range mode (default)
   const minStepSeconds = spec.step
     ? (getDurationStringSeconds(spec.step as DurationString) ?? DEFAULT_MIN_STEP_SECONDS)
     : DEFAULT_MIN_STEP_SECONDS;

--- a/loki/src/queries/loki-time-series-query/loki-time-series-query-types.test.ts
+++ b/loki/src/queries/loki-time-series-query/loki-time-series-query-types.test.ts
@@ -17,7 +17,7 @@ jest.mock('echarts/core');
 
 import { TimeSeriesQueryContext } from '@perses-dev/plugin-system';
 import { DatasourceSpec } from '@perses-dev/spec';
-import { LokiQueryRangeMatrixResponse, LokiQueryRangeResponse } from '../../model/loki-client-types';
+import { LokiQueryRangeMatrixResponse, LokiQueryRangeResponse, LokiQueryResponse } from '../../model/loki-client-types';
 import { LokiDatasource } from '../../datasources/loki-datasource';
 import { LokiDatasourceSpec } from '../../datasources/loki-datasource/loki-datasource-types';
 import { LokiTimeSeriesQuery } from './LokiTimeSeriesQuery';
@@ -48,6 +48,23 @@ lokiStubClient.queryRange = jest.fn(async () => {
   return stubResponse as LokiQueryRangeResponse;
 });
 
+// Mock instant query
+lokiStubClient.query = jest.fn(async () => {
+  const stubResponse: LokiQueryResponse = {
+    status: 'success',
+    data: {
+      resultType: 'vector',
+      result: [
+        {
+          metric: { __name__: 'loki_count', service: 'api' },
+          value: [1686141338, '99'],
+        },
+      ],
+    },
+  };
+  return stubResponse;
+});
+
 const getDatasourceClient: jest.Mock = jest.fn(() => {
   return lokiStubClient;
 });
@@ -62,7 +79,7 @@ const getDatasource: jest.Mock = jest.fn((): DatasourceSpec<LokiDatasourceSpec> 
   };
 });
 
-const createStubContext = (): TimeSeriesQueryContext => {
+const createStubContext = (overrides?: Partial<TimeSeriesQueryContext>): TimeSeriesQueryContext => {
   const stubTimeSeriesContext: TimeSeriesQueryContext = {
     datasourceStore: {
       getDatasource: getDatasource,
@@ -74,10 +91,11 @@ const createStubContext = (): TimeSeriesQueryContext => {
       setSavedDatasources: jest.fn(),
     },
     timeRange: {
-      end: new Date('01-01-2025'),
-      start: new Date('01-02-2025'),
+      end: new Date('2025-01-01T00:00:00Z'),
+      start: new Date('2024-12-25T00:00:00Z'),
     },
     variableState: {},
+    ...overrides,
   };
   return stubTimeSeriesContext;
 };
@@ -97,5 +115,52 @@ describe('LokiTimeSeriesQuery', () => {
   it('should create initial options with empty query', () => {
     const initialOptions = LokiTimeSeriesQuery.createInitialOptions();
     expect(initialOptions).toEqual({ query: '' });
+  });
+
+  describe('instant mode', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call client.query() with end time as unix seconds and return vector series', async () => {
+      const context = createStubContext({ mode: 'instant' });
+      const result = await LokiTimeSeriesQuery.getTimeSeriesData(
+        { query: 'count_over_time({service="api"} [1h])' },
+        context
+      );
+
+      expect(lokiStubClient.query).toHaveBeenCalledTimes(1);
+      expect(lokiStubClient.queryRange).not.toHaveBeenCalled();
+      const callArgs = (lokiStubClient.query as jest.Mock).mock.calls[0][0];
+      expect(callArgs.time).toBe(Math.floor(context.timeRange.end.getTime() / 1000).toString());
+      expect(result.series).toHaveLength(1);
+      expect(result.series[0]?.values[0]?.[1]).toBe(99);
+    });
+
+    it('should return empty series with warning notice for streams resultType', async () => {
+      (lokiStubClient.query as jest.Mock).mockResolvedValueOnce({
+        status: 'success',
+        data: {
+          resultType: 'streams',
+          result: [{ stream: { service: 'api' }, values: [['1686141338000000000', 'log line']] }],
+        },
+      } as LokiQueryResponse);
+
+      const context = createStubContext({ mode: 'instant' });
+      const result = await LokiTimeSeriesQuery.getTimeSeriesData({ query: '{service="api"}' }, context);
+
+      expect(result.series).toHaveLength(0);
+      expect(result.metadata?.notices?.[0]?.type).toBe('warning');
+      expect(result.metadata?.notices?.[0]?.message).toBe("log streams are not supported in 'instant' mode");
+    });
+  });
+
+  it('should use queryRange when mode is not set', async () => {
+    jest.clearAllMocks();
+    const context = createStubContext();
+    await LokiTimeSeriesQuery.getTimeSeriesData({ query: 'count_over_time({service="api"} [1h])' }, context);
+
+    expect(lokiStubClient.queryRange).toHaveBeenCalledTimes(1);
+    expect(lokiStubClient.query).not.toHaveBeenCalled();
   });
 });

--- a/loki/src/queries/loki-time-series-query/loki-time-series-query-types.ts
+++ b/loki/src/queries/loki-time-series-query/loki-time-series-query-types.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { DatasourceSelector } from '@perses-dev/spec';
-import { LokiQueryRangeMatrixResponse } from '../../model/loki-client-types';
+import { LokiQueryRangeMatrixResponse, LokiQueryResponse } from '../../model/loki-client-types';
 
 export interface LokiTimeSeriesQuerySpec {
   query: string;
@@ -20,4 +20,4 @@ export interface LokiTimeSeriesQuerySpec {
   step?: string;
 }
 
-export type LokiTimeSeriesQueryResponse = LokiQueryRangeMatrixResponse;
+export type LokiTimeSeriesQueryResponse = LokiQueryRangeMatrixResponse | LokiQueryResponse;


### PR DESCRIPTION
## Summary

Ref: perses/perses#4270

`getLokiTimeSeriesData()` always calls `client.queryRange()` regardless of `context.mode`. When a panel requests instant mode (e.g. Table without column plugins), the Loki plugin ignores it and sends `query_range` — unlike the Prometheus plugin which checks `context.mode` and dispatches to `instantQuery()` vs `rangeQuery()`.

This also causes empty results for large time ranges (14d+): `query_range` with large range vectors triggers Loki's `split_queries_by_interval`, which truncates lookback windows. The instant endpoint (`/loki/api/v1/query`) does not split and evaluates correctly.

### Changes

**`loki/src/queries/loki-time-series-query/get-loki-time-series-data.ts`:**
- Check `context.mode` — dispatch to `client.query()` (`/loki/api/v1/query`) for instant mode
- Added `convertVectorToTimeSeries()` to convert instant query vector responses to the `TimeSeries` format
- `streams` resultType (raw log queries without aggregation) returns empty — not applicable for time series panels
- Range query path completely unchanged

**`loki/src/queries/loki-time-series-query/loki-time-series-query-types.ts`:**
- Updated `LokiTimeSeriesQueryResponse` to include `LokiQueryResponse` (instant query responses)

### Reproduction

1. Create a dashboard with a LokiDatasource
2. Add a Table panel (no column plugins) with `count_over_time(... [$__range])`
3. Enable Loki gateway debug logs (`--log.level=debug`)
4. **Before fix:** 100% of requests are `/loki/api/v1/query_range`, zero instant queries
5. **After fix:** Table requests go to `/loki/api/v1/query`
6. Select "Last 14 days" — **before fix:** empty results; **after fix:** correct totals

### Test plan

- [ ] Loki gateway logs show `/loki/api/v1/query` (instant) requests when Table panel loads
- [ ] Large time ranges (14d+) return correct data instead of empty results
- [ ] Range queries (time series charts) continue working unchanged
- [ ] Aggregation queries (`count_over_time`, `sum_over_time`) return correct single values
- [ ] Raw log queries (no aggregation) in instant mode return empty gracefully