### PR TITLE
[BUGFIX] Statchart: request instant queries for stat panels

### DIFF
--- a/statchart/src/StatChart.ts
+++ b/statchart/src/StatChart.ts
@@ -23,6 +23,9 @@ import { StatChartPanel, StatChartPanelProps } from './StatChartPanel';
 export const StatChart: PanelPlugin<StatChartOptions, StatChartPanelProps> = {
   PanelComponent: StatChartPanel,
   supportedQueryTypes: ['TimeSeriesQuery'],
+  queryOptions: {
+    mode: 'instant',
+  },
   panelOptionsEditorComponents: [
     {
       label: 'Settings',


### PR DESCRIPTION
## Summary

Ref: perses/perses#4270

StatChart never sets `queryOptions.mode`, so the query plugin defaults
to range queries (`query_range`). Stat panels display a single aggregate
value (last, sum, avg, etc.) and have no use for time-series data points
— they should request instant queries instead.

This is consistent with `TimeSeriesTable` and `HistogramChart` which
already set `queryOptions: { mode: 'instant' }`.

### Changes

**`statchart/src/StatChart.ts`:**

* Add `queryOptions: { mode: 'instant' }` to the StatChart panel plugin definition

### Reproduction

1. Add a StatChart panel with an aggregate query (e.g. `count_over_time(... [$__range])`)
2. **Before fix:** panel sends `query_range` — datasource returns multiple data points, only one is used
3. **After fix:** panel sends `query` (instant) — datasource returns a single correct value

### Test plan

* StatChart panels request instant queries (verified via datasource logs showing `query_type=instant`)
* Time series charts (which need range queries) are unaffected
* Consistent with existing `TimeSeriesTable` and `HistogramChart` behavior