### PR TITLE
Revert "[BUGFIX] Statchart: request instant queries for stat panels"

### DIFF
--- a/statchart/src/StatChart.ts
+++ b/statchart/src/StatChart.ts
@@ -23,9 +23,6 @@ import { StatChartPanel, StatChartPanelProps } from './StatChartPanel';
 export const StatChart: PanelPlugin<StatChartOptions, StatChartPanelProps> = {
   PanelComponent: StatChartPanel,
   supportedQueryTypes: ['TimeSeriesQuery'],
-  queryOptions: {
-    mode: 'instant',
-  },
   panelOptionsEditorComponents: [
     {
       label: 'Settings',


### PR DESCRIPTION
Reverts perses/plugins#738

We need to revert this PR as it breaks the sparkline feature.

/cc @Gladorme @jgbernalp @tgitelman