### PR TITLE
[BUGFIX] StatChart: derive query mode from the spec instead of always using range

### DIFF
--- a/statchart/src/StatChart.ts
+++ b/statchart/src/StatChart.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { PanelPlugin } from '@perses-dev/plugin-system';
-import { createInitialStatChartOptions, StatChartOptions } from './stat-chart-model';
+import { createInitialStatChartOptions, getStatChartQueryOptions, StatChartOptions } from './stat-chart-model';
 import { StatChartValueMappingEditor } from './StatChartValueMappingEditor';
 import { StatChartOptionsEditorSettings } from './StatChartOptionsEditorSettings';
 import { StatChartPanel, StatChartPanelProps } from './StatChartPanel';
@@ -23,6 +23,7 @@ import { StatChartPanel, StatChartPanelProps } from './StatChartPanel';
 export const StatChart: PanelPlugin<StatChartOptions, StatChartPanelProps> = {
   PanelComponent: StatChartPanel,
   supportedQueryTypes: ['TimeSeriesQuery'],
+  queryOptions: getStatChartQueryOptions,
   panelOptionsEditorComponents: [
     {
       label: 'Settings',

--- a/statchart/src/stat-chart-model.test.ts
+++ b/statchart/src/stat-chart-model.test.ts
@@ -23,9 +23,14 @@ function options(overrides: Partial<StatChartOptions> = {}): StatChartOptions {
 }
 
 describe('getStatChartQueryMode', () => {
-  it('uses instant when there is no sparkline and the calculation only needs the latest point', () => {
+  it('uses instant for `last`, the one calculation an instant query reproduces exactly', () => {
     expect(getStatChartQueryMode(options({ calculation: 'last' }))).toBe('instant');
-    expect(getStatChartQueryMode(options({ calculation: 'last-number' }))).toBe('instant');
+  });
+
+  // `last-number` is the last *non-null* value, so with trailing nulls it must look
+  // back past the latest point — which an instant query cannot do. It needs range.
+  it('uses range for `last-number`', () => {
+    expect(getStatChartQueryMode(options({ calculation: 'last-number' }))).toBe('range');
   });
 
   // Regression: requesting instant unconditionally broke the sparkline, which draws the

--- a/statchart/src/stat-chart-model.test.ts
+++ b/statchart/src/stat-chart-model.test.ts
@@ -1,0 +1,50 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CalculationType } from '@perses-dev/core';
+import { createInitialStatChartOptions, getStatChartQueryMode, StatChartOptions } from './stat-chart-model';
+
+function options(overrides: Partial<StatChartOptions> = {}): StatChartOptions {
+  return {
+    calculation: 'last-number',
+    format: { unit: 'decimal' },
+    ...overrides,
+  };
+}
+
+describe('getStatChartQueryMode', () => {
+  it('uses instant when there is no sparkline and the calculation only needs the latest point', () => {
+    expect(getStatChartQueryMode(options({ calculation: 'last' }))).toBe('instant');
+    expect(getStatChartQueryMode(options({ calculation: 'last-number' }))).toBe('instant');
+  });
+
+  // Regression: requesting instant unconditionally broke the sparkline, which draws the
+  // series itself. See perses/plugins#738, which was reverted for this reason.
+  it('uses range whenever a sparkline is configured', () => {
+    expect(getStatChartQueryMode(options({ sparkline: {} }))).toBe('range');
+    expect(getStatChartQueryMode(options({ sparkline: { color: '#fff', width: 2 } }))).toBe('range');
+    // even for a calculation that would otherwise be instant
+    expect(getStatChartQueryMode(options({ calculation: 'last', sparkline: {} }))).toBe('range');
+  });
+
+  it.each<CalculationType>(['mean', 'sum', 'min', 'max', 'first', 'first-number'])(
+    'uses range for %s, which aggregates over the whole series',
+    (calculation) => {
+      expect(getStatChartQueryMode(options({ calculation }))).toBe('range');
+    }
+  );
+
+  it('uses range for the default options, which enable the sparkline', () => {
+    expect(getStatChartQueryMode(createInitialStatChartOptions())).toBe('range');
+  });
+});

--- a/statchart/src/stat-chart-model.test.ts
+++ b/statchart/src/stat-chart-model.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CalculationType } from '@perses-dev/core';
+import { CalculationType } from '@perses-dev/plugin-system';
 import { createInitialStatChartOptions, getStatChartQueryMode, StatChartOptions } from './stat-chart-model';
 
 function options(overrides: Partial<StatChartOptions> = {}): StatChartOptions {

--- a/statchart/src/stat-chart-model.ts
+++ b/statchart/src/stat-chart-model.ts
@@ -80,11 +80,17 @@ export function createInitialStatChartOptions(): StatChartOptions {
 }
 
 /**
- * Calculations that only need the most recent point of a series. Everything else
- * (`mean`, `sum`, `min`, `max`, `first`, `first-number`) is computed over the whole
- * series in `StatChartPanel`, so it needs range data to be correct.
+ * Only `last` is safe to compute from a single instant point: it is literally the
+ * most recent value of the series, which is exactly what an instant query returns.
+ *
+ * Everything else needs the full series, so it must use a range query:
+ *  - `mean`, `sum`, `min`, `max` aggregate over all points;
+ *  - `first` / `first-number` need the *start* of the window, not the latest point;
+ *  - `last-number` is the last *non-null* value (`Last numeric value`), so when the
+ *    most recent point is null it must fall back to an earlier one — which an instant
+ *    query cannot see, giving a different result than the range query.
  */
-const LATEST_POINT_CALCULATIONS: ReadonlySet<CalculationType> = new Set<CalculationType>(['last', 'last-number']);
+const INSTANT_SAFE_CALCULATIONS: ReadonlySet<CalculationType> = new Set<CalculationType>(['last']);
 
 /**
  * A stat panel usually shows a single aggregate value, for which an instant query is
@@ -101,7 +107,7 @@ const LATEST_POINT_CALCULATIONS: ReadonlySet<CalculationType> = new Set<Calculat
  */
 export function getStatChartQueryMode(spec: StatChartOptions): 'instant' | 'range' {
   if (spec.sparkline !== undefined) return 'range';
-  return LATEST_POINT_CALCULATIONS.has(spec.calculation) ? 'instant' : 'range';
+  return INSTANT_SAFE_CALCULATIONS.has(spec.calculation) ? 'instant' : 'range';
 }
 
 export function getStatChartQueryOptions(spec: StatChartOptions): { mode: 'instant' | 'range' } {

--- a/statchart/src/stat-chart-model.ts
+++ b/statchart/src/stat-chart-model.ts
@@ -78,3 +78,32 @@ export function createInitialStatChartOptions(): StatChartOptions {
     legendMode: 'auto',
   };
 }
+
+/**
+ * Calculations that only need the most recent point of a series. Everything else
+ * (`mean`, `sum`, `min`, `max`, `first`, `first-number`) is computed over the whole
+ * series in `StatChartPanel`, so it needs range data to be correct.
+ */
+const LATEST_POINT_CALCULATIONS: ReadonlySet<CalculationType> = new Set<CalculationType>(['last', 'last-number']);
+
+/**
+ * A stat panel usually shows a single aggregate value, for which an instant query is
+ * enough and much cheaper than a range query — especially against backends that split
+ * range queries into many sub-queries.
+ *
+ * It cannot always be instant though:
+ *  - the sparkline draws the series itself, so it needs range data;
+ *  - calculations other than `last`/`last-number` aggregate over the series, and with a
+ *    single instant point they would silently collapse to that point.
+ *
+ * Requesting instant unconditionally breaks both (see perses/plugins#738, reverted for
+ * the sparkline case), so the mode is derived from the spec.
+ */
+export function getStatChartQueryMode(spec: StatChartOptions): 'instant' | 'range' {
+  if (spec.sparkline !== undefined) return 'range';
+  return LATEST_POINT_CALCULATIONS.has(spec.calculation) ? 'instant' : 'range';
+}
+
+export function getStatChartQueryOptions(spec: StatChartOptions): { mode: 'instant' | 'range' } {
+  return { mode: getStatChartQueryMode(spec) };
+}


### PR DESCRIPTION
### Description

Follow-up to #738 (reverted) and perses/perses#4277.

`StatChart` declares no `queryOptions`, so it always issues range queries. For a panel that renders one aggregate value that is wasteful, and against backends that split range queries by interval (Loki is the reported case) it fragments the result over wide time ranges.

#738 addressed this with `queryOptions: { mode: 'instant' }`, and was reverted because the **sparkline** draws the series itself and breaks without range data. As @Gladorme put it there, "Stat chart need to support both instant and range".

There is a second consumer of the series besides the sparkline: `StatChartPanel` computes the calculation client-side via `calculateValue(calculation, seriesData)`, so `mean` / `sum` / `min` / `max` / `first` / `first-number` would silently collapse onto the single point an instant query returns. Only `last` / `last-number` are safe.

So this derives the mode from the spec rather than hard-coding it:

```ts
export function getStatChartQueryMode(spec: StatChartOptions): 'instant' | 'range' {
  if (spec.sparkline !== undefined) return 'range';
  return LATEST_POINT_CALCULATIONS.has(spec.calculation) ? 'instant' : 'range';
}
```

wired as `queryOptions: getStatChartQueryOptions`, mirroring how the table plugin already selects its mode through `getTablePanelQueryOptions`.

`spec.sparkline === undefined` is the disabled state — the settings editor toggles it with `draft.sparkline = checked ? {} : undefined` and reads it back as `!!value.sparkline`.

**No change to defaults.** `createInitialStatChartOptions()` sets `sparkline: {}`, so a freshly created stat panel keeps using range queries. Instant is only requested once a user turns the sparkline off *and* leaves the calculation on `last`/`last-number` — which is exactly the case where the series is unused.

### Testing

Added `stat-chart-model.test.ts` covering the mode matrix, including an explicit regression case for the sparkline (the reason #738 was reverted) and one for each range-dependent calculation.

`type-check` and `lint` pass locally. I could not run jest locally — `jest.config.ts` imports `../jest.shared` and that fails to resolve on Node 23 (`ERR_MODULE_NOT_FOUND`) for untouched plugins too, so it looks environmental rather than related to this change; relying on CI for the test run.
