### PR TITLE
[BUGFIX] statchart - Allow to have special mapping without match

### DIFF
--- a/statchart/schemas/migrate/migrate.cue
+++ b/statchart/schemas/migrate/migrate.cue
@@ -155,12 +155,14 @@ spec: {
 							}
 						},
 						if mapping.type == "special" {
+							#match: *mapping.options.match | "null"
+
 							kind: "Misc"
 							spec: {
 								value: [//switch
-									if mapping.options.match == "nan" {"NaN"},
-									if mapping.options.match == "null+nan" {"null"},
-									mapping.options.match,
+									if #match == "nan" {"NaN"},
+									if #match == "null+nan" {"null"},
+									#match,
 								][0]
 								result: #result
 							}

--- a/statchart/schemas/migrate/tests/special_mapping_without_match/expected.json
+++ b/statchart/schemas/migrate/tests/special_mapping_without_match/expected.json
@@ -1,0 +1,47 @@
+{
+  "kind": "StatChart",
+  "spec": {
+    "calculation": "last-number",
+    "colorMode": "value",
+    "mappings": [
+      {
+        "kind": "Value",
+        "spec": {
+          "result": {
+            "color": "#F2495C",
+            "value": "NO"
+          },
+          "value": "0"
+        }
+      },
+      {
+        "kind": "Value",
+        "spec": {
+          "result": {
+            "color": "#73BF69",
+            "value": "YES"
+          },
+          "value": "1"
+        }
+      },
+      {
+        "kind": "Misc",
+        "spec": {
+          "result": {
+            "color": "#5794F2",
+            "value": "No data"
+          },
+          "value": "null"
+        }
+      }
+    ],
+    "thresholds": {
+      "steps": [
+        {
+          "color": "#73BF69",
+          "value": 1
+        }
+      ]
+    }
+  }
+}

--- a/statchart/schemas/migrate/tests/special_mapping_without_match/input.json
+++ b/statchart/schemas/migrate/tests/special_mapping_without_match/input.json
@@ -1,0 +1,88 @@
+{
+  "datasource" : {
+    "uid" : "$datasource"
+  },
+  "description" : " - Dynamic Load Balancing: Dynamic load balancing enabled state for the selected stack and namespace",
+  "fieldConfig" : {
+    "defaults" : {
+      "color" : {
+        "mode" : "thresholds"
+      },
+      "links" : [ ],
+      "mappings" : [ {
+        "options" : {
+          "0" : {
+            "color" : "#F2495C",
+            "index" : 0,
+            "text" : "NO"
+          },
+          "1" : {
+            "color" : "#73BF69",
+            "index" : 1,
+            "text" : "YES"
+          }
+        },
+        "type" : "value"
+      }, {
+        "options" : {
+          "result" : {
+            "color" : "#5794F2",
+            "index" : 2,
+            "text" : "No data"
+          }
+        },
+        "type" : "special"
+      } ],
+      "max" : 1,
+      "min" : 0,
+      "thresholds" : {
+        "mode" : "absolute",
+        "steps" : [ {
+          "color" : "#F2495C"
+        }, {
+          "color" : "#73BF69",
+          "value" : 1
+        } ]
+      },
+      "unit" : ""
+    },
+    "overrides" : [ ]
+  },
+  "gridPos" : {
+    "h" : 4,
+    "w" : 3,
+    "x" : 6,
+    "y" : 16
+  },
+  "id" : 88,
+  "options" : {
+    "colorMode" : "value",
+    "graphMode" : "none",
+    "justifyMode" : "auto",
+    "orientation" : "auto",
+    "reduceOptions" : {
+      "calcs" : [ "lastNotNull" ],
+      "fields" : "",
+      "values" : false
+    },
+    "textMode" : "auto"
+  },
+  "pluginVersion" : "7",
+  "targets" : [ {
+    "datasource" : {
+      "type" : "prometheus",
+      "uid" : ""
+    },
+    "exemplar" : false,
+    "expr" : "myquery",
+    "format" : "time_series",
+    "hide" : false,
+    "instant" : false,
+    "interval" : "$sampling",
+    "intervalFactor" : 1,
+    "legendFormat" : "Dynamic Load Balancing",
+    "refId" : "dynamic_load_balancing"
+  } ],
+  "title" : "Dynamic Load Balancing",
+  "type" : "stat"
+}

--- a/statchart/schemas/tests/valid/misc_with_null_value.json
+++ b/statchart/schemas/tests/valid/misc_with_null_value.json
@@ -1,0 +1,47 @@
+{
+  "kind": "StatChart",
+  "spec": {
+    "calculation": "last-number",
+    "colorMode": "value",
+    "mappings": [
+      {
+        "kind": "Value",
+        "spec": {
+          "result": {
+            "color": "#F2495C",
+            "value": "NO"
+          },
+          "value": "0"
+        }
+      },
+      {
+        "kind": "Value",
+        "spec": {
+          "result": {
+            "color": "#73BF69",
+            "value": "YES"
+          },
+          "value": "1"
+        }
+      },
+      {
+        "kind": "Misc",
+        "spec": {
+          "result": {
+            "color": "#5794F2",
+            "value": "No data"
+          },
+          "value": "null"
+        }
+      }
+    ],
+    "thresholds": {
+      "steps": [
+        {
+          "color": "#73BF69",
+          "value": 1
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

In stat charts, value mapping should allow no match, which means value is null.

In Grafana what it looks like:
<img width="311" height="183" alt="image" src="https://github.com/user-attachments/assets/741c183b-49d8-433c-8e03-1e3f101a21d4" />


<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

