### PR TITLE
[FEATURE] Add legend and stacked/unstacked buttons to the Prometheus explorer

### DIFF
--- a/prometheus/src/explore/PrometheusExplorer.tsx
+++ b/prometheus/src/explore/PrometheusExplorer.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box, Stack, Tab, Tabs } from '@mui/material';
+import { Box, Stack, Tab, Tabs, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { DataQueriesProvider, MultiQueryEditor, useSuggestedStepMs } from '@perses-dev/plugin-system';
 import { useExplorerManagerContext } from '@perses-dev/explore';
 import useResizeObserver from 'use-resize-observer';
@@ -33,27 +33,63 @@ const FILTERED_QUERY_PLUGINS = ['PrometheusTimeSeriesQuery'];
 function TimeSeriesPanel({ queries }: { queries: QueryDefinition[] }): ReactElement {
   const { width, ref: boxRef } = useResizeObserver();
   const height = PANEL_PREVIEW_HEIGHT;
+  const [stacked, setStacked] = useState(false);
 
   const suggestedStepMs = useSuggestedStepMs(width);
 
+  const chartSpec = stacked
+    ? { legend: { position: 'bottom', mode: 'list' }, visual: { stack: 'all', areaOpacity: 0.3 } }
+    : { legend: { position: 'bottom', mode: 'list' } };
+
   return (
-    <Box ref={boxRef} height={height}>
-      <DataQueriesProvider definitions={queries} options={{ suggestedStepMs, mode: 'range' }}>
-        <Panel
-          panelOptions={{
-            hideHeader: true,
-          }}
-          definition={{
-            kind: 'Panel',
-            spec: {
-              queries: queries,
-              display: { name: '' },
-              plugin: { kind: 'TimeSeriesChart', spec: { legend: { position: 'bottom', mode: 'list' } } },
+    <Stack>
+      <ToggleButtonGroup
+        value={stacked ? 'stacked' : 'unstacked'}
+        exclusive
+        onChange={(_, value) => setStacked(value === 'stacked')}
+        size="small"
+        sx={{
+          alignSelf: 'flex-end',
+          mt: 2,
+          backgroundColor: 'background.lighter',
+          borderRadius: 1,
+          p: 0.5,
+          '& .MuiToggleButton-root': {
+            border: 'none',
+            borderRadius: '4px !important',
+            px: 2,
+            color: 'text.secondary',
+            '&.Mui-selected': {
+              backgroundColor: 'background.default',
+              color: 'text.primary',
             },
-          }}
-        />
-      </DataQueriesProvider>
-    </Box>
+            '&:hover': {
+              backgroundColor: 'action.hover',
+            },
+          },
+        }}
+      >
+        <ToggleButton value="unstacked">Unstacked</ToggleButton>
+        <ToggleButton value="stacked">Stacked</ToggleButton>
+      </ToggleButtonGroup>
+      <Box ref={boxRef} height={height}>
+        <DataQueriesProvider definitions={queries} options={{ suggestedStepMs, mode: 'range' }}>
+          <Panel
+            panelOptions={{
+              hideHeader: true,
+            }}
+            definition={{
+              kind: 'Panel',
+              spec: {
+                queries: queries,
+                display: { name: '' },
+                plugin: { kind: 'TimeSeriesChart', spec: chartSpec },
+              },
+            }}
+          />
+        </DataQueriesProvider>
+      </Box>
+    </Stack>
   );
 }
 

--- a/prometheus/src/explore/PrometheusExplorer.tsx
+++ b/prometheus/src/explore/PrometheusExplorer.tsx
@@ -45,7 +45,11 @@ function TimeSeriesPanel({ queries }: { queries: QueryDefinition[] }): ReactElem
           }}
           definition={{
             kind: 'Panel',
-            spec: { queries: queries, display: { name: '' }, plugin: { kind: 'TimeSeriesChart', spec: {} } },
+            spec: {
+              queries: queries,
+              display: { name: '' },
+              plugin: { kind: 'TimeSeriesChart', spec: { legend: { position: 'bottom', mode: 'list' } } },
+            },
           }}
         />
       </DataQueriesProvider>


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

This adds the legend and stacked/unstacked buttons to the Prometheus explorer. This improves the user experience of the Prometheus view.

The stacked view does not force the Y-axis to start at zero. This means the lowest positive band might not appear proportional, but keeps negative values visible.

# Screenshots

<details><summary>Legend + Unstacked</summary>

<img width="3024" height="2870" alt="image" src="https://github.com/user-attachments/assets/e292fa51-813b-471e-bc4a-803e9e0a4cf6" />

<img width="3024" height="2870" alt="image" src="https://github.com/user-attachments/assets/eb27db5a-2c2c-458c-90d4-77116b926661" />

</details>

<details><summary>Legend + Stacked</summary>

<img width="3024" height="2870" alt="image" src="https://github.com/user-attachments/assets/42f6f737-ab88-496b-98ec-16af04ee9db1" />

<img width="3024" height="2870" alt="image" src="https://github.com/user-attachments/assets/e771fa73-3a0d-4a06-a229-8b0c9cde73aa" />


</details>

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
