### PR TITLE
[BUGFIX] flamechart: fix palette/shows field mismatch between Go SDK …

### DIFF
--- a/flamechart/sdk/go/flamechart.go
+++ b/flamechart/sdk/go/flamechart.go
@@ -27,11 +27,11 @@ const (
 )
 
 type PluginSpec struct {
-	ShowSettings   bool    `json:"showSettings,omitempty" yaml:"showSettings,omitempty"`
-	ShowSeries     bool    `json:"showSeries,omitempty" yaml:"showSeries,omitempty"`
-	ShowTable      bool    `json:"showTable,omitempty" yaml:"showTable,omitempty"`
-	ShowFlameGraph bool    `json:"showFlameGraph,omitempty" yaml:"showFlameGraph,omitempty"`
-	Palette        Palette `json:"mode" yaml:"mode"`
+	ShowSettings   bool    `json:"showSettings" yaml:"showSettings"`
+	ShowSeries     bool    `json:"showSeries" yaml:"showSeries"`
+	ShowTable      bool    `json:"showTable" yaml:"showTable"`
+	ShowFlameGraph bool    `json:"showFlameGraph" yaml:"showFlameGraph"`
+	Palette        Palette `json:"palette" yaml:"palette"`
 }
 
 type Option func(plugin *Builder) error


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->

When trying to use the Golang SDK of flamechart plugin I am getting such error:
```
Error: something wrong happened with the request to the API. Message: bad request: invalid panel 5_6: spec.mode: field not allowed:
1:30
invalid panel 6_0: spec.mode: field not allowed:
1:30
```
The issue:
The flamechart Go DaC SDK serialized the palette field as mode instead of palette, so any dashboard built with `flamechart.Chart(flamechart.DefinePalette(...))` failed server-side CUE validation (spec.mode: field not allowed).

Additionally, showSettings, showSeries, showTable, and showFlameGraph are required (non-optional) in the CUE schema, but the Go struct tags used omitempty on their bool fields, so leaving any of them at their default false dropped the key entirely and also failed validation.

The Fix:
- Palette JSON/YAML tag: mode ->palette
- Removed omitempty from ShowSettings, ShowSeries, ShowTable, ShowFlameGraph so they're always serialized

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).