### PR TITLE
[FEATURE] Table: adds a table-wide Enable Sorting option

### DIFF
--- a/table/schemas/table.cue
+++ b/table/schemas/table.cue
@@ -27,6 +27,7 @@ spec: close({
 	defaultColumnHidden?: bool
 	pagination?:          bool
 	enableFiltering?:     bool
+	enableSorting?:       bool
 	columnSettings?: [...#columnSettings]
 	cellSettings?: [...#cellSettings]
 	transforms?: [...common.#transform]

--- a/table/schemas/tests/valid/table-enable-sorting.json
+++ b/table/schemas/tests/valid/table-enable-sorting.json
@@ -1,0 +1,8 @@
+{
+  "kind": "Table",
+  "spec": {
+    "density": "standard",
+    "enableSorting": true,
+    "enableFiltering": true
+  }
+}

--- a/table/sdk/go/options.go
+++ b/table/sdk/go/options.go
@@ -59,6 +59,13 @@ func WithEnableFiltering(enabled bool) Option {
 	}
 }
 
+func WithEnableSorting(enabled bool) Option {
+	return func(builder *Builder) error {
+		builder.EnableSorting = enabled
+		return nil
+	}
+}
+
 func WithColumnSettings(settings []ColumnSettings) Option {
 	return func(builder *Builder) error {
 		builder.ColumnSettings = settings

--- a/table/sdk/go/table.go
+++ b/table/sdk/go/table.go
@@ -167,6 +167,7 @@ type PluginSpec struct {
 	DefaultColumnHidden bool               `json:"defaultColumnHidden,omitempty" yaml:"defaultColumnHidden,omitempty"`
 	Pagination          bool               `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 	EnableFiltering     bool               `json:"enableFiltering,omitempty" yaml:"enableFiltering,omitempty"`
+	EnableSorting       bool               `json:"enableSorting,omitempty" yaml:"enableSorting,omitempty"`
 	ColumnSettings      []ColumnSettings   `json:"columnSettings,omitempty" yaml:"columnSettings,omitempty"`
 	CellSettings        []CellSettings     `json:"cellSettings,omitempty" yaml:"cellSettings,omitempty"`
 	Transforms          []common.Transform `json:"transforms,omitempty" yaml:"transforms,omitempty"`

--- a/table/src/components/ColumnsEditor/ColumnEditor.tsx
+++ b/table/src/components/ColumnsEditor/ColumnEditor.tsx
@@ -112,9 +112,7 @@ export function ColumnEditor({
             />
             <OptionsEditorControl
               label="Enable sorting"
-              control={
-                <Switch checked={enableSorting} onChange={(e) => handleEnableSortingChange(e.target.checked)} />
-              }
+              control={<Switch checked={enableSorting} onChange={(e) => handleEnableSortingChange(e.target.checked)} />}
             />
             {column.enableSorting === undefined && (
               <Typography variant="caption" color="text.secondary">

--- a/table/src/components/ColumnsEditor/ColumnEditor.tsx
+++ b/table/src/components/ColumnsEditor/ColumnEditor.tsx
@@ -40,12 +40,29 @@ type OmittedMuiProps = 'children' | 'value' | 'onChange';
 export interface ColumnEditorProps extends Omit<StackProps, OmittedMuiProps> {
   column: ColumnSettings;
   onChange: (column: ColumnSettings) => void;
+  defaultEnableSorting?: boolean;
 }
 
-export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps): ReactElement {
+export function ColumnEditor({
+  column,
+  onChange,
+  defaultEnableSorting = false,
+  ...others
+}: ColumnEditorProps): ReactElement {
   const [width, setWidth] = useState<number>(
     column.width === undefined || column.width === 'auto' ? 100 : column.width
   );
+
+  const enableSorting = column.enableSorting ?? defaultEnableSorting;
+
+  function handleEnableSortingChange(checked: boolean): void {
+    if (checked === defaultEnableSorting) {
+      const { enableSorting: _ignored, ...rest } = column;
+      onChange(rest);
+      return;
+    }
+    onChange({ ...column, enableSorting: checked });
+  }
 
   return (
     <Stack {...others}>
@@ -96,13 +113,15 @@ export function ColumnEditor({ column, onChange, ...others }: ColumnEditorProps)
             <OptionsEditorControl
               label="Enable sorting"
               control={
-                <Switch
-                  checked={column.enableSorting ?? false}
-                  onChange={(e) => onChange({ ...column, enableSorting: e.target.checked })}
-                />
+                <Switch checked={enableSorting} onChange={(e) => handleEnableSortingChange(e.target.checked)} />
               }
             />
-            {column.enableSorting && (
+            {column.enableSorting === undefined && (
+              <Typography variant="caption" color="text.secondary">
+                Inherits from General Settings
+              </Typography>
+            )}
+            {enableSorting && (
               <OptionsEditorControl
                 label="Default Sort"
                 control={

--- a/table/src/components/ColumnsEditor/ColumnEditorContainer.tsx
+++ b/table/src/components/ColumnsEditor/ColumnEditorContainer.tsx
@@ -37,6 +37,7 @@ export function ColumnEditorContainer({
   onDelete,
   onMoveUp,
   onMoveDown,
+  defaultEnableSorting,
 }: ColumnEditorContainerProps): ReactElement {
   function handleHideColumn(): void {
     onChange({ ...column, hide: !column.hide });
@@ -104,7 +105,7 @@ export function ColumnEditorContainer({
       {/* When a <Grid> is inside a <Stack> with gap, the negative margin of the grid is not applied. Therefore, let's wrap it in a div. */}
       {!isCollapsed && (
         <div>
-          <ColumnEditor column={column} onChange={onChange} />
+          <ColumnEditor column={column} onChange={onChange} defaultEnableSorting={defaultEnableSorting} />
         </div>
       )}
     </DragAndDropElement>

--- a/table/src/components/ColumnsEditor/ColumnsEditor.tsx
+++ b/table/src/components/ColumnsEditor/ColumnsEditor.tsx
@@ -21,9 +21,14 @@ import { ColumnEditorContainer } from './ColumnEditorContainer';
 export interface ColumnsEditorProps {
   columnSettings: ColumnSettings[];
   onChange: (columnOptions: ColumnSettings[]) => void;
+  defaultEnableSorting?: boolean;
 }
 
-export function ColumnsEditor({ columnSettings, onChange }: ColumnsEditorProps): ReactElement {
+export function ColumnsEditor({
+  columnSettings,
+  onChange,
+  defaultEnableSorting,
+}: ColumnsEditorProps): ReactElement {
   const [columnsCollapsed, setColumnsCollapsed] = useState(columnSettings.map(() => true));
 
   function handleColumnChange(index: number, column: ColumnSettings): void {
@@ -73,6 +78,7 @@ export function ColumnsEditor({ columnSettings, onChange }: ColumnsEditorProps):
           key={i}
           column={column}
           isCollapsed={columnsCollapsed[i] ?? true}
+          defaultEnableSorting={defaultEnableSorting}
           onChange={(updatedColumn: ColumnSettings) => handleColumnChange(i, updatedColumn)}
           onDelete={() => handleColumnDelete(i)}
           onCollapse={(collapsed) => handleColumnCollapseExpand(i, collapsed)}

--- a/table/src/components/ColumnsEditor/ColumnsEditor.tsx
+++ b/table/src/components/ColumnsEditor/ColumnsEditor.tsx
@@ -24,11 +24,7 @@ export interface ColumnsEditorProps {
   defaultEnableSorting?: boolean;
 }
 
-export function ColumnsEditor({
-  columnSettings,
-  onChange,
-  defaultEnableSorting,
-}: ColumnsEditorProps): ReactElement {
+export function ColumnsEditor({ columnSettings, onChange, defaultEnableSorting }: ColumnsEditorProps): ReactElement {
   const [columnsCollapsed, setColumnsCollapsed] = useState(columnSettings.map(() => true));
 
   function handleColumnChange(index: number, column: ColumnSettings): void {

--- a/table/src/components/TableColumnsEditor.tsx
+++ b/table/src/components/TableColumnsEditor.tsx
@@ -23,5 +23,11 @@ export function TableColumnsEditor({ onChange, value }: TableColumnsEditorProps)
     onChange({ ...value, columnSettings: columns });
   }
 
-  return <ColumnsEditor columnSettings={value.columnSettings ?? []} onChange={handleColumnsChange} />;
+  return (
+    <ColumnsEditor
+      columnSettings={value.columnSettings ?? []}
+      onChange={handleColumnsChange}
+      defaultEnableSorting={value.enableSorting}
+    />
+  );
 }

--- a/table/src/components/TablePanel.test.tsx
+++ b/table/src/components/TablePanel.test.tsx
@@ -140,7 +140,10 @@ describe('TablePanel', () => {
       renderPanel(MOCK_TIME_SERIES_DATA_SINGLEVALUE, {
         enableSorting: true,
         // column settings without an explicit enableSorting inherit the general default
-        columnSettings: [{ name: 'value', header: 'Value' }, { name: 'env', enableSorting: false }],
+        columnSettings: [
+          { name: 'value', header: 'Value' },
+          { name: 'env', enableSorting: false },
+        ],
       });
 
       const valueHeaderCell = await screen.findByRole('columnheader', { name: /Value/i });

--- a/table/src/components/TablePanel.test.tsx
+++ b/table/src/components/TablePanel.test.tsx
@@ -134,6 +134,24 @@ describe('TablePanel', () => {
     TEST_TIMEOUT
   );
 
+  it(
+    'should enable sorting on all columns when enableSorting is set in general settings',
+    async () => {
+      renderPanel(MOCK_TIME_SERIES_DATA_SINGLEVALUE, {
+        enableSorting: true,
+        // column settings without an explicit enableSorting inherit the general default
+        columnSettings: [{ name: 'value', header: 'Value' }, { name: 'env', enableSorting: false }],
+      });
+
+      const valueHeaderCell = await screen.findByRole('columnheader', { name: /Value/i });
+      expect(await within(valueHeaderCell).findByTestId('ArrowDownwardIcon')).toBeInTheDocument();
+
+      const envHeaderCell = await screen.findByRole('columnheader', { name: 'env' });
+      expect(within(envHeaderCell).queryByTestId('ArrowDownwardIcon')).not.toBeInTheDocument();
+    },
+    TEST_TIMEOUT
+  );
+
   it('should apply transforms', async () => {
     renderPanel(MOCK_TIME_SERIES_DATA_SINGLEVALUE, {
       transforms: [

--- a/table/src/components/TablePanel.tsx
+++ b/table/src/components/TablePanel.tsx
@@ -343,7 +343,8 @@ function generateColumnConfig(
   columnSettings: ColumnSettings[],
   allVariables: VariableStateMap,
   gaugeRangeByColumn: Record<string, GaugeRange>,
-  globalCellSettings: CellSettings[] = []
+  globalCellSettings: CellSettings[] = [],
+  defaultEnableSorting = false
 ): TableColumnConfig<unknown> | undefined {
   for (const column of columnSettings) {
     if (column.name === name) {
@@ -360,7 +361,7 @@ function generateColumnConfig(
         accessorKey: name,
         header: header ?? name,
         headerDescription,
-        enableSorting,
+        enableSorting: enableSorting ?? defaultEnableSorting,
         width,
         align,
         dataLink: modifiedDataLink,
@@ -372,6 +373,7 @@ function generateColumnConfig(
   return {
     accessorKey: name,
     header: name,
+    enableSorting: defaultEnableSorting,
   };
 }
 
@@ -544,7 +546,8 @@ export function TablePanel({ contentDimensions, spec, queryResults }: TableProps
         spec.columnSettings ?? [],
         allVariables,
         gaugeRangeByColumn,
-        spec.cellSettings ?? []
+        spec.cellSettings ?? [],
+        spec.enableSorting ?? false
       );
       if (columnConfig !== undefined) {
         columns.push(columnConfig);
@@ -561,7 +564,8 @@ export function TablePanel({ contentDimensions, spec, queryResults }: TableProps
             spec.columnSettings ?? [],
             allVariables,
             gaugeRangeByColumn,
-            spec.cellSettings ?? []
+            spec.cellSettings ?? [],
+            spec.enableSorting ?? false
           );
           if (columnConfig !== undefined) {
             columns.push(columnConfig);
@@ -571,7 +575,15 @@ export function TablePanel({ contentDimensions, spec, queryResults }: TableProps
     }
 
     return columns;
-  }, [keys, spec.columnSettings, spec.defaultColumnHidden, allVariables, gaugeRangeByColumn, spec.cellSettings]);
+  }, [
+    keys,
+    spec.columnSettings,
+    spec.defaultColumnHidden,
+    spec.enableSorting,
+    allVariables,
+    gaugeRangeByColumn,
+    spec.cellSettings,
+  ]);
 
   // Filtering state — declared before cellConfigs so filteredData is available for cell config evaluation
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);

--- a/table/src/components/TableSettingsEditor.tsx
+++ b/table/src/components/TableSettingsEditor.tsx
@@ -93,6 +93,14 @@ export function TableSettingsEditor({ onChange, value }: TableSettingsEditorProp
     onChange({ ...value, enableFiltering: checked });
   }
 
+  function handleEnableSortingChange(_event: ChangeEvent, checked: boolean): void {
+    onChange({
+      ...value,
+      enableSorting: checked,
+      columnSettings: value.columnSettings?.map(({ enableSorting: _ignored, ...column }) => column),
+    });
+  }
+
   return (
     <OptionsEditorGrid>
       <OptionsEditorColumn>
@@ -109,6 +117,10 @@ export function TableSettingsEditor({ onChange, value }: TableSettingsEditorProp
           <OptionsEditorControl
             label="Enable Column Filtering"
             control={<Switch checked={!!value.enableFiltering} onChange={handleEnableFilteringChange} />}
+          />
+          <OptionsEditorControl
+            label="Enable Sorting"
+            control={<Switch checked={!!value.enableSorting} onChange={handleEnableSortingChange} />}
           />
 
           <DefaultColumnsDimensionsControl

--- a/table/src/models/table-model.ts
+++ b/table/src/models/table-model.ts
@@ -48,6 +48,7 @@ export interface ColumnSettings {
   align?: 'left' | 'center' | 'right';
 
   // When `true`, the column will be sortable.
+  // When unset, inherits TableOptions.enableSorting from General Settings.
   enableSorting?: boolean;
 
   // Default sort order for the column.
@@ -138,6 +139,8 @@ export interface TableOptions {
   pagination?: boolean;
   // Enable filtering for individual columns.
   enableFiltering?: boolean;
+  // When true, columns are sortable by default unless overridden in columnSettings.
+  enableSorting?: boolean;
   // Enable row selection.
   selection?: SelectionOptions;
   // Customize actions available for selected rows.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Implements [perses/perses#4204](https://github.com/perses/perses/issues/3939)
Adds a table-wide Enable Sorting option in General Settings so all columns are sortable by default, without configuring each column individually:
- New `enableSorting` on Table options 
- Columns inherit the general default; Column Settings can still override
- Toggling General Settings re-applies the default to all columns (clears stale per-column flags)
- Column editor only persists `enableSorting` when it differs from the general default

# Screenshots

Enable sorting function button:
<img width="439" height="456" alt="image" src="https://github.com/user-attachments/assets/f33b0d35-1d5c-4abd-bac3-2bbac17098cf" />

# Checklist

- [X] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [X] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
