### PR TITLE
Prepare timeserieschart release v0.14.0-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15494,7 +15494,7 @@
     },
     "timeserieschart": {
       "name": "@perses-dev/timeseries-chart-plugin",
-      "version": "0.13.0",
+      "version": "0.14.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "color-hash": "^2.0.2"

--- a/timeserieschart/package.json
+++ b/timeserieschart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/timeseries-chart-plugin",
-  "version": "0.13.0",
+  "version": "0.14.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {


### PR DESCRIPTION
Bumps `@perses-dev/timeseries-chart-plugin` to `0.14.0-rc.0` to release the panel-level annotations support added in #754.

Pre-release, since it depends on the beta `@perses-dev/spec@^0.3.0-beta.1` and shared `^0.55.0-beta.1` while the 0.55/0.3 line is still in beta.

After merge, the release tag `timeserieschart/v0.14.0-rc.0` will be cut via `scripts/release/release.go`.