### PR TITLE
[BUGFIX] rsbuild: handle plugin version

### DIFF
--- a/rsbuild.shared.ts
+++ b/rsbuild.shared.ts
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { ModuleFederationOptions, pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { mergeRsbuildConfig, RsbuildConfig } from '@rsbuild/core';
 
@@ -73,7 +76,7 @@ interface PluginConfigOptions {
  * });
  * ```
  */
-export function createConfigForPlugin(options: PluginConfigOptions) {
+export function createConfigForPlugin(options: PluginConfigOptions): RsbuildConfig {
   const { name, rsbuildConfig = {}, moduleFederation = {} } = options;
 
   const mfConfig: ModuleFederationOptions = {
@@ -91,12 +94,31 @@ export function createConfigForPlugin(options: PluginConfigOptions) {
   );
 }
 
-function getAssetPrefix(name: string): string {
-  return `${PLUGINS_PATH}/${name}/`;
+function getAssetPrefix(name: string, version?: string): string {
+  // The Perses server serves plugin files from `/plugins/<name>[~<version>[~<registry>]]/`. Including the version makes
+  // each version's assets resolve from its own directory: without it, every request lands on `/plugins/<name>/`, which
+  // the server resolves to the *latest* installed version, so any non-latest (e.g. pinned/locked) version tries to load
+  // the latest version's files and fails.
+  const identity = version ? `${name}~${version}` : name;
+  return `${PLUGINS_PATH}/${identity}/`;
+}
+
+/**
+ * Reads the plugin version from the `package.json` of the plugin currently being built. Returns `undefined` when it
+ * cannot be determined, in which case asset paths fall back to the version-less prefix.
+ */
+function getPluginVersion(): string | undefined {
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8'));
+    return typeof pkg.version === 'string' && pkg.version.length > 0 ? pkg.version : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function getRsbuildConfig(name: string): RsbuildConfig {
   const assetPrefix = getAssetPrefix(name);
+  const version = process.env.NODE_ENV === 'development' ? undefined : getPluginVersion();
 
   return {
     server: {
@@ -131,6 +153,18 @@ function getRsbuildConfig(name: string): RsbuildConfig {
         if (process.env.NODE_ENV !== 'development') {
           config.output.publicPath = 'auto';
         }
+        // Isolate each version's webpack runtime.
+        //
+        // `chunk_<uniqueName>` is the global array async chunks register into. When two versions of the same plugin
+        // share it, the version loaded second pushes its chunks into the first one's runtime, and because module IDs are
+        // deterministic they collide, so both versions end up resolving to the first one's modules (two different
+        // versions rendering identically). `chunkLoadingGlobal` is derived before this hook runs, so it has to be set
+        // explicitly rather than relying on `uniqueName`.
+        if (version) {
+          const uniqueName = toGlobalName(name, version);
+          config.output.uniqueName = uniqueName;
+          config.output.chunkLoadingGlobal = `chunk_${uniqueName}`;
+        }
         return config;
       },
     },
@@ -138,10 +172,36 @@ function getRsbuildConfig(name: string): RsbuildConfig {
 }
 
 function getBaseModuleFederationConfig(name: string): ModuleFederationOptions {
-  return {
+  const config: ModuleFederationOptions = {
     name,
     dts: false,
     runtime: false,
-    getPublicPath: `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${getAssetPrefix(name)}"; }`,
   };
+
+  // In development the plugin is served by the rsbuild dev server and proxied by Perses, which strips the whole
+  // `/plugins/<segment>` prefix, so the version-less prefix is what works there.
+  //
+  // For production builds the prefix embeds the plugin version (`/plugins/<name>~<version>/`) so that each installed
+  // version loads its own assets. Without it every request goes to `/plugins/<name>/`, which the server resolves to the
+  // latest installed version, so a pinned/older version ends up requesting the latest version's hashed files (404).
+  const version = process.env.NODE_ENV === 'development' ? undefined : getPluginVersion();
+  config.getPublicPath = `function() { const prefix = window.PERSES_PLUGIN_ASSETS_PATH || window.PERSES_APP_CONFIG?.api_prefix || ""; return prefix + "${getAssetPrefix(name, version)}"; }`;
+
+  // Give each version its own global container name.
+  //
+  // The Module Federation runtime resolves a remote's container through `globalThis[globalName]`, where `globalName`
+  // comes from this library name via the manifest (see `assignRemoteInfo` in `@module-federation/runtime-core`). It also
+  // early-returns an already-registered container: `if (remoteEntryExports) return remoteEntryExports`. So when several
+  // versions of the same plugin share the global name, the first version loaded wins and every other version silently
+  // reuses its container instead of loading its own entry, which makes two different versions render identically.
+  if (version) {
+    config.library = { type: 'global', name: toGlobalName(name, version) };
+  }
+
+  return config;
+}
+
+/** Build a JS-identifier-safe global container name that is unique per plugin version. */
+function toGlobalName(name: string, version: string): string {
+  return `${name}_${version}`.replace(/[^a-zA-Z0-9_$]/g, '_');
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Context useful to a reviewer -->
In spec of plugin we can define "metadata" (version + registry) and when I wanted to implement it on frontside, I got some issue when there is multiple instances of a same plugin with different versions.

Makes plugin builds version-aware so multiple versions of the same plugin can be installed and loaded side by side. Previously only the latest installed version of a plugin was actually loadable — any other version either failed to load or silently rendered the latest one's code.

**1. Version in the asset prefix**

  `getPublicPath` now returns `/plugins/<name>~<version>/` instead of `/plugins/<name>/`. The version is read from the plugin's `package.json` at build time.

  **Why:** a manifest fetched from `/plugins/<name>~<version>/mf-manifest.json` resolved its (relative) remoteEntry against the version-less prefix. The server maps a path with no `~version` to  `LatestVersion`, so an older version requested the latest version's directory. Since chunk filenames are content-hashed, the file didn't exist there:

  `RUNTIME-008 ScriptNetworkError resourceUrl: /plugins/TimeSeriesChart/__mf/js/TimeSeriesChart.7c5da441.js (404)`

  This also explains why the newest version always appeared to work, and why an older version worked right up until a newer archive was dropped in.

  **2. Version in the Module Federation container global name**

  Sets library: `{ type: 'global', name: '<Name>_<version>' }`, so the manifest's globalName is unique per version.

  **Why:** MF resolves a remote's container via `globalThis[globalName]`, taken from the manifest (`assignRemoteInfo` in `@module-federation/runtime-core`), and `loadEntryScript` early-returns an already-registered container:

```
  const { entryExports } = getRemoteEntryExports(name, globalName);
  if (entryExports) return entryExports;
```

  With every version sharing the global name, the first version loaded won and later versions silently reused its container without ever fetching their own entry.

  **3. Version in the webpack chunk registry**

  Sets `output.uniqueName` and `output.chunkLoadingGlobal` to `chunk_<Name>_<version>`.

  **Why:** async chunks register into a shared global array:

```
  (self.chunk_TimeSeriesChart = self.chunk_TimeSeriesChart || []).push([["53"], { 10985(...) }])
```

  When two versions share that global, the second one pushes its chunks into the runtime the first installed, and because module IDs are deterministic they collide: both versions resolve to the first one's modules. `chunkLoadingGlobal` is set explicitly because rspack derives it from `uniqueName` before the tools.rspack hook runs, so setting `uniqueName` alone is not enough.


**Plugins must be rebuilt for this to take effect; it is not retroactive for already-published archives**
I did not handle registry name to have super long name, because I am not sure it will happen often 🙏 
I guess if someone has the issue, he can change plugin name as quick win/fix

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
