### PR TITLE
[FEATURE] BarChart: add regex based color override

### DIFF
--- a/barchart/schemas/bar.cue
+++ b/barchart/schemas/bar.cue
@@ -26,4 +26,8 @@ spec: close({
 	orientation?: "horizontal" | "vertical"
 	groupBy?: [...string]
 	isStacked?: bool
+	colorOverrides?: [...{
+		regex: string
+		color: string
+	}]
 })

--- a/barchart/schemas/bar.cue
+++ b/barchart/schemas/bar.cue
@@ -26,8 +26,10 @@ spec: close({
 	orientation?: "horizontal" | "vertical"
 	groupBy?: [...string]
 	isStacked?: bool
-	colorOverrides?: [...{
-		regex: string
-		color: string
-	}]
+	visual?: {
+		colorOverrides?: [...{
+			regex: string
+			color: string
+		}]
+	}
 })

--- a/barchart/schemas/tests/valid/bar_color_overrides.json
+++ b/barchart/schemas/tests/valid/bar_color_overrides.json
@@ -7,11 +7,13 @@
     },
     "sort": "desc",
     "mode": "value",
-    "colorOverrides": [
-      {
-        "regex": "errors",
-        "color": "#ff0000"
-      }
-    ]
+    "visual": {
+      "colorOverrides": [
+        {
+          "regex": "errors",
+          "color": "#ff0000"
+        }
+      ]
+    }
   }
 }

--- a/barchart/schemas/tests/valid/bar_color_overrides.json
+++ b/barchart/schemas/tests/valid/bar_color_overrides.json
@@ -1,0 +1,17 @@
+{
+  "kind": "BarChart",
+  "spec": {
+    "calculation": "last-number",
+    "format": {
+      "unit": "decimal"
+    },
+    "sort": "desc",
+    "mode": "value",
+    "colorOverrides": [
+      {
+        "regex": "errors",
+        "color": "#ff0000"
+      }
+    ]
+  }
+}

--- a/barchart/src/BarChartBase.tsx
+++ b/barchart/src/BarChartBase.tsx
@@ -26,6 +26,9 @@ import { use as registerECharts, EChartsCoreOption } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { ReactElement, useMemo } from 'react';
 
+import { ColorOverride } from './bar-chart-model';
+import { getOverrideColor } from './utils';
+
 registerECharts([
   EChartsBarChart,
   GridComponent,
@@ -64,6 +67,7 @@ export interface BarChartBaseProps {
   groupedData?: StackedBarChartData | null;
   isStacked?: boolean;
   orientation?: 'horizontal' | 'vertical';
+  colorOverrides?: ColorOverride[];
 }
 
 export function BarChartBase(props: BarChartBaseProps): ReactElement {
@@ -76,6 +80,7 @@ export function BarChartBase(props: BarChartBaseProps): ReactElement {
     groupedData,
     isStacked = false,
     orientation = 'horizontal',
+    colorOverrides,
   } = props;
   const chartsTheme = useChartsTheme();
   const isHorizontal = orientation === 'horizontal';
@@ -103,14 +108,20 @@ export function BarChartBase(props: BarChartBaseProps): ReactElement {
               axisLabel: { overflow: 'truncate', width: width / 3 },
             }
           : getFormattedAxis({}, format),
-        series: series.map((s) => ({
-          name: s.name,
-          type: 'bar',
-          stack: isStacked ? 'total' : undefined,
-          data: s.values,
-          label: { show: false },
-          itemStyle: { borderRadius: isStacked ? 0 : 4 },
-        })),
+        series: series.map((s) => {
+          const overrideColor = getOverrideColor(s.name, colorOverrides);
+          return {
+            name: s.name,
+            type: 'bar',
+            stack: isStacked ? 'total' : undefined,
+            data: s.values,
+            label: { show: false },
+            itemStyle: {
+              borderRadius: isStacked ? 0 : 4,
+              ...(overrideColor ? { color: overrideColor } : {}),
+            },
+          };
+        }),
         tooltip: {
           trigger: 'axis',
           axisPointer: { type: 'shadow' },
@@ -182,7 +193,12 @@ export function BarChartBase(props: BarChartBaseProps): ReactElement {
         },
         itemStyle: {
           borderRadius: 4,
-          color: chartsTheme.echartsTheme[0],
+          color: (params: { name: string }): string => {
+            const overrideColor = getOverrideColor(params.name, colorOverrides);
+            if (overrideColor) return overrideColor;
+            const palette = chartsTheme.echartsTheme.color as string[] | undefined;
+            return palette?.[0] ?? '';
+          },
         },
       },
       tooltip: {
@@ -197,7 +213,7 @@ export function BarChartBase(props: BarChartBaseProps): ReactElement {
         right: '5%',
       },
     };
-  }, [data, groupedData, isStacked, chartsTheme, width, mode, format, isHorizontal]);
+  }, [data, groupedData, isStacked, chartsTheme, width, mode, format, isHorizontal, colorOverrides]);
 
   let numGroupedRows = 0;
   if (groupedData) {

--- a/barchart/src/BarChartOptionsEditorSettings.test.tsx
+++ b/barchart/src/BarChartOptionsEditorSettings.test.tsx
@@ -170,7 +170,7 @@ describe('BarChartOptionsEditorSettings', () => {
     userEvent.click(addButton);
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        colorOverrides: [{ regex: '', color: '#555' }],
+        visual: { colorOverrides: [{ regex: '', color: '#555' }] },
       }),
     );
   });
@@ -185,7 +185,7 @@ describe('BarChartOptionsEditorSettings', () => {
         calculation: 'first',
         sort: 'desc',
         mode: 'value',
-        colorOverrides: [{ regex: 'errors', color: '#ff0000' }],
+        visual: { colorOverrides: [{ regex: 'errors', color: '#ff0000' }] },
       },
       onChange,
     );
@@ -193,7 +193,7 @@ describe('BarChartOptionsEditorSettings', () => {
     userEvent.click(deleteButton);
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        colorOverrides: [],
+        visual: { colorOverrides: [] },
       }),
     );
   });

--- a/barchart/src/BarChartOptionsEditorSettings.test.tsx
+++ b/barchart/src/BarChartOptionsEditorSettings.test.tsx
@@ -162,4 +162,39 @@ describe('BarChartOptionsEditorSettings', () => {
       }),
     );
   });
+
+  it('can add a color override', () => {
+    const onChange = jest.fn();
+    renderBarChartOptionsEditorSettings(undefined, onChange);
+    const addButton = screen.getByRole('button', { name: 'Add Color Override' });
+    userEvent.click(addButton);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        colorOverrides: [{ regex: '', color: '#555' }],
+      }),
+    );
+  });
+
+  it('can remove a color override', () => {
+    const onChange = jest.fn();
+    renderBarChartOptionsEditorSettings(
+      {
+        format: {
+          unit: 'decimal',
+        },
+        calculation: 'first',
+        sort: 'desc',
+        mode: 'value',
+        colorOverrides: [{ regex: 'errors', color: '#ff0000' }],
+      },
+      onChange,
+    );
+    const deleteButton = screen.getByRole('button', { name: 'delete color override n°1' });
+    userEvent.click(deleteButton);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        colorOverrides: [],
+      }),
+    );
+  });
 });

--- a/barchart/src/BarChartOptionsEditorSettings.tsx
+++ b/barchart/src/BarChartOptionsEditorSettings.tsx
@@ -230,6 +230,8 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
             label="Stack bars"
           />
         </OptionsEditorGroup>
+      </OptionsEditorColumn>
+      <OptionsEditorColumn>
         <OptionsEditorGroup title="Color Overrides">
           {colorOverrides.map((override, i) => (
             <Stack key={i} direction="row" alignItems="center" spacing={1}>
@@ -254,8 +256,6 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
             Add Color Override
           </Button>
         </OptionsEditorGroup>
-      </OptionsEditorColumn>
-      <OptionsEditorColumn>
         <OptionsEditorGroup title="Reset Settings">
           <Button variant="outlined" color="secondary" onClick={handleResetSettings}>
             Reset To Defaults

--- a/barchart/src/BarChartOptionsEditorSettings.tsx
+++ b/barchart/src/BarChartOptionsEditorSettings.tsx
@@ -62,7 +62,7 @@ import {
   DEFAULT_SORT,
   DEFAULT_IS_STACKED,
   DEFAULT_GROUP_BY,
-  DEFAULT_COLOR_OVERRIDES,
+  DEFAULT_VISUAL,
 } from './bar-chart-model';
 
 const DEFAULT_COLOR_VALUE = '#555';
@@ -112,7 +112,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
         draft.groupBy = DEFAULT_GROUP_BY;
         draft.isStacked = DEFAULT_IS_STACKED;
         draft.orientation = DEFAULT_ORIENTATION;
-        draft.colorOverrides = DEFAULT_COLOR_OVERRIDES;
+        draft.visual = DEFAULT_VISUAL;
       }),
     );
   };
@@ -120,8 +120,9 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
   const handleAddColorOverride = (): void => {
     onChange(
       produce(value, (draft: BarChartOptions) => {
-        if (!draft.colorOverrides) draft.colorOverrides = [];
-        draft.colorOverrides.push({ regex: '', color: DEFAULT_COLOR_VALUE });
+        if (!draft.visual) draft.visual = {};
+        if (!draft.visual.colorOverrides) draft.visual.colorOverrides = [];
+        draft.visual.colorOverrides.push({ regex: '', color: DEFAULT_COLOR_VALUE });
       }),
     );
   };
@@ -129,7 +130,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
   const handleRemoveColorOverride = (index: number): void => {
     onChange(
       produce(value, (draft: BarChartOptions) => {
-        draft.colorOverrides?.splice(index, 1);
+        draft.visual?.colorOverrides?.splice(index, 1);
       }),
     );
   };
@@ -137,7 +138,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
   const handleColorOverrideRegexChange = (index: number, regex: string): void => {
     onChange(
       produce(value, (draft: BarChartOptions) => {
-        const override = draft.colorOverrides?.[index];
+        const override = draft.visual?.colorOverrides?.[index];
         if (override) override.regex = regex;
       }),
     );
@@ -146,7 +147,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
   const handleColorOverrideColorChange = (index: number, color: string): void => {
     onChange(
       produce(value, (draft: BarChartOptions) => {
-        const override = draft.colorOverrides?.[index];
+        const override = draft.visual?.colorOverrides?.[index];
         if (override) override.color = color;
       }),
     );
@@ -160,7 +161,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
   );
   const groupBy = value.groupBy ?? DEFAULT_GROUP_BY;
   const isStacked = value.isStacked ?? DEFAULT_IS_STACKED;
-  const colorOverrides = value.colorOverrides ?? DEFAULT_COLOR_OVERRIDES;
+  const colorOverrides = value.visual?.colorOverrides ?? [];
 
   return (
     <OptionsEditorGrid>
@@ -244,10 +245,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
                 color={override.color || DEFAULT_COLOR_VALUE}
                 onColorChange={(color) => handleColorOverrideColorChange(i, color)}
               />
-              <IconButton
-                aria-label={`delete color override n°${i + 1}`}
-                onClick={() => handleRemoveColorOverride(i)}
-              >
+              <IconButton aria-label={`delete color override n°${i + 1}`} onClick={() => handleRemoveColorOverride(i)}>
                 <DeleteIcon />
               </IconButton>
             </Stack>

--- a/barchart/src/BarChartOptionsEditorSettings.tsx
+++ b/barchart/src/BarChartOptionsEditorSettings.tsx
@@ -16,6 +16,8 @@ import {
   Button,
   Chip,
   FormControlLabel,
+  IconButton,
+  Stack,
   Switch,
   TextField,
   ToggleButton,
@@ -30,6 +32,7 @@ import {
   ModeOption,
   ModeSelector,
   ModeSelectorProps,
+  OptionsColorPicker,
   OptionsEditorColumn,
   OptionsEditorGrid,
   OptionsEditorGroup,
@@ -46,6 +49,8 @@ import {
 import { produce } from 'immer';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
+import DeleteIcon from 'mdi-material-ui/DeleteOutline';
+import AddIcon from 'mdi-material-ui/Plus';
 import { MouseEventHandler, ReactElement } from 'react';
 
 import {
@@ -57,7 +62,10 @@ import {
   DEFAULT_SORT,
   DEFAULT_IS_STACKED,
   DEFAULT_GROUP_BY,
+  DEFAULT_COLOR_OVERRIDES,
 } from './bar-chart-model';
+
+const DEFAULT_COLOR_VALUE = '#555';
 
 export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps): ReactElement {
   const { onChange, value } = props;
@@ -104,6 +112,42 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
         draft.groupBy = DEFAULT_GROUP_BY;
         draft.isStacked = DEFAULT_IS_STACKED;
         draft.orientation = DEFAULT_ORIENTATION;
+        draft.colorOverrides = DEFAULT_COLOR_OVERRIDES;
+      }),
+    );
+  };
+
+  const handleAddColorOverride = (): void => {
+    onChange(
+      produce(value, (draft: BarChartOptions) => {
+        if (!draft.colorOverrides) draft.colorOverrides = [];
+        draft.colorOverrides.push({ regex: '', color: DEFAULT_COLOR_VALUE });
+      }),
+    );
+  };
+
+  const handleRemoveColorOverride = (index: number): void => {
+    onChange(
+      produce(value, (draft: BarChartOptions) => {
+        draft.colorOverrides?.splice(index, 1);
+      }),
+    );
+  };
+
+  const handleColorOverrideRegexChange = (index: number, regex: string): void => {
+    onChange(
+      produce(value, (draft: BarChartOptions) => {
+        const override = draft.colorOverrides?.[index];
+        if (override) override.regex = regex;
+      }),
+    );
+  };
+
+  const handleColorOverrideColorChange = (index: number, color: string): void => {
+    onChange(
+      produce(value, (draft: BarChartOptions) => {
+        const override = draft.colorOverrides?.[index];
+        if (override) override.color = color;
       }),
     );
   };
@@ -116,6 +160,7 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
   );
   const groupBy = value.groupBy ?? DEFAULT_GROUP_BY;
   const isStacked = value.isStacked ?? DEFAULT_IS_STACKED;
+  const colorOverrides = value.colorOverrides ?? DEFAULT_COLOR_OVERRIDES;
 
   return (
     <OptionsEditorGrid>
@@ -183,6 +228,33 @@ export function BarChartOptionsEditorSettings(props: BarChartOptionsEditorProps)
             }
             label="Stack bars"
           />
+        </OptionsEditorGroup>
+        <OptionsEditorGroup title="Color Overrides">
+          {colorOverrides.map((override, i) => (
+            <Stack key={i} direction="row" alignItems="center" spacing={1}>
+              <TextField
+                size="small"
+                label="Regex"
+                value={override.regex}
+                onChange={(e) => handleColorOverrideRegexChange(i, e.target.value)}
+                sx={{ flexGrow: 1 }}
+              />
+              <OptionsColorPicker
+                label={override.regex || `Color override n°${i + 1}`}
+                color={override.color || DEFAULT_COLOR_VALUE}
+                onColorChange={(color) => handleColorOverrideColorChange(i, color)}
+              />
+              <IconButton
+                aria-label={`delete color override n°${i + 1}`}
+                onClick={() => handleRemoveColorOverride(i)}
+              >
+                <DeleteIcon />
+              </IconButton>
+            </Stack>
+          ))}
+          <Button variant="outlined" startIcon={<AddIcon />} onClick={handleAddColorOverride}>
+            Add Color Override
+          </Button>
         </OptionsEditorGroup>
       </OptionsEditorColumn>
       <OptionsEditorColumn>

--- a/barchart/src/BarChartPanel.tsx
+++ b/barchart/src/BarChartPanel.tsx
@@ -33,7 +33,7 @@ export function BarChartPanel(props: BarChartPanelProps): ReactElement | null {
       groupBy = [],
       isStacked = false,
       orientation = 'horizontal',
-      colorOverrides,
+      visual,
     },
     contentDimensions,
     queryResults,
@@ -142,7 +142,7 @@ export function BarChartPanel(props: BarChartPanelProps): ReactElement | null {
         groupedData={stackedBarChartData}
         isStacked={isStacked}
         orientation={orientation}
-        colorOverrides={colorOverrides}
+        colorOverrides={visual?.colorOverrides}
       />
     </Box>
   );

--- a/barchart/src/BarChartPanel.tsx
+++ b/barchart/src/BarChartPanel.tsx
@@ -25,16 +25,7 @@ export type BarChartPanelProps = PanelProps<BarChartOptions, TimeSeriesData>;
 
 export function BarChartPanel(props: BarChartPanelProps): ReactElement | null {
   const {
-    spec: {
-      calculation,
-      format,
-      sort,
-      mode,
-      groupBy = [],
-      isStacked = false,
-      orientation = 'horizontal',
-      visual,
-    },
+    spec: { calculation, format, sort, mode, groupBy = [], isStacked = false, orientation = 'horizontal', visual },
     contentDimensions,
     queryResults,
   } = props;

--- a/barchart/src/BarChartPanel.tsx
+++ b/barchart/src/BarChartPanel.tsx
@@ -25,7 +25,16 @@ export type BarChartPanelProps = PanelProps<BarChartOptions, TimeSeriesData>;
 
 export function BarChartPanel(props: BarChartPanelProps): ReactElement | null {
   const {
-    spec: { calculation, format, sort, mode, groupBy = [], isStacked = false, orientation = 'horizontal' },
+    spec: {
+      calculation,
+      format,
+      sort,
+      mode,
+      groupBy = [],
+      isStacked = false,
+      orientation = 'horizontal',
+      colorOverrides,
+    },
     contentDimensions,
     queryResults,
   } = props;
@@ -133,6 +142,7 @@ export function BarChartPanel(props: BarChartPanelProps): ReactElement | null {
         groupedData={stackedBarChartData}
         isStacked={isStacked}
         orientation={orientation}
+        colorOverrides={colorOverrides}
       />
     </Box>
   );

--- a/barchart/src/bar-chart-model.ts
+++ b/barchart/src/bar-chart-model.ts
@@ -21,7 +21,6 @@ export const DEFAULT_MODE: ModeOption = 'value';
 export const DEFAULT_ORIENTATION: 'horizontal' | 'vertical' = 'horizontal';
 export const DEFAULT_GROUP_BY: string[] = [];
 export const DEFAULT_IS_STACKED = false;
-export const DEFAULT_COLOR_OVERRIDES: ColorOverride[] = [];
 export const DEFAULT_VISUAL: BarChartVisual = {};
 
 /**

--- a/barchart/src/bar-chart-model.ts
+++ b/barchart/src/bar-chart-model.ts
@@ -21,6 +21,15 @@ export const DEFAULT_MODE: ModeOption = 'value';
 export const DEFAULT_ORIENTATION: 'horizontal' | 'vertical' = 'horizontal';
 export const DEFAULT_GROUP_BY: string[] = [];
 export const DEFAULT_IS_STACKED = false;
+export const DEFAULT_COLOR_OVERRIDES: ColorOverride[] = [];
+
+/**
+ * A regex-based color override for a series/bar.
+ */
+export interface ColorOverride {
+  regex: string;
+  color: string;
+}
 
 /**
  * The schema for a BarChart panel.
@@ -40,6 +49,7 @@ export interface BarChartOptions {
   orientation?: 'horizontal' | 'vertical';
   groupBy?: string[];
   isStacked?: boolean;
+  colorOverrides?: ColorOverride[];
 }
 
 export type BarChartOptionsEditorProps = OptionsEditorProps<BarChartOptions>;
@@ -56,5 +66,6 @@ export function createInitialBarChartOptions(): BarChartOptions {
     orientation: DEFAULT_ORIENTATION,
     groupBy: DEFAULT_GROUP_BY,
     isStacked: DEFAULT_IS_STACKED,
+    colorOverrides: DEFAULT_COLOR_OVERRIDES,
   };
 }

--- a/barchart/src/bar-chart-model.ts
+++ b/barchart/src/bar-chart-model.ts
@@ -22,6 +22,7 @@ export const DEFAULT_ORIENTATION: 'horizontal' | 'vertical' = 'horizontal';
 export const DEFAULT_GROUP_BY: string[] = [];
 export const DEFAULT_IS_STACKED = false;
 export const DEFAULT_COLOR_OVERRIDES: ColorOverride[] = [];
+export const DEFAULT_VISUAL: BarChartVisual = {};
 
 /**
  * A regex-based color override for a series/bar.
@@ -29,6 +30,13 @@ export const DEFAULT_COLOR_OVERRIDES: ColorOverride[] = [];
 export interface ColorOverride {
   regex: string;
   color: string;
+}
+
+/**
+ * Visual display options for a BarChart panel.
+ */
+export interface BarChartVisual {
+  colorOverrides?: ColorOverride[];
 }
 
 /**
@@ -49,7 +57,7 @@ export interface BarChartOptions {
   orientation?: 'horizontal' | 'vertical';
   groupBy?: string[];
   isStacked?: boolean;
-  colorOverrides?: ColorOverride[];
+  visual?: BarChartVisual;
 }
 
 export type BarChartOptionsEditorProps = OptionsEditorProps<BarChartOptions>;
@@ -66,6 +74,6 @@ export function createInitialBarChartOptions(): BarChartOptions {
     orientation: DEFAULT_ORIENTATION,
     groupBy: DEFAULT_GROUP_BY,
     isStacked: DEFAULT_IS_STACKED,
-    colorOverrides: DEFAULT_COLOR_OVERRIDES,
+    visual: DEFAULT_VISUAL,
   };
 }

--- a/barchart/src/utils.test.ts
+++ b/barchart/src/utils.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { BarChartData } from './BarChartBase';
-import { calculatePercentages, sortSeriesData } from './utils';
+import { calculatePercentages, getOverrideColor, sortSeriesData } from './utils';
 
 const MOCK_DATA: BarChartData[] = [
   {
@@ -116,5 +116,48 @@ describe('sortSeriesData', () => {
         value: 5,
       },
     ]);
+  });
+});
+
+describe('getOverrideColor', () => {
+  it('returns the color of the first matching override', () => {
+    const color = getOverrideColor('errors_total', [
+      { regex: 'errors', color: '#ff0000' },
+      { regex: 'total', color: '#00ff00' },
+    ]);
+    expect(color).toBe('#ff0000');
+  });
+
+  it('returns undefined when no override matches', () => {
+    const color = getOverrideColor('latency', [{ regex: 'errors', color: '#ff0000' }]);
+    expect(color).toBeUndefined();
+  });
+
+  it('returns undefined when overrides is undefined', () => {
+    expect(getOverrideColor('errors')).toBeUndefined();
+  });
+
+  it('ignores invalid regex and continues to the next override', () => {
+    const color = getOverrideColor('errors_total', [
+      { regex: '[', color: '#ff0000' },
+      { regex: 'errors', color: '#00ff00' },
+    ]);
+    expect(color).toBe('#00ff00');
+  });
+
+  it('ignores empty regex and continues to the next override', () => {
+    const color = getOverrideColor('errors_total', [
+      { regex: '', color: '#ff0000' },
+      { regex: 'errors', color: '#00ff00' },
+    ]);
+    expect(color).toBe('#00ff00');
+  });
+
+  it('ignores empty regex and falls back to undefined if no other overrides match', () => {
+    const color = getOverrideColor('latency', [
+      { regex: '', color: '#ff0000' },
+      { regex: 'errors', color: '#00ff00' },
+    ]);
+    expect(color).toBeUndefined();
   });
 });

--- a/barchart/src/utils.ts
+++ b/barchart/src/utils.ts
@@ -13,7 +13,7 @@
 
 import { SortOption } from '@perses-dev/components';
 
-import { DEFAULT_SORT } from './bar-chart-model';
+import { ColorOverride, DEFAULT_SORT } from './bar-chart-model';
 import { BarChartData } from './BarChartBase';
 
 export function calculatePercentages(data: BarChartData[]): Array<{ label: string; value: number }> {
@@ -57,4 +57,25 @@ export function sortSeriesData(data: BarChartData[], sortOrder: SortOption = DEF
       return a.value < b.value ? -1 : 1;
     });
   }
+}
+
+/**
+ * Returns the color of the first override whose regex matches the given name.
+ * Invalid regex patterns are skipped. Returns undefined if no override matches.
+ */
+export function getOverrideColor(name: string, overrides?: ColorOverride[]): string | undefined {
+  if (!overrides) return undefined;
+  for (const override of overrides) {
+    if (override.regex === '') {
+      continue;
+    }
+    try {
+      if (new RegExp(override.regex).test(name)) {
+        return override.color;
+      }
+    } catch {
+      // ignore invalid regex patterns
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
# Description

Adds support for regex-based color overrides in the BarChart panel. Previously users had no way to control this. 

With this change, users can define a list of `{ regex, color }` overrides in the panel settings. A color is applied when a regex matches, otherwise the chart falls back to the palette as before.

Behavior details:
- The regex is matched against **both** series names (grouped/stacked) **and** bar labels (ungrouped).
- When multiple overrides match, the **first** matching entry in the list wins.
- Empty and invalid regex patterns are ignored (skipped) rather than throwing an error or matching all values.

# Screenshots

### Without stacking, matches multiple bars
<img width="297" height="202" alt="Bildschirmfoto 2026-08-20 um 11 12 09" src="https://github.com/user-attachments/assets/5332a437-1e3c-4635-972d-322c1978a2b6" />
<img width="942" height="285" alt="Bildschirmfoto 2026-08-20 um 11 12 01" src="https://github.com/user-attachments/assets/6a898509-6825-4ffd-a250-ddd3bef08867" />

### Without stacking, matches all bars

<img width="301" height="118" alt="Bildschirmfoto 2026-08-20 um 11 36 37" src="https://github.com/user-attachments/assets/121a2f1a-9057-4ee2-afa7-f29d48b4a025" />
<img width="952" height="281" alt="Bildschirmfoto 2026-08-20 um 11 36 32" src="https://github.com/user-attachments/assets/318502f3-cd50-4a97-ac19-e6a2a397b54c" />

### With stacking

<img width="310" height="159" alt="Bildschirmfoto 2026-08-20 um 11 39 11" src="https://github.com/user-attachments/assets/34d59b5e-ad69-4df3-b45e-dcc556a9fdd1" />
<img width="879" height="259" alt="Bildschirmfoto 2026-08-20 um 11 39 17" src="https://github.com/user-attachments/assets/705b6a59-83c2-4d0b-9242-5dc2272eacc3" />

### General updated settings view

With overrides:
<img width="951" height="720" alt="Bildschirmfoto 2026-08-20 um 11 51 03" src="https://github.com/user-attachments/assets/88649a1d-4d95-4b35-8e5b-97370d044854" />

Empty:
<img width="953" height="590" alt="Bildschirmfoto 2026-08-20 um 11 51 14" src="https://github.com/user-attachments/assets/8e22e88b-55fd-413b-85f2-2ea83fe11652" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [X] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).