### PR TITLE
[ENHANCEMENT] - Added auto/custom legend sizing on multi-series stat panels

### DIFF
--- a/statchart/schemas/stat.cue
+++ b/statchart/schemas/stat.cue
@@ -27,8 +27,9 @@ spec: close({
 		color?: string
 		width?: number
 	})
-	valueFontSize?: number
-	colorMode?:     *"value" | "background_solid" | "none"
+	valueFontSize?:  number
+	legendFontSize?: number
+	colorMode?:      *"value" | "background_solid" | "none"
 	legendMode?:    *"auto" | "on" | "off"
 	mappings?: [...common.#mappings]
 })

--- a/statchart/schemas/stat.cue
+++ b/statchart/schemas/stat.cue
@@ -30,6 +30,6 @@ spec: close({
 	valueFontSize?:  number
 	legendFontSize?: number
 	colorMode?:      *"value" | "background_solid" | "none"
-	legendMode?:    *"auto" | "on" | "off"
+	legendMode?:     *"auto" | "on" | "off"
 	mappings?: [...common.#mappings]
 })

--- a/statchart/src/StatChartBase.tsx
+++ b/statchart/src/StatChartBase.tsx
@@ -53,6 +53,8 @@ export interface StatChartProps {
   showSeriesName?: boolean;
   valueFontSize?: FontSizeOption;
   colorMode?: ColorMode;
+  alignmentText?: string;
+  alignmentSeriesName?: string;
 }
 
 export const StatChartBase: FC<StatChartProps> = (props) => {
@@ -66,6 +68,8 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
     format,
     valueFontSize,
     colorMode,
+    alignmentText,
+    alignmentSeriesName,
   } = props;
 
   const {
@@ -78,37 +82,40 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
   const formattedValue = formatStatChartValue(data.calculatedValue, format);
   const containerPadding = chartsTheme.container.padding.default;
 
-  // calculate series name font size and height
+  const availableWidth = width - containerPadding * 2;
+
+  // in multi-series: legend gets a fixed portion of height (like Grafana)
   let seriesNameFontSize = useOptimalFontSize({
     text: data?.seriesData?.name ?? '',
     fontWeight: SERIES_NAME_FONT_WEIGHT,
     width,
-    height: height * 0.125, // assume series name will take 12.5% of available height
+    height: height * 0.2,
     lineHeight: LINE_HEIGHT,
     maxSize: SERIES_NAME_MAX_FONT_SIZE,
   });
 
+  if (alignmentSeriesName !== undefined) {
+    // multi-series: use 15% of cell height for legend, clamped between 14px and 30px
+    seriesNameFontSize = Math.max(14, Math.min((height * 0.15) / LINE_HEIGHT, SERIES_NAME_MAX_FONT_SIZE));
+  }
+
   const seriesNameHeight = showSeriesName ? seriesNameFontSize * LINE_HEIGHT + containerPadding : 0;
 
-  // calculate value font size and height
-  const availableWidth = width - containerPadding * 2;
   const availableHeight = height - seriesNameHeight;
   const optimalValueFontSize = useOptimalFontSize({
-    text: formattedValue,
-    // override the font size if user selects it in the settings
+    text: alignmentText || formattedValue,
     fontSizeOverride: valueFontSize,
     fontWeight: VALUE_FONT_WEIGHT,
-    // without sparkline, use only 50% of the available width so it looks better for multiseries
     width: sparkline ? availableWidth : availableWidth * 0.5,
-    // with sparkline, use only 25% of available height to leave room for chart
-    // without sparkline, value should take up 90% of available space
     height: sparkline ? availableHeight * 0.25 : availableHeight * 0.9,
     lineHeight: LINE_HEIGHT,
   });
   const valueFontHeight = optimalValueFontSize * LINE_HEIGHT;
 
-  // make sure the series name font size is slightly smaller than value font size
-  seriesNameFontSize = Math.min(optimalValueFontSize * 0.7, seriesNameFontSize);
+  // single-series: keep legend smaller than value
+  if (alignmentSeriesName === undefined) {
+    seriesNameFontSize = Math.min(optimalValueFontSize * 0.7, seriesNameFontSize);
+  }
 
   const option: EChartsCoreOption = useMemo(() => {
     if (!data.seriesData) return chartsTheme.noDataOption;
@@ -232,7 +239,10 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
     <Box
       sx={{
         height: '100%',
-        width: '100%',
+        width: width,
+        minWidth: width,
+        flexShrink: 0,
+        overflow: 'hidden',
         backgroundColor: colorMode === 'background_solid' ? color : 'transparent',
         display: 'flex',
         flexDirection: 'column',
@@ -267,8 +277,6 @@ const SeriesName = styled(Typography, {
   color: color,
   padding: `${padding}px`,
   fontSize: `${fontSize}px`,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
 }));
 

--- a/statchart/src/StatChartBase.tsx
+++ b/statchart/src/StatChartBase.tsx
@@ -52,6 +52,7 @@ export interface StatChartProps {
   sparkline?: LineSeriesOption;
   showSeriesName?: boolean;
   valueFontSize?: FontSizeOption;
+  legendFontSize?: FontSizeOption;
   colorMode?: ColorMode;
   alignmentText?: string;
   alignmentSeriesName?: string;
@@ -67,6 +68,7 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
     showSeriesName,
     format,
     valueFontSize,
+    legendFontSize,
     colorMode,
     alignmentText,
     alignmentSeriesName,
@@ -94,7 +96,9 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
     maxSize: SERIES_NAME_MAX_FONT_SIZE,
   });
 
-  if (alignmentSeriesName !== undefined) {
+  if (legendFontSize !== undefined) {
+    seriesNameFontSize = legendFontSize;
+  } else if (alignmentSeriesName !== undefined) {
     // multi-series: use 15% of cell height for legend, clamped between 14px and 30px
     seriesNameFontSize = Math.max(14, Math.min((height * 0.15) / LINE_HEIGHT, SERIES_NAME_MAX_FONT_SIZE));
   }
@@ -112,8 +116,8 @@ export const StatChartBase: FC<StatChartProps> = (props) => {
   });
   const valueFontHeight = optimalValueFontSize * LINE_HEIGHT;
 
-  // single-series: keep legend smaller than value
-  if (alignmentSeriesName === undefined) {
+  // single-series: keep legend smaller than value (unless explicitly set)
+  if (alignmentSeriesName === undefined && legendFontSize === undefined) {
     seriesNameFontSize = Math.min(optimalValueFontSize * 0.7, seriesNameFontSize);
   }
 

--- a/statchart/src/StatChartOptionsEditorSettings.tsx
+++ b/statchart/src/StatChartOptionsEditorSettings.tsx
@@ -115,6 +115,14 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
     );
   };
 
+  const handleLegendFontSizeChange: FontSizeSelectorProps['onChange'] = (fontSize: FontSizeOption) => {
+    onChange(
+      produce(value, (draft: StatChartOptions) => {
+        draft.legendFontSize = fontSize;
+      }),
+    );
+  };
+
   const handleColorModeChange = useCallback(
     (_: unknown, newColorMode: ColorModeLabelItem): void => {
       onChange(
@@ -167,7 +175,10 @@ export function StatChartOptionsEditorSettings(props: StatChartOptionsEditorProp
   return (
     <OptionsEditorGrid>
       <OptionsEditorColumn>
-        <OptionsEditorGroup title="Legend">{selectShowLegend}</OptionsEditorGroup>
+        <OptionsEditorGroup title="Legend">
+          {selectShowLegend}
+          <FontSizeSelector value={value.legendFontSize} onChange={handleLegendFontSizeChange} />
+        </OptionsEditorGroup>
         <OptionsEditorGroup title="Misc">
           <OptionsEditorControl
             label="Sparkline"

--- a/statchart/src/StatChartPanel.tsx
+++ b/statchart/src/StatChartPanel.tsx
@@ -38,7 +38,7 @@ export type StatChartPanelProps = PanelProps<StatChartOptions, TimeSeriesData>;
 export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
   const { spec, contentDimensions, queryResults } = props;
 
-  const { format, sparkline, valueFontSize, colorMode } = spec;
+  const { format, sparkline, valueFontSize, legendFontSize, colorMode } = spec;
   const chartsTheme = useChartsTheme();
   const statChartData = useStatChartData(queryResults, spec, chartsTheme);
 
@@ -95,7 +95,7 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
   let chartWidth = (contentDimensions.width - spacing) / statChartData.length;
   if (isMultiSeries) {
     const fontFamily = chartsTheme.echartsTheme.textStyle?.fontFamily ?? 'Lato';
-    const seriesNameFontSize = Math.max(14, Math.min((contentDimensions.height * 0.15) / 1.2, 30));
+    const seriesNameFontSize = legendFontSize ?? Math.max(14, Math.min((contentDimensions.height * 0.15) / 1.2, 30));
     const padding = chartsTheme.container.padding.default;
     let maxTextWidth = MIN_WIDTH;
     for (const series of statChartData) {
@@ -159,6 +159,7 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
               showSeriesName={shouldShowLegend}
               valueFontSize={valueFontSize}
               colorMode={colorMode}
+              legendFontSize={legendFontSize}
               alignmentText={alignmentText}
               alignmentSeriesName={alignmentSeriesName}
             />

--- a/statchart/src/StatChartPanel.tsx
+++ b/statchart/src/StatChartPanel.tsx
@@ -48,7 +48,7 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
   const alignmentText = useMemo(() => {
     if (!isMultiSeries) return undefined;
     const fontFamily = chartsTheme.echartsTheme.textStyle?.fontFamily ?? 'Lato';
-    const fontSize = Number(chartsTheme.echartsTheme.textStyle?.fontSize) ?? 12;
+    const fontSize = Number(chartsTheme.echartsTheme.textStyle?.fontSize) || 12;
     let widest = '';
     let maxWidth = 0;
     for (const series of statChartData) {
@@ -66,7 +66,7 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
   const alignmentSeriesName = useMemo(() => {
     if (!isMultiSeries) return undefined;
     const fontFamily = chartsTheme.echartsTheme.textStyle?.fontFamily ?? 'Lato';
-    const fontSize = Number(chartsTheme.echartsTheme.textStyle?.fontSize) ?? 12;
+    const fontSize = Number(chartsTheme.echartsTheme.textStyle?.fontSize) || 12;
     let widest = '';
     let maxWidth = 0;
     for (const series of statChartData) {
@@ -104,7 +104,7 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
         formatStatChartValue(series.calculatedValue, format),
         700,
         seriesNameFontSize * 1.5,
-        fontFamily
+        fontFamily,
       );
       const needed = Math.max(nameWidth, valWidth) + padding * 2;
       if (needed > maxTextWidth) maxTextWidth = needed;

--- a/statchart/src/StatChartPanel.tsx
+++ b/statchart/src/StatChartPanel.tsx
@@ -24,8 +24,10 @@ import { useMemo } from 'react';
 import type { StatChartOptions } from './stat-chart-model';
 import type { StatChartData } from './StatChartBase';
 import { StatChartBase } from './StatChartBase';
+import { measureTextWidth } from './utils/calculate-font-size';
 import { calculateValue } from './utils/calculate-value';
 import { convertSparkline } from './utils/data-transform';
+import { formatStatChartValue } from './utils/format-stat-chart-value';
 import { getStatChartColor } from './utils/get-color';
 
 const MIN_WIDTH = 100;
@@ -42,6 +44,42 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
 
   const isMultiSeries = statChartData.length > 1;
 
+  // Find the widest value text (by pixel width) to use as alignment reference
+  const alignmentText = useMemo(() => {
+    if (!isMultiSeries) return undefined;
+    const fontFamily = chartsTheme.echartsTheme.textStyle?.fontFamily ?? 'Lato';
+    const fontSize = Number(chartsTheme.echartsTheme.textStyle?.fontSize) ?? 12;
+    let widest = '';
+    let maxWidth = 0;
+    for (const series of statChartData) {
+      const formatted = formatStatChartValue(series.calculatedValue, format);
+      const width = measureTextWidth(formatted, 700, fontSize, fontFamily);
+      if (width > maxWidth) {
+        maxWidth = width;
+        widest = formatted;
+      }
+    }
+    return widest;
+  }, [statChartData, format, isMultiSeries, chartsTheme.echartsTheme.textStyle]);
+
+  // Find the longest series name (by pixel width) to unify legend sizing
+  const alignmentSeriesName = useMemo(() => {
+    if (!isMultiSeries) return undefined;
+    const fontFamily = chartsTheme.echartsTheme.textStyle?.fontFamily ?? 'Lato';
+    const fontSize = Number(chartsTheme.echartsTheme.textStyle?.fontSize) ?? 12;
+    let widest = '';
+    let maxWidth = 0;
+    for (const series of statChartData) {
+      const name = series.seriesData?.name ?? '';
+      const width = measureTextWidth(name, 400, fontSize, fontFamily);
+      if (width > maxWidth) {
+        maxWidth = width;
+        widest = name;
+      }
+    }
+    return widest;
+  }, [statChartData, isMultiSeries, chartsTheme.echartsTheme.textStyle]);
+
   // Handle three-state showLegend: 'on' | 'off' | 'auto' (or undefined for backward compatibility)
   let shouldShowLegend = isMultiSeries;
   if (spec.legendMode === 'on') {
@@ -52,11 +90,26 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
 
   if (!contentDimensions) return null;
 
-  // Calculates chart width
+  // Calculates chart width — ensure cells are wide enough to show full series names
   const spacing = SPACING * (statChartData.length - 1);
   let chartWidth = (contentDimensions.width - spacing) / statChartData.length;
-  if (isMultiSeries && chartWidth < MIN_WIDTH) {
-    chartWidth = MIN_WIDTH;
+  if (isMultiSeries) {
+    const fontFamily = chartsTheme.echartsTheme.textStyle?.fontFamily ?? 'Lato';
+    const seriesNameFontSize = Math.max(14, Math.min((contentDimensions.height * 0.15) / 1.2, 30));
+    const padding = chartsTheme.container.padding.default;
+    let maxTextWidth = MIN_WIDTH;
+    for (const series of statChartData) {
+      const nameWidth = measureTextWidth(series.seriesData?.name ?? '', 400, seriesNameFontSize, fontFamily);
+      const valWidth = measureTextWidth(
+        formatStatChartValue(series.calculatedValue, format),
+        700,
+        seriesNameFontSize * 1.5,
+        fontFamily
+      );
+      const needed = Math.max(nameWidth, valWidth) + padding * 2;
+      if (needed > maxTextWidth) maxTextWidth = needed;
+    }
+    chartWidth = Math.max(chartWidth, maxTextWidth);
   }
 
   const noDataTextStyle = (chartsTheme.noDataOption.title as TitleComponentOption).textStyle;
@@ -70,7 +123,25 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
       justifyContent={isMultiSeries ? 'left' : 'center'}
       alignItems="center"
       sx={{
-        overflowX: isMultiSeries ? 'scroll' : 'auto',
+        overflowX: isMultiSeries ? 'auto' : 'hidden',
+        '&::-webkit-scrollbar': {
+          height: '4px',
+        },
+        '&::-webkit-scrollbar-track': {
+          background: 'transparent',
+        },
+        '&::-webkit-scrollbar-thumb': {
+          background: 'transparent',
+          borderRadius: '2px',
+        },
+        '&:hover::-webkit-scrollbar-thumb': {
+          background: 'rgba(128, 128, 128, 0.4)',
+        },
+        scrollbarWidth: 'thin',
+        scrollbarColor: 'transparent transparent',
+        '&:hover': {
+          scrollbarColor: 'rgba(128, 128, 128, 0.4) transparent',
+        },
       }}
     >
       {statChartData.length ? (
@@ -88,6 +159,8 @@ export const StatChartPanel: FC<StatChartPanelProps> = (props) => {
               showSeriesName={shouldShowLegend}
               valueFontSize={valueFontSize}
               colorMode={colorMode}
+              alignmentText={alignmentText}
+              alignmentSeriesName={alignmentSeriesName}
             />
           );
         })

--- a/statchart/src/stat-chart-model.ts
+++ b/statchart/src/stat-chart-model.ts
@@ -56,6 +56,7 @@ export interface StatChartOptions {
   thresholds?: ThresholdOptions;
   sparkline?: StatChartSparklineOptions;
   valueFontSize?: FontSizeOption;
+  legendFontSize?: FontSizeOption;
   mappings?: ValueMapping[];
   colorMode?: ColorMode;
   legendMode?: legendMode;

--- a/statchart/src/utils/calculate-font-size.ts
+++ b/statchart/src/utils/calculate-font-size.ts
@@ -37,6 +37,15 @@ function getGlobalCanvasContext(): CanvasRenderingContext2D {
 }
 
 /**
+ * Measure the pixel width of text at a given font weight and size.
+ */
+export function measureTextWidth(text: string, fontWeight: number, fontSize: number, fontFamily: string): number {
+  const ctx = getGlobalCanvasContext();
+  ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+  return ctx.measureText(text).width;
+}
+
+/**
  * Find the optimal font size given available space
  */
 export function useOptimalFontSize({


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Fixes perses/perses#3519

In multi-series stat panels, values rendered with different font sizes and legends appeared at inconsistent heights.

This PR picks the widest value (measured via Canvas) as the sizing reference for all cells  same approach Grafana uses. Also unifies legend font sizing across cells and enforces a 12px minimum so labels stay readable

Allows default size or selecting custom px.

Single-series panels are unaffected.


# Screenshots

<img width="1708" height="651" alt="image" src="https://github.com/user-attachments/assets/41df5227-0c17-4ed9-99ac-1e6018f8fb4b" />

<img width="1056" height="538" alt="image" src="https://github.com/user-attachments/assets/871e13be-2e40-43b5-b2b7-917c51dc292b" />

<img width="1715" height="617" alt="image" src="https://github.com/user-attachments/assets/99a40ad9-2598-4637-a286-e24cd3288094" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
