### PR TITLE
[IGNORE] Fix workflows permissions for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
     needs: 'build'
     runs-on: ubuntu-latest
     permissions:
+      id-token: write # Required for OIDC trusted publishing
       contents: write
     if: ${{ github.event.release.tag_name }}
     env:


### PR DESCRIPTION
This will fix the permission required to publish a package with OIDC trusted publishing