### PR TITLE
feat(statchart): use an instant query when the value allows it

### DIFF
--- a/statchart/src/StatChart.ts
+++ b/statchart/src/StatChart.ts
@@ -13,7 +13,7 @@
 
 import { PanelPlugin } from '@perses-dev/plugin-system';
 
-import { createInitialStatChartOptions, StatChartOptions } from './stat-chart-model';
+import { createInitialStatChartOptions, getStatChartQueryOptions, StatChartOptions } from './stat-chart-model';
 import { StatChartOptionsEditorSettings } from './StatChartOptionsEditorSettings';
 import { StatChartPanel, StatChartPanelProps } from './StatChartPanel';
 import { StatChartValueMappingEditor } from './StatChartValueMappingEditor';
@@ -24,6 +24,7 @@ import { StatChartValueMappingEditor } from './StatChartValueMappingEditor';
 export const StatChart: PanelPlugin<StatChartOptions, StatChartPanelProps> = {
   PanelComponent: StatChartPanel,
   supportedQueryTypes: ['TimeSeriesQuery'],
+  queryOptions: getStatChartQueryOptions,
   panelOptionsEditorComponents: [
     {
       label: 'Settings',

--- a/statchart/src/stat-chart-model.test.ts
+++ b/statchart/src/stat-chart-model.test.ts
@@ -1,0 +1,55 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { CalculationType } from '@perses-dev/plugin-system';
+import { createInitialStatChartOptions, getStatChartQueryMode, StatChartOptions } from './stat-chart-model';
+
+function options(overrides: Partial<StatChartOptions> = {}): StatChartOptions {
+  return {
+    calculation: 'last',
+    format: { unit: 'decimal' },
+    ...overrides,
+  };
+}
+
+describe('getStatChartQueryMode', () => {
+  it('uses instant for `last`, the one calculation an instant query reproduces exactly', () => {
+    expect(getStatChartQueryMode(options({ calculation: 'last' }))).toBe('instant');
+  });
+
+  // `last-number` is the last *non-null* value, so with trailing nulls it must look
+  // back past the latest point — which an instant query cannot do. It needs range.
+  it('uses range for `last-number`', () => {
+    expect(getStatChartQueryMode(options({ calculation: 'last-number' }))).toBe('range');
+  });
+
+  // Regression: requesting instant unconditionally broke the sparkline, which draws
+  // the series itself. See perses/plugins#738, which was reverted for this reason.
+  it('uses range whenever a sparkline is configured', () => {
+    expect(getStatChartQueryMode(options({ sparkline: {} }))).toBe('range');
+    expect(getStatChartQueryMode(options({ sparkline: { color: '#fff', width: 2 } }))).toBe('range');
+    // even for a calculation that would otherwise be instant
+    expect(getStatChartQueryMode(options({ calculation: 'last', sparkline: {} }))).toBe('range');
+  });
+
+  it.each<CalculationType>(['mean', 'sum', 'min', 'max', 'first', 'first-number'])(
+    'uses range for %s, which aggregates over the whole series',
+    (calculation) => {
+      expect(getStatChartQueryMode(options({ calculation }))).toBe('range');
+    }
+  );
+
+  it('uses range for the default options, which enable the sparkline', () => {
+    expect(getStatChartQueryMode(createInitialStatChartOptions())).toBe('range');
+  });
+});

--- a/statchart/src/stat-chart-model.ts
+++ b/statchart/src/stat-chart-model.ts
@@ -78,3 +78,37 @@ export function createInitialStatChartOptions(): StatChartOptions {
     legendMode: 'auto',
   };
 }
+
+/**
+ * Only `last` reproduces exactly from a single instant point: it is the most
+ * recent value of the series, which is precisely what an instant query returns.
+ *
+ * Everything else needs the full series and must stay a range query:
+ *  - `mean`, `sum`, `min`, `max` aggregate over every point;
+ *  - `first` / `first-number` need the start of the window, not the latest point;
+ *  - `last-number` is the last *non-null* value, so with a trailing null it has to
+ *    look back past the latest point, which an instant query cannot see.
+ */
+const INSTANT_SAFE_CALCULATIONS: ReadonlySet<CalculationType> = new Set<CalculationType>(['last']);
+
+/**
+ * A stat panel usually shows a single aggregate value, for which an instant query
+ * is enough and much cheaper than a range query — especially against backends that
+ * split range queries into many sub-queries.
+ *
+ * It cannot always be instant though:
+ *  - the sparkline draws the series itself, so it needs the range data;
+ *  - calculations other than `last` aggregate over the series and would silently
+ *    collapse to a single point.
+ *
+ * Requesting instant unconditionally breaks both (see perses/plugins#738, which was
+ * reverted for the sparkline case), so the mode is derived from the spec.
+ */
+export function getStatChartQueryMode(spec: StatChartOptions): 'instant' | 'range' {
+  if (spec.sparkline !== undefined) return 'range';
+  return INSTANT_SAFE_CALCULATIONS.has(spec.calculation) ? 'instant' : 'range';
+}
+
+export function getStatChartQueryOptions(spec: StatChartOptions): { mode: 'instant' | 'range' } {
+  return { mode: getStatChartQueryMode(spec) };
+}


### PR DESCRIPTION
## What

StatChart always issued a range query, even when it only needed the latest point. Now that #752 added a per-query instant mode, this derives the panel query mode from the spec — the same thing `TablePanel` already does via `getTablePanelQueryMode`.

`getStatChartQueryMode` returns `instant` only when it's safe:
- **`last`** → instant (it's exactly what an instant query returns)
- **`last-number`, `mean`/`sum`/`min`/`max`, `first`/`first-number`** → range (they need the full series)
- **any spec with a sparkline** → range (it draws the series)

So the default (sparkline on) stays range, and nothing that renders the series changes — the #738 sparkline regression is kept covered by tests.

Follow-up to #746, which was closed in favour of #752's per-query flag.

## Test

`stat-chart-model.test.ts` covers each calculation + the sparkline cases. `npm run test`, `tsc`, and `oxlint` are clean.
