### PR TITLE
[IGNORE] Bump all plugins as beta, updating script

### DIFF
--- a/alertmanager/package.json
+++ b/alertmanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/alert-manager-plugin",
-  "version": "0.1.1",
+  "version": "0.2.0-beta.0",
   "description": "Alert Manager plugin for Perses",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",

--- a/barchart/package.json
+++ b/barchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/bar-chart-plugin",
-  "version": "0.13.0",
+  "version": "0.14.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/clickhouse/package.json
+++ b/clickhouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/clickhouse-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "rsbuild dev",

--- a/datasourcevariable/package.json
+++ b/datasourcevariable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/datasource-variable-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/plugins-e2e",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "description": "e2e tests for plugins",
   "private": true,
   "scripts": {

--- a/flamechart/package.json
+++ b/flamechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/flame-chart-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/gaugechart/package.json
+++ b/gaugechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/gauge-chart-plugin",
-  "version": "0.13.0",
+  "version": "0.14.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/greptimedb/package.json
+++ b/greptimedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/greptimedb-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "rsbuild dev",

--- a/heatmapchart/package.json
+++ b/heatmapchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/heatmap-chart-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/histogramchart/package.json
+++ b/histogramchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/histogram-chart-plugin",
-  "version": "0.12.0",
+  "version": "0.13.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/jaeger/package.json
+++ b/jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/jaeger-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/logexplorer/package.json
+++ b/logexplorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/log-explorer-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
     "type": "git",

--- a/logstable/package.json
+++ b/logstable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/logs-table-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/loki/package.json
+++ b/loki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/loki-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "rsbuild dev",

--- a/markdown/package.json
+++ b/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/markdown-plugin",
-  "version": "0.12.0",
+  "version": "0.13.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/opensearch/package.json
+++ b/opensearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/opensearch-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "description": "OpenSearch plugin for Perses",
   "license": "Apache-2.0",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
     },
     "alertmanager": {
       "name": "@perses-dev/alert-manager-plugin",
-      "version": "0.1.1",
+      "version": "0.2.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -104,7 +104,7 @@
     },
     "barchart": {
       "name": "@perses-dev/bar-chart-plugin",
-      "version": "0.13.0",
+      "version": "0.14.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -125,7 +125,7 @@
     },
     "clickhouse": {
       "name": "@perses-dev/clickhouse-plugin",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -151,7 +151,7 @@
     },
     "datasourcevariable": {
       "name": "@perses-dev/datasource-variable-plugin",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -170,7 +170,7 @@
     },
     "e2e": {
       "name": "@perses-dev/plugins-e2e",
-      "version": "0.1.0",
+      "version": "0.2.0-beta.0",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@types/node": "^25.2.3"
@@ -191,7 +191,7 @@
     },
     "flamechart": {
       "name": "@perses-dev/flame-chart-plugin",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/color-hash": "^2.0.0"
@@ -216,7 +216,7 @@
     },
     "gaugechart": {
       "name": "@perses-dev/gauge-chart-plugin",
-      "version": "0.13.0",
+      "version": "0.14.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -237,7 +237,7 @@
     },
     "greptimedb": {
       "name": "@perses-dev/greptimedb-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -262,7 +262,7 @@
     },
     "heatmapchart": {
       "name": "@perses-dev/heatmap-chart-plugin",
-      "version": "0.5.0",
+      "version": "0.6.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@perses-dev/components": "^0.55.0-beta.3",
@@ -277,7 +277,7 @@
     },
     "histogramchart": {
       "name": "@perses-dev/histogram-chart-plugin",
-      "version": "0.12.0",
+      "version": "0.13.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@perses-dev/components": "^0.55.0-beta.3",
@@ -292,7 +292,7 @@
     },
     "jaeger": {
       "name": "@perses-dev/jaeger-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -318,7 +318,7 @@
     },
     "logexplorer": {
       "name": "@perses-dev/log-explorer-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0-beta.0",
       "devDependencies": {
         "@types/qs": "^6.9.18"
       },
@@ -345,7 +345,7 @@
     },
     "logstable": {
       "name": "@perses-dev/logs-table-plugin",
-      "version": "0.3.0",
+      "version": "0.4.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ansi_up": "^6.0.0",
@@ -370,7 +370,7 @@
     },
     "loki": {
       "name": "@perses-dev/loki-plugin",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grafana/lezer-logql": "^0.2.8"
@@ -398,7 +398,7 @@
     },
     "markdown": {
       "name": "@perses-dev/markdown-plugin",
-      "version": "0.12.0",
+      "version": "0.13.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.4.11",
@@ -11048,7 +11048,7 @@
     },
     "opensearch": {
       "name": "@perses-dev/opensearch-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -11073,7 +11073,7 @@
     },
     "piechart": {
       "name": "@perses-dev/pie-chart-plugin",
-      "version": "0.14.0",
+      "version": "0.15.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -11094,7 +11094,7 @@
     },
     "prometheus": {
       "name": "@perses-dev/prometheus-plugin",
-      "version": "0.58.0",
+      "version": "0.59.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
@@ -11131,7 +11131,7 @@
     },
     "pyroscope": {
       "name": "@perses-dev/pyroscope-plugin",
-      "version": "0.6.0",
+      "version": "0.7.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
@@ -11162,7 +11162,7 @@
     },
     "scatterchart": {
       "name": "@perses-dev/scatter-chart-plugin",
-      "version": "0.11.0",
+      "version": "0.12.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react-virtuoso": "^4.12.2"
@@ -11188,7 +11188,7 @@
     },
     "splunk": {
       "name": "@perses-dev/splunk-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {},
       "peerDependencies": {
@@ -11201,7 +11201,7 @@
     },
     "statchart": {
       "name": "@perses-dev/stat-chart-plugin",
-      "version": "0.14.0",
+      "version": "0.15.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chroma-js": "^3.1.2"
@@ -11228,7 +11228,7 @@
     },
     "staticlistvariable": {
       "name": "@perses-dev/static-list-variable-plugin",
-      "version": "0.9.0",
+      "version": "0.10.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "color-hash": "^2.0.2"
@@ -11250,7 +11250,7 @@
     },
     "statushistorychart": {
       "name": "@perses-dev/status-history-chart-plugin",
-      "version": "0.13.0",
+      "version": "0.14.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -11271,7 +11271,7 @@
     },
     "table": {
       "name": "@perses-dev/table-plugin",
-      "version": "0.13.0",
+      "version": "0.14.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -11293,7 +11293,7 @@
     },
     "tempo": {
       "name": "@perses-dev/tempo-plugin",
-      "version": "0.59.0",
+      "version": "0.60.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.0",
@@ -11325,7 +11325,7 @@
     },
     "timeserieschart": {
       "name": "@perses-dev/timeseries-chart-plugin",
-      "version": "0.14.0-beta.0",
+      "version": "0.15.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "color-hash": "^2.0.2"
@@ -11350,7 +11350,7 @@
     },
     "timeseriestable": {
       "name": "@perses-dev/timeseries-table-plugin",
-      "version": "0.12.0",
+      "version": "0.13.0-beta.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
@@ -11371,7 +11371,7 @@
     },
     "tracetable": {
       "name": "@perses-dev/trace-table-plugin",
-      "version": "0.11.0",
+      "version": "0.12.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mui/x-data-grid": "^7.20.0"
@@ -11397,7 +11397,7 @@
     },
     "tracingganttchart": {
       "name": "@perses-dev/tracing-gantt-chart-plugin",
-      "version": "0.13.0",
+      "version": "0.14.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "color-hash": "^2.0.2",
@@ -11424,7 +11424,7 @@
     },
     "victorialogs": {
       "name": "@perses-dev/victorialogs-plugin",
-      "version": "0.4.0",
+      "version": "0.5.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grafana/lezer-logql": "^0.2.8"

--- a/piechart/package.json
+++ b/piechart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/pie-chart-plugin",
-  "version": "0.14.0",
+  "version": "0.15.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/prometheus/package.json
+++ b/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/prometheus-plugin",
-  "version": "0.58.0",
+  "version": "0.59.0-beta.0",
   "description": "Prometheus plugin for Perses",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",

--- a/pyroscope/package.json
+++ b/pyroscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/pyroscope-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/scatterchart/package.json
+++ b/scatterchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/scatter-chart-plugin",
-  "version": "0.11.0",
+  "version": "0.12.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/scripts/bump-plugin/bump-plugin.go
+++ b/scripts/bump-plugin/bump-plugin.go
@@ -20,30 +20,43 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func bump(pluginName string, bumpType string) error {
+func bump(pluginName, bumpType, preID string) error {
 	if pluginName == "" {
-		return command.Run("npm", "version", bumpType, "--workspaces", "--no-git-tag-version")
+		if preID == "" {
+			return command.Run("npm", "version", bumpType, "--workspaces", "--no-git-tag-version")
+		}
+		return command.Run("npm", "version", bumpType, "--workspaces", "--preid", preID, "--no-git-tag-version")
 	}
-	return command.Run("npm", "version", bumpType, "--workspace", pluginName, "--no-git-tag-version")
+	if preID == "" {
+		return command.Run("npm", "version", bumpType, "--workspace", pluginName, "--no-git-tag-version")
+	}
+	return command.Run("npm", "version", bumpType, "--workspace", pluginName, "--preid", preID, "--no-git-tag-version")
 }
 
 func main() {
-	bumpAll := flag.Bool("all", false, "bump all the plugins versions to the next minor version")
+	bumpAll := flag.Bool("all", false, `bump all the plugins versions to the next minor version.
+You can also reuse it to create and update beta, rc, ...
+# Creation of the first beta
+go run ./scripts/bump-plugin --all --type preminor --preid beta
+
+# Following betas
+go run ./scripts/bump-plugin --all --type prerelease --preid beta`)
 	bumpSinglePlugin := flag.String("name", "", "bump a single plugin to the next minor version")
 	bumpType := flag.String("type", "minor", "the type of version bump (major, minor, patch)")
+	bumpPreID := flag.String("preid", "", "the preid for the version bump (alpha, beta, rc)")
 	flag.Parse()
 	if !*bumpAll {
 		if len(*bumpSinglePlugin) == 0 {
 			logrus.Fatal("you must provide a plugin name if the --all flag is not set")
 		}
 		logrus.Infof("bumping %s", *bumpSinglePlugin)
-		if err := bump(*bumpSinglePlugin, *bumpType); err != nil {
+		if err := bump(*bumpSinglePlugin, *bumpType, *bumpPreID); err != nil {
 			logrus.WithError(err).Fatalf("unable to bump the version of the plugin %s", *bumpSinglePlugin)
 		}
 		return
 	}
 	logrus.Info("bumping all the plugins")
-	if err := bump("", *bumpType); err != nil {
+	if err := bump("", *bumpType, *bumpPreID); err != nil {
 		logrus.WithError(err).Fatal("unable to bump the versions of the plugins")
 	}
 }

--- a/splunk/package.json
+++ b/splunk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/splunk-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/statchart/package.json
+++ b/statchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/stat-chart-plugin",
-  "version": "0.14.0",
+  "version": "0.15.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/staticlistvariable/package.json
+++ b/staticlistvariable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/static-list-variable-plugin",
-  "version": "0.9.0",
+  "version": "0.10.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/statushistorychart/package.json
+++ b/statushistorychart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/status-history-chart-plugin",
-  "version": "0.13.0",
+  "version": "0.14.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/table/package.json
+++ b/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/table-plugin",
-  "version": "0.13.0",
+  "version": "0.14.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/tempo/package.json
+++ b/tempo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tempo-plugin",
-  "version": "0.59.0",
+  "version": "0.60.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/timeserieschart/package.json
+++ b/timeserieschart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/timeseries-chart-plugin",
-  "version": "0.14.0-beta.0",
+  "version": "0.15.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/timeseriestable/package.json
+++ b/timeseriestable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/timeseries-table-plugin",
-  "version": "0.12.0",
+  "version": "0.13.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/tracetable/package.json
+++ b/tracetable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/trace-table-plugin",
-  "version": "0.11.0",
+  "version": "0.12.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/tracingganttchart/package.json
+++ b/tracingganttchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/tracing-gantt-chart-plugin",
-  "version": "0.13.0",
+  "version": "0.14.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {

--- a/victorialogs/package.json
+++ b/victorialogs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/victorialogs-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "rsbuild dev",


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Let's create all beta versions using the script to bump automatically.

It required again some little changes on the script, **Don't miss them** https://github.com/perses/plugins/pull/783/changes#diff-27cd5d8a25d7f82aee17042ef1930a864520ee54fae92fd735feea5bdb713f31

```bash 
plugins % go run ./scripts/bump-plugin --all --type preminor --preid beta
INFO[0000] bumping all the plugins                      
@perses-dev/alert-manager-plugin
v0.2.0-beta.0
@perses-dev/bar-chart-plugin
v0.14.0-beta.0
@perses-dev/clickhouse-plugin
v0.7.0-beta.0
@perses-dev/datasource-variable-plugin
v0.7.0-beta.0
@perses-dev/flame-chart-plugin
v0.7.0-beta.0
@perses-dev/gauge-chart-plugin
v0.14.0-beta.0
@perses-dev/greptimedb-plugin
v0.2.0-beta.0
@perses-dev/heatmap-chart-plugin
v0.6.0-beta.0
@perses-dev/histogram-chart-plugin
v0.13.0-beta.0
@perses-dev/jaeger-plugin
v0.2.0-beta.0
@perses-dev/log-explorer-plugin
v0.2.0-beta.0
@perses-dev/logs-table-plugin
v0.4.0-beta.0
@perses-dev/loki-plugin
v0.7.0-beta.0
@perses-dev/markdown-plugin
v0.13.0-beta.0
@perses-dev/opensearch-plugin
v0.2.0-beta.0
@perses-dev/pie-chart-plugin
v0.15.0-beta.0
@perses-dev/prometheus-plugin
v0.59.0-beta.0
@perses-dev/pyroscope-plugin
v0.7.0-beta.0
@perses-dev/scatter-chart-plugin
v0.12.0-beta.0
@perses-dev/stat-chart-plugin
v0.15.0-beta.0
@perses-dev/static-list-variable-plugin
v0.10.0-beta.0
@perses-dev/status-history-chart-plugin
v0.14.0-beta.0
@perses-dev/splunk-plugin
v0.2.0-beta.0
@perses-dev/table-plugin
v0.14.0-beta.0
@perses-dev/tempo-plugin
v0.60.0-beta.0
@perses-dev/timeseries-chart-plugin
v0.15.0-beta.0
@perses-dev/timeseries-table-plugin
v0.13.0-beta.0
@perses-dev/trace-table-plugin
v0.12.0-beta.0
@perses-dev/tracing-gantt-chart-plugin
v0.14.0-beta.0
@perses-dev/victorialogs-plugin
v0.5.0-beta.0
@perses-dev/plugins-e2e
v0.2.0-beta.0
```
<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
