### PR TITLE
[IGNORE] fix timeseries chart version to 0.14.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11325,7 +11325,7 @@
     },
     "timeserieschart": {
       "name": "@perses-dev/timeseries-chart-plugin",
-      "version": "0.15.0-beta.0",
+      "version": "0.14.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "color-hash": "^2.0.2"

--- a/timeserieschart/package.json
+++ b/timeserieschart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/timeseries-chart-plugin",
-  "version": "0.15.0-beta.0",
+  "version": "0.14.0-beta.1",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Last PR https://github.com/perses/plugins/pull/783 was increasing minor where it has already been bumped before
<img width="1286" height="230" alt="image" src="https://github.com/user-attachments/assets/8457b0d2-40e5-420f-ad98-be6e5b1278e4" />

As long as I didn't run the release yet, I can still fix it.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

