### PR TITLE
[BUGFIX] prometheus: evaluate instant queries at the exact end of the time range

### DIFF
--- a/prometheus/src/plugins/prometheus-time-series-query/get-time-series-data.ts
+++ b/prometheus/src/plugins/prometheus-time-series-query/get-time-series-data.ts
@@ -73,24 +73,33 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   const timeRange = getPrometheusTimeRange(context.timeRange);
   const step = getRangeStep(timeRange, minStep, undefined, context.suggestedStepMs); // TODO: resolution
 
-  // Align the time range so that it's a multiple of the step
+  // `spec.instant` is a per-query override: `true` forces instant, `false` forces range.
+  // When left unset (Auto), defer to the panel-provided `context.mode`.
+  const isInstant = spec.instant ?? context.mode === 'instant';
+
   let { start, end } = timeRange;
 
-  const utcOffsetSec = new Date().getTimezoneOffset() * 60;
+  // Range queries are aligned so that start and end are multiples of the step.
+  // Instant queries have no step: they are evaluated at the exact end of the time range.
+  // Aligning them too would move the evaluation time back by up to one step, i.e. by
+  // several minutes on long time ranges and by a different amount for each panel width.
+  if (!isInstant) {
+    const utcOffsetSec = new Date().getTimezoneOffset() * 60;
 
-  const alignedEnd = Math.floor((end + utcOffsetSec) / step) * step - utcOffsetSec;
-  const alignedStart = Math.floor((start + utcOffsetSec) / step) * step - utcOffsetSec;
-  start = alignedStart;
-  end = alignedEnd;
+    const alignedEnd = Math.floor((end + utcOffsetSec) / step) * step - utcOffsetSec;
+    const alignedStart = Math.floor((start + utcOffsetSec) / step) * step - utcOffsetSec;
+    start = alignedStart;
+    end = alignedEnd;
 
-  /* Ensure end is always greater than start:
-     If the step is greater than equal to the diff of end and start,
-     both start, and end will eventually be rounded to the same value,
-     Consequently, the time range will be zero, which does not return any valid value
-  */
-  if (end === start) {
-    end = start + step;
-    console.warn(`Step (${step}) was larger than the time range! end of time range was set accordingly.`);
+    /* Ensure end is always greater than start:
+       If the step is greater than equal to the diff of end and start,
+       both start, and end will eventually be rounded to the same value,
+       Consequently, the time range will be zero, which does not return any valid value
+    */
+    if (end === start) {
+      end = start + step;
+      console.warn(`Step (${step}) was larger than the time range! end of time range was set accordingly.`);
+    }
   }
 
   // Replace variable placeholders in PromQL query
@@ -112,9 +121,6 @@ export const getTimeSeriesData: TimeSeriesQueryPlugin<PrometheusTimeSeriesQueryS
   // Make the request to Prom
 
   let response;
-  // `spec.instant` is a per-query override: `true` forces instant, `false` forces range.
-  // When left unset (Auto), defer to the panel-provided `context.mode`.
-  const isInstant = spec.instant ?? context.mode === 'instant';
   if (isInstant) {
     response = await client.instantQuery({ query, time: end }, { ...interpolatedOptions, signal: abortSignal });
   } else {

--- a/prometheus/src/plugins/prometheus-time-series-query/plugin.test.ts
+++ b/prometheus/src/plugins/prometheus-time-series-query/plugin.test.ts
@@ -136,6 +136,24 @@ describe('PrometheusTimeSeriesQuery', () => {
     expect(results.series[0]?.formattedName).toEqual('bar - format');
   });
 
+  it('should evaluate instant queries at the exact end of the time range, not the step-aligned end', async () => {
+    const ctx = createStubContext();
+    ctx.mode = 'instant';
+    // An end that is not a multiple of the step, with a step large enough that
+    // aligning the end to it would move the evaluation time by several minutes.
+    ctx.timeRange = { start: new Date('2023-01-01T00:00:00Z'), end: new Date('2023-01-01T06:07:23Z') };
+    ctx.suggestedStepMs = 30 * 60 * 1000;
+    (promStubClient.instantQuery as Mock).mockClear();
+    (promStubClient.rangeQuery as Mock).mockClear();
+
+    await PrometheusTimeSeriesQuery.getTimeSeriesData({ query: 'up' }, ctx);
+
+    expect(promStubClient.instantQuery).toHaveBeenCalledTimes(1);
+    expect(promStubClient.rangeQuery).not.toHaveBeenCalled();
+    const [params] = (promStubClient.instantQuery as Mock).mock.calls[0] as [{ query: string; time: number }];
+    expect(params.time).toBe(Math.floor(ctx.timeRange.end.getTime() / 1000));
+  });
+
   it('should use instantQuery when spec.instant is true', async () => {
     const ctx = createStubContext();
     (promStubClient.instantQuery as Mock).mockClear();


### PR DESCRIPTION
# Description

`getTimeSeriesData` aligns the start and end of the time range to the step before sending the query. Range queries need that (stable samples, x-axis), but instant queries have no step: aligning their evaluation time moves it back by up to one step. The step depends on the time range *and the panel width*, so on a 1-week range a full-width Table panel evaluates ~5 min behind "now" and a narrower panel with the same query up to 30 min behind, and two panels on the same dashboard can evaluate the same query at different instants.

Observed on an OpenShift console dashboard (Perses Table panels in instant mode): after a VM stopped, its rows stayed in the table for up to one step on a 1-week range, while they disappeared immediately on a 1-hour range.

This change only aligns the time range for range queries. Instant queries (`context.mode === 'instant'` or `spec.instant: true`) now use the exact end of the time range, which is what the Loki plugin already does (`get-loki-time-series-data.ts`). The returned `timeRange` follows the same rule. Range queries are unchanged, including the "step larger than range" guard from #213.

Test added: with a range end of `06:07:23` and a 30-min step, the instant query must be sent with `time = 06:07:23` (before this change it was sent with `06:00:00`).

# Screenshots

No UI change.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes. (N/A)
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md). (N/A)
