### PR TITLE
[DOC] Document the Prometheus annotation plugin

### DIFF
--- a/docs/prometheus/README.md
+++ b/docs/prometheus/README.md
@@ -78,6 +78,15 @@ See also technical docs related to this plugin:
 - [Data model](./model.md#prometheustimeseriesquery)
 - [Dashboard-as-Code Go lib](./go-sdk/query.md)
 
+## Annotation (`PrometheusPromQLAnnotation`)
+
+The annotation plugin overlays contextual events on the panels of a dashboard, like deployments, incidents or maintenance windows. The provided PromQL expression is executed as a range query over the time range of the dashboard, and each series it returns becomes an annotation spanning from the timestamp of its first sample to the timestamp of its last one.
+
+The `title` and `legend` displayed in the annotation tooltip can be built from the labels of the series, using the `{{label_name}}` syntax (e.g `Deployment {{service}}`). The labels shown as tags can be restricted with `tags`, all of them being displayed otherwise.
+
+See also technical docs related to this plugin:
+- [Data model](./model.md#prometheuspromqlannotation)
+
 ## Explore (`PrometheusExplorer`)
 
 The Prometheus package comes also with a built-in metrics explorer that mirror Prometheus's native UI experience.

--- a/docs/prometheus/model.md
+++ b/docs/prometheus/model.md
@@ -248,6 +248,59 @@ spec:
       labelName: "job"
 ```
 
+## PrometheusPromQLAnnotation
+
+```yaml
+kind: "PrometheusPromQLAnnotation"
+spec:
+  # `datasource` is a datasource selector. If not provided, the default PrometheusDatasource is used.
+  # See the documentation about the datasources to understand how it is selected.
+  datasource: <Prometheus Datasource selector> # Optional
+
+  # The promql expression, executed as a range query over the time range of the dashboard.
+  # Each series returned becomes an annotation, spanning from the timestamp of its first sample
+  # to the timestamp of its last one.
+  expr: <string>
+
+  # Title displayed in the annotation tooltip.
+  # Labels of the series can be interpolated with the `{{label_name}}` syntax.
+  title: <string> # Optional
+
+  # Text displayed below the title in the annotation tooltip.
+  # Labels of the series can be interpolated with the `{{label_name}}` syntax.
+  legend: <string> # Optional
+
+  # Label names to display as tags in the annotation tooltip. All the labels are displayed if not provided.
+  tags:
+    - <string> # Optional
+```
+
+- See [Prometheus Datasource selector](#prometheus-datasource-selector)
+
+### Example
+
+A simple Prometheus PromQL annotation defined in a dashboard would look like:
+
+```yaml
+kind: "Dashboard"
+metadata:
+  name: "MyDashboard"
+  project: "perses"
+spec:
+  annotations:
+    - display:
+        name: "Deployments"
+        color: "#EE6C6C"
+      plugin:
+        kind: "PrometheusPromQLAnnotation"
+        spec:
+          expr: "changes(kube_deployment_status_observed_generation{namespace=\"$namespace\"}[5m]) > 0"
+          title: "Deployment of {{deployment}}"
+          tags:
+            - "deployment"
+  # ...
+```
+
 ## Shared definitions
 
 ### Prometheus Datasource selector


### PR DESCRIPTION
# Description

The Prometheus package ships an annotation plugin since #642, but `docs/prometheus` still lists only the datasource, the variables, the time series query and the explorer.

- `docs/prometheus/README.md`: add an `Annotation (PrometheusPromQLAnnotation)` section.
- `docs/prometheus/model.md`: add the corresponding data model entry, so the section can link to it like the others do.

The described behaviour comes from `prometheus/src/annotations/get-annotation-data.ts` (range query over the dashboard time range, one annotation per returned series, spanning first to last sample, `{{label_name}}` interpolation in `title`/`legend` via `formatSeriesName`, `tags` restricting the labels shown) and from `prometheus/schemas/prometheus-promql-annotation`.

Part of perses/perses#4408, whose other half (documenting the plugin kind itself) is perses/perses#4427.

One thing I did not touch, but that looks like a typo: `prometheus-promql-annotation.cue` declares `tags?: [string]`, i.e. a list of exactly one element, while `PrometheusPromQLAnnotationOptions.tags` is a `string[]` and the option editor lets you add several. The generator template uses `[...string]`. The example in the docs uses a single tag so that it validates either way. Let me know if you want the schema fixed here or in a separate PR.

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
