### PR TITLE
[IGNORE] bump canvas perses deps and sort workspace in alphabetic order

### DIFF
--- a/canvas/package.json
+++ b/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perses-dev/canvas-plugin",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/perses/plugins/blob/main/README.md",
   "repository": {
@@ -28,9 +28,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@mui/material": "^5.0.0 || ^6.0.0",
-    "@perses-dev/components": "^0.55.0-beta.6",
-    "@perses-dev/plugin-system": "^0.55.0-beta.6",
-    "@perses-dev/spec": "^0.3.0-beta.5",
+    "@perses-dev/components": "^0.55.0-beta.8",
+    "@perses-dev/plugin-system": "^0.55.0-beta.8",
+    "@perses-dev/spec": "^0.3.0-beta.7",
     "immer": "^10.1.1",
     "mdi-material-ui": "^7.9.2",
     "react": "^18.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "workspaces": [
         "alertmanager",
         "barchart",
+        "canvas",
         "clickhouse",
         "datasourcevariable",
         "flamechart",
@@ -38,7 +39,6 @@
         "tracetable",
         "tracingganttchart",
         "victorialogs",
-        "canvas",
         "e2e"
       ],
       "devDependencies": {
@@ -131,7 +131,7 @@
     },
     "canvas": {
       "name": "@perses-dev/canvas-plugin",
-      "version": "0.1.0",
+      "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-selection": "^3.0.0",
@@ -145,9 +145,9 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@mui/material": "^5.0.0 || ^6.0.0",
-        "@perses-dev/components": "^0.55.0-beta.6",
-        "@perses-dev/plugin-system": "^0.55.0-beta.6",
-        "@perses-dev/spec": "^0.3.0-beta.5",
+        "@perses-dev/components": "^0.55.0-beta.8",
+        "@perses-dev/plugin-system": "^0.55.0-beta.8",
+        "@perses-dev/spec": "^0.3.0-beta.7",
         "immer": "^10.1.1",
         "mdi-material-ui": "^7.9.2",
         "react": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "workspaces": [
     "alertmanager",
     "barchart",
+    "canvas",
     "clickhouse",
     "datasourcevariable",
     "flamechart",
@@ -59,7 +60,6 @@
     "tracetable",
     "tracingganttchart",
     "victorialogs",
-    "canvas",
     "e2e"
   ],
   "peerDependencies": {


### PR DESCRIPTION
I have also change the version of the canvas plugins since it depends on a plugin-system which is in beta