### PR TITLE
[FEATURE] Add horizontal crosshair option to TimeSeriesChart plugin

### DIFF
--- a/docs/timeserieschart/model.md
+++ b/docs/timeserieschart/model.md
@@ -24,6 +24,15 @@ See [common plugin definitions](https://perses.dev/perses/docs/plugins/common/#c
 
 ```yaml
 enablePinning: <boolean | default = false> # Optional
+axisPointer: <AxisPointer specification> # Optional
+```
+
+### AxisPointer specification
+
+```yaml
+# "cross" adds a horizontal line at the cursor's y position while hovering the panel.
+# The horizontal line only shows on the hovered panel.
+type: <enum = "cross"> # Optional
 ```
 
 ## YAxis specification

--- a/timeserieschart/schemas/tests/invalid/time-series-tooltip-axis-pointer-invalid-type.json
+++ b/timeserieschart/schemas/tests/invalid/time-series-tooltip-axis-pointer-invalid-type.json
@@ -1,0 +1,10 @@
+{
+  "kind": "TimeSeriesChart",
+  "spec": {
+    "tooltip": {
+      "axisPointer": {
+        "type": "shadow"
+      }
+    }
+  }
+}

--- a/timeserieschart/schemas/tests/valid/time-series-tooltip-cross.json
+++ b/timeserieschart/schemas/tests/valid/time-series-tooltip-cross.json
@@ -1,0 +1,11 @@
+{
+  "kind": "TimeSeriesChart",
+  "spec": {
+    "tooltip": {
+      "enablePinning": true,
+      "axisPointer": {
+        "type": "cross"
+      }
+    }
+  }
+}

--- a/timeserieschart/schemas/time-series.cue
+++ b/timeserieschart/schemas/time-series.cue
@@ -29,6 +29,9 @@ spec: close({
 
 #tooltip: {
 	enablePinning?: bool
+	axisPointer?: {
+		type?: "cross"
+	}
 }
 
 #palette: {

--- a/timeserieschart/src/TimeSeriesChartBase.tsx
+++ b/timeserieschart/src/TimeSeriesChartBase.tsx
@@ -67,6 +67,7 @@ import type { MouseEvent } from 'react';
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 
 import { AnnotationTooltip, buildAnnotationSeries } from './annotations/AnnotationTooltip';
+import type { TooltipAxisPointerOptions } from './time-series-chart-model';
 import type { TimeSeriesAnnotation } from './utils/annotation';
 import { createTimezoneAwareAxisFormatter } from './utils/timezone-formatter';
 
@@ -99,6 +100,7 @@ export interface TimeChartProps {
   seriesFormatMap?: Map<string, FormatOptions>;
   grid?: GridComponentOption;
   tooltipConfig?: TooltipConfig;
+  axisPointer?: TooltipAxisPointerOptions;
   noDataVariant?: 'chart' | 'message';
   syncGroup?: string;
   isStackedBar?: boolean;
@@ -120,6 +122,7 @@ export const TimeSeriesChartBase = forwardRef<ChartInstance, TimeChartProps>(fun
     grid,
     isStackedBar = false,
     tooltipConfig = DEFAULT_TOOLTIP_CONFIG,
+    axisPointer,
     noDataVariant = 'message',
     syncGroup,
     onDataZoom,
@@ -133,6 +136,7 @@ export const TimeSeriesChartBase = forwardRef<ChartInstance, TimeChartProps>(fun
   const isPinningEnabled = tooltipConfig.enablePinning && enablePinning;
   const chartRef = useRef<EChartsInstance>();
   const [showTooltip, setShowTooltip] = useState<boolean>(true);
+  const [isHovered, setIsHovered] = useState<boolean>(false);
   const [tooltipPinnedCoords, setTooltipPinnedCoords] = useState<CursorCoordinates | null>(null);
   const [pinnedCrosshair, setPinnedCrosshair] = useState<LineSeriesOption | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -252,6 +256,8 @@ export const TimeSeriesChartBase = forwardRef<ChartInstance, TimeChartProps>(fun
 
   const { noDataOption } = chartsTheme;
 
+  const axisPointerType = axisPointer?.type;
+
   const option: EChartsCoreOption = useMemo(() => {
     // The "chart" `noDataVariant` is only used when the `timeSeries` is an
     // empty array because a `null` value will throw an error.
@@ -273,6 +279,16 @@ export const TimeSeriesChartBase = forwardRef<ChartInstance, TimeChartProps>(fun
         ? [...seriesMapping, pinnedCrosshair, ...annotationSeries]
         : [...seriesMapping, ...annotationSeries];
 
+    const tooltip: TooltipComponentOption = {
+      show: true,
+      // ECharts tooltip content hidden by default since we use custom tooltip instead.
+      // Stacked bar uses ECharts tooltip so subgroup data shows correctly.
+      showContent: isStackedBar,
+      trigger: isStackedBar ? 'item' : 'axis',
+      appendToBody: isStackedBar,
+      ...(axisPointerType && isHovered ? { axisPointer: { type: axisPointerType, label: { show: false } } } : {}),
+    };
+
     const option: EChartsCoreOption = {
       dataset: dataset,
       series: updatedSeriesMapping,
@@ -291,14 +307,7 @@ export const TimeSeriesChartBase = forwardRef<ChartInstance, TimeChartProps>(fun
       // If yAxis is already an array (multiple Y axes), use it directly; otherwise use getFormattedAxis
       yAxis: Array.isArray(yAxis) ? yAxis : getFormattedAxis(yAxis, format),
       animation: false,
-      tooltip: {
-        show: true,
-        // ECharts tooltip content hidden by default since we use custom tooltip instead.
-        // Stacked bar uses ECharts tooltip so subgroup data shows correctly.
-        showContent: isStackedBar,
-        trigger: isStackedBar ? 'item' : 'axis',
-        appendToBody: isStackedBar,
-      },
+      tooltip,
       // https://echarts.apache.org/en/option.html#axisPointer
       axisPointer: {
         type: 'line',
@@ -338,6 +347,8 @@ export const TimeSeriesChartBase = forwardRef<ChartInstance, TimeChartProps>(fun
     enablePinning,
     pinnedCrosshair,
     getTimezoneAwareAxisFormatter,
+    axisPointerType,
+    isHovered,
   ]);
 
   // Update adjacent charts so tooltip is unpinned when current chart is clicked.
@@ -481,6 +492,7 @@ export const TimeSeriesChartBase = forwardRef<ChartInstance, TimeChartProps>(fun
         setShowTooltip(true);
       }}
       onMouseLeave={() => {
+        setIsHovered(false);
         if (tooltipPinnedCoords === null) {
           setShowTooltip(false);
         }
@@ -491,6 +503,7 @@ export const TimeSeriesChartBase = forwardRef<ChartInstance, TimeChartProps>(fun
         }
       }}
       onMouseEnter={() => {
+        setIsHovered(true);
         setShowTooltip(true);
         if (chartRef.current !== undefined) {
           enableDataZoom(chartRef.current);

--- a/timeserieschart/src/TimeSeriesChartPanel.tsx
+++ b/timeserieschart/src/TimeSeriesChartPanel.tsx
@@ -478,6 +478,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps): ReactElement 
     ...DEFAULT_TOOLTIP_CONFIG,
     enablePinning,
   };
+  const axisPointer = isStackedBar ? undefined : tooltip?.axisPointer;
 
   return (
     <Box sx={{ padding: `${contentPadding}px` }}>
@@ -525,6 +526,7 @@ export function TimeSeriesChartPanel(props: TimeSeriesChartProps): ReactElement 
                 grid={gridOverrides}
                 isStackedBar={isStackedBar}
                 tooltipConfig={tooltipConfig}
+                axisPointer={axisPointer}
                 syncGroup="default-panel-group" // TODO: make configurable from dashboard settings and per panel-group overrides
                 onDataZoom={handleDataZoom}
                 //  Show an empty chart when there is no data because the user unselected all items in

--- a/timeserieschart/src/time-series-chart-model.ts
+++ b/timeserieschart/src/time-series-chart-model.ts
@@ -66,8 +66,13 @@ export interface TimeSeriesChartYAxisOptions {
   logBase?: LOG_BASE;
 }
 
+export interface TooltipAxisPointerOptions {
+  type?: 'cross';
+}
+
 export interface TooltipSpecOptions {
   enablePinning: boolean;
+  axisPointer?: TooltipAxisPointerOptions;
 }
 
 export interface TimeSeriesChartPaletteOptions {


### PR DESCRIPTION
Closes perses/perses#4434.

Adds an optional `axisPointer` setting to the TimeSeriesChart tooltip spec to control the axis pointer of the ECharts tooltip. Specifically the single option to add a horizontal line.

With `type: "cross"`, hovering a panel now shows a horizontal line at the cursor's y position in addition to the default vertical line. Useful for visually comparing series levels within a panel.

It adds a spec field (no UI editing as of now) mirroring the ECharts naming and nesting.

```yaml
kind: TimeSeriesChart
spec:
  tooltip:
    axisPointer:
      type: "cross"
```

# Choices:
- Single panel only. Currently this setting is enabled per chart and the horizontal line is kept active only on the hovered chart (no syncing across charts). Syncing would be misleading: ECharts `connect` forwards the y pointer by value ([`axisTrigger.ts#L407-L411`](https://github.com/apache/echarts/blob/5.5.0/src/component/axisPointer/axisTrigger.ts#L407-L411)), so other panels would show a line at the same y value mapped into their own scale, which means nothing across different units. This is the most controversial change and I introduced `isHovered` to distinguish a panel being hovered from the tooltip being shown (which can stay pinned). Open to other solutions here.
- `cross` only. While ECharts also allows `line`, `shadow` and `none`, only `cross` is accepted for now. Not sure if there is value in adding the other options, but it leaves room for it.
- No axis value labels. ECharts defaults `label.show` to true for `cross` ([`modelHelper.ts#L266-L269`](https://github.com/apache/echarts/blob/5.5.0/src/component/axisPointer/modelHelper.ts#L266-L269)). I disabled it since the custom tooltip from Perses clashes with that idea.
- Stacked bar excluded. `cross` does not apply there.

# Testing

- Manually tested live against a Perses v0.54.0 server with the plugin dev server, by rebasing the patch onto `timeserieschart/v0.13.0` for host compatibility

# Screenshots

<img width="614" height="486" alt="Screenshot 2026-09-10 at 10 35 09" src="https://github.com/user-attachments/assets/7ea8d63d-776e-4cf9-9213-f3e2eeb63744" />

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention.
- [x] All commits have DCO signoffs.