### PR TITLE
[BUGFIX] Do not query label values before a label name is selected

### DIFF
--- a/pyroscope/src/utils/use-query.ts
+++ b/pyroscope/src/utils/use-query.ts
@@ -55,7 +55,7 @@ export function useLabelValues(
   const { start, end } = getUnixTimeRange(absoluteTimeRange);
 
   return useQuery<SearchLabelValuesResponse, StatusError>({
-    enabled: !!client,
+    enabled: !!client && labelName !== '', // do not trigger query if no labelName is set
     queryKey: ['searchLabelValues', labelName, client],
     queryFn: async () => {
       return await client!.searchLabelValues(


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

A new filter row in the profile query editor starts with no label name, but the value dropdown still asked Pyroscope for the values of an empty label leading to Pyroscope rejecting it:
```
XHRPOST
https://.../proxy/globaldatasources/pyroscope/querier.v1.QuerierService/LabelValues?
[HTTP/2 400  78ms]

	
code	"invalid_argument"
message	"name is required"
```

The request is now skipped until a label name is picked.


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).
