### PR TITLE
[FEATURE] ClickHouse: add trace query plugin

### DIFF
--- a/clickhouse/package.json
+++ b/clickhouse/package.json
@@ -81,6 +81,15 @@
           },
           "name": "ClickHouseLogQuery"
         }
+      },
+      {
+        "kind": "TraceQuery",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Trace Query"
+          },
+          "name": "ClickHouseTraceQuery"
+        }
       }
     ]
   }

--- a/clickhouse/rsbuild.config.ts
+++ b/clickhouse/rsbuild.config.ts
@@ -26,6 +26,7 @@ export default createConfigForPlugin({
       './ClickHouseDatasource': './src/datasources/click-house-datasource',
       './ClickHouseTimeSeriesQuery': './src/queries/click-house-time-series-query',
       './ClickHouseLogQuery': './src/queries/click-house-log-query',
+      './ClickHouseTraceQuery': './src/queries/click-house-trace-query',
     },
     shared: {
       react: { requiredVersion: '18.2.0', singleton: true },

--- a/clickhouse/schemas/queries/click-house-trace-query/query.cue
+++ b/clickhouse/schemas/queries/click-house-trace-query/query.cue
@@ -11,6 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './click-house-time-series-query';
-export * from './click-house-log-query';
-export * from './click-house-trace-query';
+package model
+
+import (
+	"strings"
+	ds "github.com/perses/plugins/clickhouse/schemas/datasources/click-house-datasource:model"
+)
+
+kind: "ClickHouseTraceQuery"
+spec: close({
+	ds.#selector
+	query: strings.MinRunes(1)
+	// table name, optionally prefixed with its database, read when looking up a trace by ID
+	table?: =~"^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)?$"
+	limit?: int & >0
+})

--- a/clickhouse/schemas/queries/click-house-trace-query/tests/invalid/empty-query.json
+++ b/clickhouse/schemas/queries/click-house-trace-query/tests/invalid/empty-query.json
@@ -1,0 +1,6 @@
+{
+  "kind": "ClickHouseTraceQuery",
+  "spec": {
+    "query": ""
+  }
+}

--- a/clickhouse/schemas/queries/click-house-trace-query/tests/invalid/invalid-table.json
+++ b/clickhouse/schemas/queries/click-house-trace-query/tests/invalid/invalid-table.json
@@ -1,0 +1,7 @@
+{
+  "kind": "ClickHouseTraceQuery",
+  "spec": {
+    "query": "5b8efff798038103d269b633813fc60c",
+    "table": "otel_traces WHERE 1=1 --"
+  }
+}

--- a/clickhouse/schemas/queries/click-house-trace-query/tests/invalid/non-positive-limit.json
+++ b/clickhouse/schemas/queries/click-house-trace-query/tests/invalid/non-positive-limit.json
@@ -1,0 +1,7 @@
+{
+  "kind": "ClickHouseTraceQuery",
+  "spec": {
+    "query": "SELECT TraceId, Timestamp FROM otel_traces",
+    "limit": 0
+  }
+}

--- a/clickhouse/schemas/queries/click-house-trace-query/tests/valid/search.json
+++ b/clickhouse/schemas/queries/click-house-trace-query/tests/valid/search.json
@@ -1,0 +1,12 @@
+{
+  "kind": "ClickHouseTraceQuery",
+  "spec": {
+    "datasource": {
+      "kind": "ClickHouseDatasource",
+      "name": "clickhouse"
+    },
+    "query": "SELECT TraceId, ParentSpanId, SpanName, ServiceName, Timestamp, Duration, StatusCode FROM otel.otel_traces WHERE Timestamp BETWEEN '{start}' AND '{end}'",
+    "table": "otel.otel_traces",
+    "limit": 50
+  }
+}

--- a/clickhouse/schemas/queries/click-house-trace-query/tests/valid/trace-id.json
+++ b/clickhouse/schemas/queries/click-house-trace-query/tests/valid/trace-id.json
@@ -1,0 +1,6 @@
+{
+  "kind": "ClickHouseTraceQuery",
+  "spec": {
+    "query": "5b8efff798038103d269b633813fc60c"
+  }
+}

--- a/clickhouse/sdk/go/query/trace/options.go
+++ b/clickhouse/sdk/go/query/trace/options.go
@@ -1,0 +1,46 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	clickhouseDatasource "github.com/perses/plugins/clickhouse/sdk/go/datasource"
+)
+
+func Query(expr string) Option {
+	return func(builder *Builder) error {
+		builder.Query = expr
+		return nil
+	}
+}
+
+func Datasource(datasourceName string) Option {
+	return func(builder *Builder) error {
+		builder.Datasource = clickhouseDatasource.Selector(datasourceName)
+		return nil
+	}
+}
+
+func Table(table string) Option {
+	return func(builder *Builder) error {
+		builder.Table = table
+		return nil
+	}
+}
+
+func Limit(limit int) Option {
+	return func(builder *Builder) error {
+		builder.Limit = &limit
+		return nil
+	}
+}

--- a/clickhouse/sdk/go/query/trace/trace.go
+++ b/clickhouse/sdk/go/query/trace/trace.go
@@ -1,0 +1,65 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"github.com/perses/perses/go-sdk/datasource"
+	"github.com/perses/perses/go-sdk/query"
+	"github.com/perses/spec/go/plugin"
+)
+
+const PluginKind = "ClickHouseTraceQuery"
+
+type PluginSpec struct {
+	Datasource *datasource.Selector `json:"datasource,omitempty" yaml:"datasource,omitempty"`
+	Query      string               `json:"query" yaml:"query"`
+	Table      string               `json:"table,omitempty" yaml:"table,omitempty"`
+	Limit      *int                 `json:"limit,omitempty" yaml:"limit,omitempty"`
+}
+
+type Option func(plugin *Builder) error
+
+func create(query string, options ...Option) (Builder, error) {
+	builder := &Builder{
+		PluginSpec: PluginSpec{},
+	}
+
+	defaults := []Option{
+		Query(query),
+	}
+
+	for _, opt := range append(defaults, options...) {
+		if err := opt(builder); err != nil {
+			return *builder, err
+		}
+	}
+
+	return *builder, nil
+}
+
+type Builder struct {
+	PluginSpec `json:",inline" yaml:",inline"`
+}
+
+func ClickHouseTraceQuery(expr string, options ...Option) query.Option {
+	plg, err := create(expr, options...)
+	return query.Option{
+		Kind: plugin.KindTraceQuery,
+		Plugin: plugin.Plugin{
+			Kind: PluginKind,
+			Spec: plg,
+		},
+		Error: err,
+	}
+}

--- a/clickhouse/sdk/go/query/trace/trace_test.go
+++ b/clickhouse/sdk/go/query/trace/trace_test.go
@@ -1,0 +1,82 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/perses/spec/go/plugin"
+)
+
+func TestClickHouseTraceQueryBuilder(t *testing.T) {
+	q := ClickHouseTraceQuery(
+		"SELECT * FROM otel.otel_traces",
+		Datasource("clickhouse"),
+		Table("otel.otel_traces"),
+		Limit(50),
+	)
+	if q.Error != nil {
+		t.Fatalf("unexpected error: %v", q.Error)
+	}
+	if q.Kind != plugin.KindTraceQuery {
+		t.Fatalf("unexpected query kind: %s", q.Kind)
+	}
+	if q.Plugin.Kind != PluginKind {
+		t.Fatalf("unexpected plugin kind: %s", q.Plugin.Kind)
+	}
+
+	raw, err := json.Marshal(q.Plugin.Spec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if out["query"] != "SELECT * FROM otel.otel_traces" {
+		t.Errorf("query mismatch: %v", out["query"])
+	}
+	if out["table"] != "otel.otel_traces" {
+		t.Errorf("table mismatch: %v", out["table"])
+	}
+	if out["limit"] != float64(50) {
+		t.Errorf("limit mismatch: %v", out["limit"])
+	}
+	datasource, ok := out["datasource"].(map[string]any)
+	if !ok || datasource["kind"] != "ClickHouseDatasource" || datasource["name"] != "clickhouse" {
+		t.Errorf("datasource mismatch: %v", out["datasource"])
+	}
+}
+
+func TestClickHouseTraceQueryOmitsEmptyOptionalFields(t *testing.T) {
+	q := ClickHouseTraceQuery("5b8efff798038103d269b633813fc60c")
+	raw, err := json.Marshal(q.Plugin.Spec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, f := range []string{"datasource", "table", "limit"} {
+		if _, present := out[f]; present {
+			t.Errorf("expected %s to be omitted, got: %v", f, out[f])
+		}
+	}
+}

--- a/clickhouse/src/queries/click-house-trace-query/ClickHouseTraceQuery.test.ts
+++ b/clickhouse/src/queries/click-house-trace-query/ClickHouseTraceQuery.test.ts
@@ -1,0 +1,35 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { TraceQueryContext } from '@perses-dev/plugin-system';
+
+import { ClickHouseTraceQuery } from './ClickHouseTraceQuery';
+
+describe('ClickHouseTraceQuery', () => {
+  it('should properly resolve variable dependencies', () => {
+    if (!ClickHouseTraceQuery.dependsOn) throw new Error('dependsOn is not defined');
+    const { variables } = ClickHouseTraceQuery.dependsOn(
+      {
+        query:
+          "SELECT * FROM otel_traces WHERE ServiceName = '$service' AND (SpanName = '$span' OR ServiceName = '$service')",
+      },
+      {} as TraceQueryContext,
+    );
+    expect(variables).toEqual(['service', 'span']);
+  });
+
+  it('should create initial options with empty query', () => {
+    const initialOptions = ClickHouseTraceQuery.createInitialOptions();
+    expect(initialOptions).toEqual({ query: '' });
+  });
+});

--- a/clickhouse/src/queries/click-house-trace-query/ClickHouseTraceQuery.tsx
+++ b/clickhouse/src/queries/click-house-trace-query/ClickHouseTraceQuery.tsx
@@ -1,0 +1,32 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { TraceQueryPlugin } from '@perses-dev/plugin-system';
+import { parseVariables } from '@perses-dev/plugin-system';
+
+import type { ClickHouseTraceQuerySpec } from './click-house-trace-query-types';
+import { ClickHouseTraceQueryEditor } from './ClickHouseTraceQueryEditor';
+import { getClickHouseTraceData } from './get-click-house-trace-data';
+
+export const ClickHouseTraceQuery: TraceQueryPlugin<ClickHouseTraceQuerySpec> = {
+  getTraceData: getClickHouseTraceData,
+  OptionsEditorComponent: ClickHouseTraceQueryEditor,
+  createInitialOptions: () => ({ query: '' }),
+  dependsOn: (spec) => {
+    const queryVariables = parseVariables(spec.query);
+    const allVariables = [...new Set(queryVariables)];
+    return {
+      variables: allVariables,
+    };
+  },
+};

--- a/clickhouse/src/queries/click-house-trace-query/ClickHouseTraceQueryEditor.test.tsx
+++ b/clickhouse/src/queries/click-house-trace-query/ClickHouseTraceQueryEditor.test.tsx
@@ -1,0 +1,72 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { ClickHouseTraceQueryEditor } from './ClickHouseTraceQueryEditor';
+
+vi.mock('@perses-dev/plugin-system', () => ({
+  DatasourceSelect: vi.fn(() => null),
+  isVariableDatasource: vi.fn(() => false),
+}));
+
+vi.mock('@perses-dev/dashboards', () => ({
+  createModEnterHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../components', () => ({
+  ClickQLEditor: vi.fn(() => null),
+}));
+
+describe('ClickHouseTraceQueryEditor', () => {
+  it('commits the trace table on blur instead of each keystroke', () => {
+    const onChange = vi.fn();
+    render(<ClickHouseTraceQueryEditor value={{ query: 'SELECT 1' }} onChange={onChange} />);
+
+    const tableInput = screen.getByLabelText('Trace table');
+    fireEvent.change(tableInput, { target: { value: ' otel.otel_traces ' } });
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.blur(tableInput);
+    expect(onChange).toHaveBeenCalledWith({ query: 'SELECT 1', table: 'otel.otel_traces' });
+  });
+
+  it('removes the trace table from the spec when it is cleared', () => {
+    const onChange = vi.fn();
+    render(<ClickHouseTraceQueryEditor value={{ query: 'SELECT 1', table: 'otel.otel_traces' }} onChange={onChange} />);
+
+    const tableInput = screen.getByLabelText('Trace table');
+    fireEvent.change(tableInput, { target: { value: '' } });
+    fireEvent.blur(tableInput);
+
+    const nextSpec = onChange.mock.calls[0]?.[0];
+    expect(nextSpec).toEqual({ query: 'SELECT 1' });
+    expect(nextSpec.table).toBeUndefined();
+  });
+
+  it('updates the search limit', () => {
+    const onChange = vi.fn();
+    render(<ClickHouseTraceQueryEditor value={{ query: 'SELECT 1' }} onChange={onChange} />);
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Max traces' }));
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: '50' }));
+
+    expect(onChange).toHaveBeenCalledWith({ query: 'SELECT 1', limit: 50 });
+  });
+
+  it('keeps a limit that is not one of the preset options selectable', () => {
+    render(<ClickHouseTraceQueryEditor value={{ query: 'SELECT 1', limit: 30 }} onChange={vi.fn()} />);
+
+    expect(screen.getByRole('combobox', { name: 'Max traces' })).toHaveTextContent('30');
+  });
+});

--- a/clickhouse/src/queries/click-house-trace-query/ClickHouseTraceQueryEditor.tsx
+++ b/clickhouse/src/queries/click-house-trace-query/ClickHouseTraceQueryEditor.tsx
@@ -1,0 +1,137 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { MenuItem, Stack, TextField, Typography } from '@mui/material';
+import { createModEnterHandler } from '@perses-dev/dashboards';
+import type { DatasourceSelectProps, OptionsEditorProps } from '@perses-dev/plugin-system';
+import { DatasourceSelect, isVariableDatasource } from '@perses-dev/plugin-system';
+import { produce } from 'immer';
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+
+import { ClickQLEditor } from '../../components';
+import { DATASOURCE_KIND, DEFAULT_DATASOURCE } from '../constants';
+import { useQueryState } from '../query-editor-model';
+import type { ClickHouseTraceQuerySpec } from './click-house-trace-query-types';
+import { DEFAULT_TRACE_SEARCH_LIMIT, DEFAULT_TRACE_TABLE } from './click-house-trace-query-types';
+
+const LIMIT_OPTIONS = [20, 50, 100, 500, 1000, 5000];
+
+type ClickHouseTraceQueryEditorProps = OptionsEditorProps<ClickHouseTraceQuerySpec>;
+
+export function ClickHouseTraceQueryEditor(props: ClickHouseTraceQueryEditorProps): ReactElement {
+  const { onChange, value } = props;
+  const selectedDatasource = value.datasource ?? DEFAULT_DATASOURCE;
+  const { query, handleQueryChange, handleQueryBlur } = useQueryState(props);
+
+  // Like the query, the table is only synced with the spec on blur, so the preview doesn't re-run on every keystroke
+  const [table, setTable] = useState(value.table ?? '');
+  const [lastSyncedTable, setLastSyncedTable] = useState(value.table);
+  if (value.table !== lastSyncedTable) {
+    setTable(value.table ?? '');
+    setLastSyncedTable(value.table);
+  }
+
+  const limit = value.limit ?? DEFAULT_TRACE_SEARCH_LIMIT;
+  const limitOptions = LIMIT_OPTIONS.includes(limit)
+    ? LIMIT_OPTIONS
+    : [...LIMIT_OPTIONS, limit].toSorted((a, b) => a - b);
+
+  const handleDatasourceChange: DatasourceSelectProps['onChange'] = (newDatasourceSelection) => {
+    if (!isVariableDatasource(newDatasourceSelection) && newDatasourceSelection.kind === DATASOURCE_KIND) {
+      onChange(
+        produce(value, (draft) => {
+          draft.datasource = newDatasourceSelection;
+        }),
+      );
+      return;
+    }
+    throw new Error('Got unexpected non ClickHouse datasource selection');
+  };
+
+  const handleQueryExecute = (): void => {
+    onChange(
+      produce(value, (draft) => {
+        draft.query = query;
+      }),
+    );
+  };
+
+  const handleTableBlur = (): void => {
+    const nextTable = table.trim() === '' ? undefined : table.trim();
+    setLastSyncedTable(nextTable);
+    onChange(
+      produce(value, (draft) => {
+        draft.table = nextTable;
+      }),
+    );
+  };
+
+  const handleLimitChange = (nextLimit: number): void => {
+    onChange(
+      produce(value, (draft) => {
+        draft.limit = nextLimit;
+      }),
+    );
+  };
+
+  return (
+    <Stack spacing={1.5}>
+      <DatasourceSelect
+        datasourcePluginKind={DATASOURCE_KIND}
+        value={selectedDatasource}
+        onChange={handleDatasourceChange}
+        label="ClickHouse Datasource"
+        notched
+      />
+      <ClickQLEditor
+        value={query}
+        onChange={handleQueryChange}
+        onBlur={handleQueryBlur}
+        onKeyDown={createModEnterHandler(handleQueryExecute)}
+        placeholder="Enter a trace ID, or a SQL query returning one row per span"
+      />
+      <Typography variant="caption" color="text.secondary">
+        A trace ID shows that trace. A SQL query searches traces: return one row per span with the columns TraceId,
+        Timestamp, Duration, ParentSpanId, SpanName, ServiceName and StatusCode. {'{start}'} and {'{end}'} are replaced
+        with the dashboard time range.
+      </Typography>
+      <Stack direction="row" spacing={2}>
+        <TextField
+          label="Trace table"
+          size="small"
+          value={table}
+          placeholder={DEFAULT_TRACE_TABLE}
+          helperText="Read when looking up a trace by ID"
+          onChange={(e) => setTable(e.target.value)}
+          onBlur={handleTableBlur}
+          sx={{ flexGrow: 1 }}
+        />
+        <TextField
+          select
+          label="Max traces"
+          size="small"
+          value={limit}
+          onChange={(e) => handleLimitChange(Number(e.target.value))}
+          sx={{ width: 120 }}
+        >
+          {limitOptions.map((option) => (
+            <MenuItem key={option} value={option}>
+              {option}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Stack>
+    </Stack>
+  );
+}

--- a/clickhouse/src/queries/click-house-trace-query/click-house-trace-query-types.ts
+++ b/clickhouse/src/queries/click-house-trace-query/click-house-trace-query-types.ts
@@ -1,0 +1,72 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DatasourceSelector } from '@perses-dev/spec';
+
+export const DEFAULT_TRACE_TABLE = 'otel_traces';
+export const DEFAULT_TRACE_SEARCH_LIMIT = 20;
+
+export interface ClickHouseTraceQuerySpec {
+  /**
+   * A trace ID to show a single trace, or a SQL query returning one row per span to search traces.
+   */
+  query: string;
+  /**
+   * Table (or `database.table`) using the OpenTelemetry Collector ClickHouse exporter schema, read by trace ID lookups.
+   */
+  table?: string;
+  /**
+   * Maximum number of traces returned by a search.
+   */
+  limit?: number;
+  datasource?: DatasourceSelector;
+}
+
+/**
+ * A span returned by a search query. Column names follow the OpenTelemetry Collector ClickHouse exporter schema.
+ */
+export interface ClickHouseSpanRow {
+  TraceId?: string;
+  ParentSpanId?: string;
+  SpanName?: string;
+  ServiceName?: string;
+  Timestamp?: string;
+  Duration?: string | number;
+  StatusCode?: string;
+}
+
+/**
+ * A span returned by the trace ID lookup, see `buildTraceByIdQuery`.
+ */
+export interface ClickHouseTraceSpanRow {
+  TraceId: string;
+  SpanId: string;
+  ParentSpanId: string;
+  SpanName: string;
+  SpanKind: string;
+  ServiceName: string;
+  ResourceAttributes: Record<string, string>;
+  ScopeName: string;
+  ScopeVersion: string;
+  SpanAttributes: Record<string, string>;
+  StartTimeUnixNano: string;
+  DurationNano: string;
+  StatusCode: string;
+  StatusMessage: string;
+  EventTimesUnixNano: string[];
+  EventNames: string[];
+  EventAttributes: Array<Record<string, string>>;
+  LinkTraceIds: string[];
+  LinkSpanIds: string[];
+  LinkAttributes: Array<Record<string, string>>;
+}

--- a/clickhouse/src/queries/click-house-trace-query/get-click-house-trace-data.test.ts
+++ b/clickhouse/src/queries/click-house-trace-query/get-click-house-trace-data.test.ts
@@ -1,0 +1,428 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { TraceQueryContext } from '@perses-dev/plugin-system';
+import type { Mock } from 'vitest';
+
+import { ClickHouseDatasource } from '../../datasources/click-house-datasource';
+import type { ClickHouseQueryResponse } from '../../model/click-house-client';
+import type { ClickHouseSpanRow, ClickHouseTraceSpanRow } from './click-house-trace-query-types';
+import { getClickHouseTraceData } from './get-click-house-trace-data';
+
+const TRACE_ID = '5b8efff798038103d269b633813fc60c';
+const OTHER_TRACE_ID = '0af7651916cd43dd8448eb211c80319c';
+
+const createStubContext = (
+  data: unknown,
+  status: ClickHouseQueryResponse['status'] = 'success',
+): { context: TraceQueryContext; query: Mock } => {
+  const client = ClickHouseDatasource.createClient({ directUrl: '/test' }, {});
+  const query: Mock = vi.fn(async () => ({ status, data }));
+  client.query = query;
+
+  const getDatasourceClient: Mock = vi.fn(async () => client);
+  const context: TraceQueryContext = {
+    datasourceStore: {
+      getDatasource: vi.fn(),
+      getDatasourceClient,
+      listDatasourceSelectItems: vi.fn(),
+      getLocalDatasources: vi.fn(),
+      setLocalDatasources: vi.fn(),
+      getSavedDatasources: vi.fn(),
+      setSavedDatasources: vi.fn(),
+    },
+    absoluteTimeRange: {
+      start: new Date('2025-01-01T00:00:00.000Z'),
+      end: new Date('2025-01-02T00:00:00.000Z'),
+    },
+    variableState: {},
+  };
+  return { context, query };
+};
+
+const executedQuery = (query: Mock): string => query.mock.calls[0]![0].query;
+
+const traceSpanRow = (row: Partial<ClickHouseTraceSpanRow>): ClickHouseTraceSpanRow => ({
+  TraceId: TRACE_ID,
+  SpanId: '',
+  ParentSpanId: '',
+  SpanName: '',
+  SpanKind: 'Internal',
+  ServiceName: 'frontend',
+  ResourceAttributes: { 'service.name': 'frontend' },
+  ScopeName: '',
+  ScopeVersion: '',
+  SpanAttributes: {},
+  StartTimeUnixNano: '1735689600000000000',
+  DurationNano: '0',
+  StatusCode: 'Unset',
+  StatusMessage: '',
+  EventTimesUnixNano: [],
+  EventNames: [],
+  EventAttributes: [],
+  LinkTraceIds: [],
+  LinkSpanIds: [],
+  LinkAttributes: [],
+  ...row,
+});
+
+describe('getClickHouseTraceData', () => {
+  it('should return an empty search result for an empty query without querying ClickHouse', async () => {
+    const { context, query } = createStubContext([]);
+
+    const result = await getClickHouseTraceData({ query: '  ' }, context);
+
+    expect(result).toEqual({ searchResult: [] });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  describe('with a trace ID', () => {
+    it('should fetch the spans of the trace from the default table', async () => {
+      const { context, query } = createStubContext([traceSpanRow({ SpanId: 'eee19b7ec3c1b174' })]);
+
+      const result = await getClickHouseTraceData({ query: TRACE_ID }, context);
+
+      expect(query).toHaveBeenCalledTimes(1);
+      expect(executedQuery(query)).toContain('FROM otel_traces\n');
+      expect(executedQuery(query)).toContain(`WHERE TraceId = '${TRACE_ID}'`);
+      expect(result.metadata?.executedQueryString).toBe(executedQuery(query));
+      expect(result.searchResult).toBeUndefined();
+    });
+
+    it('should convert the spans to OTLP, grouped by resource and instrumentation scope', async () => {
+      const { context } = createStubContext([
+        traceSpanRow({
+          SpanId: 'eee19b7ec3c1b174',
+          SpanName: 'GET /cart',
+          SpanKind: 'Server',
+          ResourceAttributes: { 'service.name': 'frontend', 'host.name': 'web-1' },
+          ScopeName: '@opentelemetry/instrumentation-http',
+          ScopeVersion: '0.52.0',
+          SpanAttributes: { 'http.request.method': 'GET' },
+          DurationNano: '250000000',
+          StatusCode: 'Ok',
+          EventTimesUnixNano: ['1735689600100000000'],
+          EventNames: ['cache.miss'],
+          EventAttributes: [{ 'cache.key': 'cart' }],
+        }),
+        traceSpanRow({
+          SpanId: 'b7ad6b7169203331',
+          ParentSpanId: 'eee19b7ec3c1b174',
+          SpanName: 'GET /api/cart',
+          SpanKind: 'Client',
+          ResourceAttributes: { 'service.name': 'frontend', 'host.name': 'web-1' },
+          ScopeName: '@opentelemetry/instrumentation-http',
+          ScopeVersion: '0.52.0',
+          StartTimeUnixNano: '1735689600050000000',
+          DurationNano: '120000000',
+          StatusCode: 'Error',
+          StatusMessage: 'upstream timed out',
+          LinkTraceIds: [OTHER_TRACE_ID],
+          LinkSpanIds: ['00f067aa0ba902b7'],
+          LinkAttributes: [{ 'link.reason': 'retry' }],
+        }),
+        traceSpanRow({
+          SpanId: '53995c3f42cd8ad8',
+          ParentSpanId: 'b7ad6b7169203331',
+          SpanName: 'cart.get',
+          SpanKind: 'SPAN_KIND_SERVER',
+          ServiceName: 'cart',
+          ResourceAttributes: {},
+          ScopeName: 'cart-service',
+          StartTimeUnixNano: '1735689600060000000',
+          DurationNano: '100000000',
+          StatusCode: 'STATUS_CODE_ERROR',
+        }),
+      ]);
+
+      const result = await getClickHouseTraceData({ query: TRACE_ID }, context);
+
+      expect(result.trace).toEqual({
+        resourceSpans: [
+          {
+            resource: {
+              attributes: [
+                { key: 'service.name', value: { stringValue: 'frontend' } },
+                { key: 'host.name', value: { stringValue: 'web-1' } },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: '@opentelemetry/instrumentation-http', version: '0.52.0' },
+                spans: [
+                  {
+                    traceId: TRACE_ID,
+                    spanId: 'eee19b7ec3c1b174',
+                    parentSpanId: undefined,
+                    name: 'GET /cart',
+                    kind: 'SPAN_KIND_SERVER',
+                    startTimeUnixNano: '1735689600000000000',
+                    endTimeUnixNano: '1735689600250000000',
+                    attributes: [{ key: 'http.request.method', value: { stringValue: 'GET' } }],
+                    events: [
+                      {
+                        timeUnixNano: '1735689600100000000',
+                        name: 'cache.miss',
+                        attributes: [{ key: 'cache.key', value: { stringValue: 'cart' } }],
+                      },
+                    ],
+                    links: [],
+                    status: { code: 'STATUS_CODE_OK', message: undefined },
+                  },
+                  {
+                    traceId: TRACE_ID,
+                    spanId: 'b7ad6b7169203331',
+                    parentSpanId: 'eee19b7ec3c1b174',
+                    name: 'GET /api/cart',
+                    kind: 'SPAN_KIND_CLIENT',
+                    startTimeUnixNano: '1735689600050000000',
+                    endTimeUnixNano: '1735689600170000000',
+                    attributes: [],
+                    events: [],
+                    links: [
+                      {
+                        traceId: OTHER_TRACE_ID,
+                        spanId: '00f067aa0ba902b7',
+                        attributes: [{ key: 'link.reason', value: { stringValue: 'retry' } }],
+                      },
+                    ],
+                    status: { code: 'STATUS_CODE_ERROR', message: 'upstream timed out' },
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            resource: { attributes: [{ key: 'service.name', value: { stringValue: 'cart' } }] },
+            scopeSpans: [
+              {
+                scope: { name: 'cart-service', version: '' },
+                spans: [
+                  {
+                    traceId: TRACE_ID,
+                    spanId: '53995c3f42cd8ad8',
+                    parentSpanId: 'b7ad6b7169203331',
+                    name: 'cart.get',
+                    kind: 'SPAN_KIND_SERVER',
+                    startTimeUnixNano: '1735689600060000000',
+                    endTimeUnixNano: '1735689600160000000',
+                    attributes: [],
+                    events: [],
+                    links: [],
+                    status: { code: 'STATUS_CODE_ERROR', message: undefined },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should normalize 16 character and uppercase trace IDs to the format stored by the exporter', async () => {
+      const { context, query } = createStubContext([traceSpanRow({})]);
+
+      await getClickHouseTraceData({ query: 'ABCDEF0123456789' }, context);
+
+      expect(executedQuery(query)).toContain("WHERE TraceId = '0000000000000000abcdef0123456789'");
+    });
+
+    it('should resolve variables before detecting a trace ID', async () => {
+      const { context, query } = createStubContext([traceSpanRow({})]);
+      context.variableState = { traceId: { value: TRACE_ID, loading: false } };
+
+      const result = await getClickHouseTraceData({ query: '$traceId' }, context);
+
+      expect(executedQuery(query)).toContain(`WHERE TraceId = '${TRACE_ID}'`);
+      expect(result.trace).toBeDefined();
+    });
+
+    it('should read the spans from the configured table', async () => {
+      const { context, query } = createStubContext([traceSpanRow({})]);
+
+      await getClickHouseTraceData({ query: TRACE_ID, table: 'otel.otel_traces' }, context);
+
+      expect(executedQuery(query)).toContain('FROM otel.otel_traces\n');
+    });
+
+    it('should reject a table that is not a table name', async () => {
+      const { context, query } = createStubContext([traceSpanRow({})]);
+
+      await expect(
+        getClickHouseTraceData({ query: TRACE_ID, table: "otel_traces WHERE TraceId != ''" }, context),
+      ).rejects.toThrow('Invalid trace table');
+      expect(query).not.toHaveBeenCalled();
+    });
+
+    it('should throw when the trace is not found', async () => {
+      const { context } = createStubContext([]);
+
+      await expect(getClickHouseTraceData({ query: TRACE_ID }, context)).rejects.toThrow(
+        `Trace ${TRACE_ID} was not found in otel_traces.`,
+      );
+    });
+  });
+
+  describe('with a SQL query', () => {
+    it('should group spans into one search result per trace, most recent first', async () => {
+      const rows: ClickHouseSpanRow[] = [
+        {
+          TraceId: TRACE_ID,
+          ParentSpanId: '',
+          SpanName: 'GET /cart',
+          ServiceName: 'frontend',
+          Timestamp: '2025-01-01 00:00:00.000000000',
+          Duration: '250000000',
+          StatusCode: 'Ok',
+        },
+        {
+          TraceId: TRACE_ID,
+          ParentSpanId: 'eee19b7ec3c1b174',
+          SpanName: 'cart.get',
+          ServiceName: 'cart',
+          Timestamp: '2025-01-01 00:00:00.100000000',
+          Duration: '300000000',
+          StatusCode: 'Error',
+        },
+        {
+          TraceId: TRACE_ID,
+          ParentSpanId: '53995c3f42cd8ad8',
+          SpanName: 'redis GET',
+          ServiceName: 'cart',
+          Timestamp: '2025-01-01 00:00:00.150000000',
+          Duration: '1000000',
+          StatusCode: 'Unset',
+        },
+        {
+          TraceId: OTHER_TRACE_ID,
+          ParentSpanId: '',
+          SpanName: 'POST /checkout',
+          ServiceName: 'frontend',
+          Timestamp: '2025-01-01T00:10:00Z',
+          Duration: 50000000,
+          StatusCode: 'Unset',
+        },
+      ];
+      const { context } = createStubContext(rows);
+
+      const result = await getClickHouseTraceData({ query: 'SELECT * FROM otel_traces' }, context);
+
+      expect(result.searchResult).toEqual([
+        {
+          traceId: OTHER_TRACE_ID,
+          rootServiceName: 'frontend',
+          rootTraceName: 'POST /checkout',
+          startTimeUnixMs: Date.parse('2025-01-01T00:10:00Z'),
+          durationMs: 50,
+          serviceStats: { frontend: { spanCount: 1 } },
+        },
+        {
+          traceId: TRACE_ID,
+          rootServiceName: 'frontend',
+          rootTraceName: 'GET /cart',
+          startTimeUnixMs: Date.parse('2025-01-01T00:00:00Z'),
+          durationMs: 400,
+          serviceStats: { frontend: { spanCount: 1 }, cart: { spanCount: 2, errorCount: 1 } },
+        },
+      ]);
+      expect(result.trace).toBeUndefined();
+      expect(result.metadata?.hasMoreResults).toBe(false);
+      expect(result.metadata?.notices).toEqual([]);
+    });
+
+    it('should use the earliest span as root when the query does not return the root span', async () => {
+      const { context } = createStubContext([
+        {
+          TraceId: TRACE_ID,
+          ParentSpanId: 'b7ad6b7169203331',
+          SpanName: 'redis GET',
+          ServiceName: 'cart',
+          Timestamp: '2025-01-01 00:00:02',
+        },
+        {
+          TraceId: TRACE_ID,
+          ParentSpanId: 'eee19b7ec3c1b174',
+          SpanName: 'cart.get',
+          ServiceName: 'cart',
+          Timestamp: '2025-01-01 00:00:01',
+        },
+      ]);
+
+      const result = await getClickHouseTraceData({ query: 'SELECT * FROM otel_traces' }, context);
+
+      expect(result.searchResult?.[0]).toMatchObject({ rootServiceName: 'cart', rootTraceName: 'cart.get' });
+    });
+
+    it('should replace the time range placeholders', async () => {
+      const { context, query } = createStubContext([]);
+
+      const result = await getClickHouseTraceData(
+        { query: "SELECT * FROM otel_traces WHERE Timestamp BETWEEN '{start}' AND '{end}'" },
+        context,
+      );
+
+      const expectedQuery =
+        "SELECT * FROM otel_traces WHERE Timestamp BETWEEN '2025-01-01 00:00:00' AND '2025-01-02 00:00:00'";
+      expect(query).toHaveBeenCalledWith({
+        start: '2025-01-01 00:00:00',
+        end: '2025-01-02 00:00:00',
+        query: expectedQuery,
+      });
+      expect(result.metadata?.executedQueryString).toBe(expectedQuery);
+      expect(result.searchResult).toEqual([]);
+    });
+
+    it('should limit the number of traces and report that more are available', async () => {
+      const { context } = createStubContext([
+        { TraceId: 'a', Timestamp: '2025-01-01 00:00:01' },
+        { TraceId: 'b', Timestamp: '2025-01-01 00:00:03' },
+        { TraceId: 'c', Timestamp: '2025-01-01 00:00:02' },
+      ]);
+
+      const result = await getClickHouseTraceData({ query: 'SELECT * FROM otel_traces', limit: 2 }, context);
+
+      expect(result.searchResult?.map((trace) => trace.traceId)).toEqual(['b', 'c']);
+      expect(result.metadata?.hasMoreResults).toBe(true);
+      expect(result.metadata?.notices).toEqual([
+        {
+          type: 'info',
+          message:
+            'Not all matching traces are currently displayed. Increase the result limit to view additional traces.',
+        },
+      ]);
+    });
+
+    it('should ignore rows without a trace ID or a valid timestamp and report them', async () => {
+      const { context } = createStubContext([
+        { TraceId: TRACE_ID, Timestamp: '2025-01-01 00:00:00' },
+        { Timestamp: '2025-01-01 00:00:00' },
+        { TraceId: OTHER_TRACE_ID, Timestamp: 'yesterday' },
+      ]);
+
+      const result = await getClickHouseTraceData({ query: 'SELECT * FROM otel_traces' }, context);
+
+      expect(result.searchResult?.map((trace) => trace.traceId)).toEqual([TRACE_ID]);
+      expect(result.metadata?.notices).toEqual([
+        { type: 'warning', message: '2 rows were ignored because they have no TraceId or no valid Timestamp.' },
+      ]);
+    });
+
+    it('should throw when ClickHouse returns an error', async () => {
+      const { context } = createStubContext([], 'error');
+
+      await expect(getClickHouseTraceData({ query: 'SELECT * FROM missing_table' }, context)).rejects.toThrow(
+        'ClickHouse returned an error for the trace query',
+      );
+    });
+  });
+});

--- a/clickhouse/src/queries/click-house-trace-query/get-click-house-trace-data.ts
+++ b/clickhouse/src/queries/click-house-trace-query/get-click-house-trace-data.ts
@@ -1,0 +1,331 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { TraceQueryPlugin } from '@perses-dev/plugin-system';
+import { replaceVariables } from '@perses-dev/plugin-system';
+import type { AbsoluteTimeRange, Notice, ServiceStats, TraceData, TraceSearchResult } from '@perses-dev/spec';
+import type * as otlpcommonv1 from '@perses-dev/spec/dist/dashboard/query-type/otlp/common/v1/common';
+import type * as otlptracev1 from '@perses-dev/spec/dist/dashboard/query-type/otlp/trace/v1/trace';
+
+import type { ClickHouseClient, ClickHouseQueryResponse } from '../../model/click-house-client';
+import { formatClickHouseDateTime, replaceTimeRangePlaceholders } from '../../model/click-house-client';
+import { DEFAULT_DATASOURCE } from '../constants';
+import type {
+  ClickHouseSpanRow,
+  ClickHouseTraceQuerySpec,
+  ClickHouseTraceSpanRow,
+} from './click-house-trace-query-types';
+import { DEFAULT_TRACE_SEARCH_LIMIT, DEFAULT_TRACE_TABLE } from './click-house-trace-query-types';
+
+const TRACE_ID_PATTERN = /^[a-fA-F0-9]{16}(?:[a-fA-F0-9]{16})?$/;
+const TABLE_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/;
+const CLICKHOUSE_DATETIME_PATTERN = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?$/;
+
+// The exporter writes the short names (Server, Error). The OTLP enum names (SPAN_KIND_SERVER) are accepted as well.
+const SPAN_KIND_MAP: Record<string, otlptracev1.Span['kind']> = {
+  unspecified: 'SPAN_KIND_UNSPECIFIED',
+  internal: 'SPAN_KIND_INTERNAL',
+  server: 'SPAN_KIND_SERVER',
+  client: 'SPAN_KIND_CLIENT',
+  producer: 'SPAN_KIND_PRODUCER',
+  consumer: 'SPAN_KIND_CONSUMER',
+};
+
+const STATUS_CODE_MAP: Record<string, otlptracev1.Status['code']> = {
+  unset: 'STATUS_CODE_UNSET',
+  ok: 'STATUS_CODE_OK',
+  error: 'STATUS_CODE_ERROR',
+};
+
+interface TraceSummary {
+  startTimeUnixMs: number;
+  endTimeUnixMs: number;
+  root: { hasParent: boolean; startTimeUnixMs: number; serviceName: string; spanName: string };
+  serviceStats: Record<string, ServiceStats>;
+}
+
+export const getClickHouseTraceData: TraceQueryPlugin<ClickHouseTraceQuerySpec>['getTraceData'] = async (
+  spec,
+  context,
+) => {
+  const query = replaceVariables(spec.query ?? '', context.variableState).trim();
+  if (query === '') {
+    return { searchResult: [] };
+  }
+
+  const client = (await context.datasourceStore.getDatasourceClient(
+    spec.datasource ?? DEFAULT_DATASOURCE,
+  )) as ClickHouseClient;
+
+  /**
+   * determine type of query:
+   * if the query is a valid trace ID, fetch the spans of this trace from the trace table
+   * otherwise, run the query as SQL and group the spans it returns into search results
+   */
+  if (TRACE_ID_PATTERN.test(query)) {
+    return getTraceById(client, query, spec.table || DEFAULT_TRACE_TABLE);
+  }
+  return searchTraces(client, query, spec.limit ?? DEFAULT_TRACE_SEARCH_LIMIT, context.absoluteTimeRange);
+};
+
+async function getTraceById(client: ClickHouseClient, traceId: string, table: string): Promise<TraceData> {
+  // The table name is interpolated into SQL, so anything other than a plain identifier is rejected
+  if (!TABLE_PATTERN.test(table)) {
+    throw new Error(`Invalid trace table "${table}": expected a table name, optionally prefixed with its database.`);
+  }
+
+  // The exporter stores trace IDs as 32 lowercase hexadecimal characters
+  const normalizedTraceId = traceId.toLowerCase().padStart(32, '0');
+  const executedQueryString = buildTraceByIdQuery(normalizedTraceId, table);
+  const response = await client.query({ start: '', end: '', query: executedQueryString });
+  const rows = getRows<ClickHouseTraceSpanRow>(response);
+  if (rows.length === 0) {
+    throw new Error(`Trace ${normalizedTraceId} was not found in ${table}.`);
+  }
+
+  return {
+    trace: clickHouseTraceToOTLP(rows),
+    metadata: {
+      executedQueryString,
+    },
+  };
+}
+
+async function searchTraces(
+  client: ClickHouseClient,
+  query: string,
+  limit: number,
+  timeRange?: AbsoluteTimeRange,
+): Promise<TraceData> {
+  const start = timeRange ? formatClickHouseDateTime(timeRange.start) : undefined;
+  const end = timeRange ? formatClickHouseDateTime(timeRange.end) : undefined;
+  const executedQueryString = replaceTimeRangePlaceholders(query, start, end);
+  // Without a time range the placeholders are left in place, instead of letting the client replace them with ''
+  const response = await client.query({ start: start ?? '{start}', end: end ?? '{end}', query: executedQueryString });
+  const { searchResult, skippedRows } = clickHouseSpansToSearchResults(getRows<ClickHouseSpanRow>(response));
+
+  const notices: Notice[] = [];
+  if (skippedRows > 0) {
+    notices.push({
+      type: 'warning',
+      message: `${skippedRows} rows were ignored because they have no TraceId or no valid Timestamp.`,
+    });
+  }
+
+  // Unlike Tempo, the limit cannot be pushed down into a user-written query, so it is applied to the grouped traces
+  const hasMoreResults = searchResult.length > limit;
+  if (hasMoreResults) {
+    notices.push({
+      type: 'info',
+      message: 'Not all matching traces are currently displayed. Increase the result limit to view additional traces.',
+    });
+    searchResult.splice(limit);
+  }
+
+  return {
+    searchResult,
+    metadata: {
+      executedQueryString,
+      hasMoreResults,
+      notices,
+    },
+  };
+}
+
+/**
+ * Builds the query returning every span of a trace, for a table with the OpenTelemetry Collector ClickHouse exporter
+ * schema. Timestamps are converted to nanosecond strings in SQL: DateTime64 values are rendered in the server's
+ * timezone, and JSON numbers cannot hold nanoseconds since the epoch.
+ *
+ * The lookup is deliberately not bounded by time, so that a trace opens from a link whatever the dashboard time
+ * range. It relies on the bloom filter index the exporter creates on TraceId. The exporter's `<table>_trace_id_ts`
+ * table could bound the scan on large tables, but it only exists when the exporter created the schema. See "Trace ID
+ * lookup" in the data model docs.
+ */
+function buildTraceByIdQuery(traceId: string, table: string): string {
+  return `SELECT
+  TraceId,
+  SpanId,
+  ParentSpanId,
+  SpanName,
+  SpanKind,
+  ServiceName,
+  ResourceAttributes,
+  ScopeName,
+  ScopeVersion,
+  SpanAttributes,
+  toString(toUnixTimestamp64Nano(Timestamp)) AS StartTimeUnixNano,
+  toString(Duration) AS DurationNano,
+  StatusCode,
+  StatusMessage,
+  arrayMap(t -> toString(toUnixTimestamp64Nano(t)), Events.Timestamp) AS EventTimesUnixNano,
+  Events.Name AS EventNames,
+  Events.Attributes AS EventAttributes,
+  Links.TraceId AS LinkTraceIds,
+  Links.SpanId AS LinkSpanIds,
+  Links.Attributes AS LinkAttributes
+FROM ${table}
+WHERE TraceId = '${traceId}'
+ORDER BY Timestamp`;
+}
+
+function getRows<T>(response: ClickHouseQueryResponse): T[] {
+  // The ClickHouse client logs the error returned by the server to the console, and only returns the status
+  if (response.status === 'error') {
+    throw new Error('ClickHouse returned an error for the trace query, see the browser console for details.');
+  }
+  return Array.isArray(response.data) ? (response.data as T[]) : [];
+}
+
+function clickHouseTraceToOTLP(rows: ClickHouseTraceSpanRow[]): otlptracev1.TracesData {
+  const resourceSpans = new Map<string, otlptracev1.ResourceSpan>();
+  const scopeSpans = new Map<string, otlptracev1.ScopeSpan>();
+
+  for (const row of rows) {
+    const resourceKey = JSON.stringify([row.ServiceName, row.ResourceAttributes]);
+    let resourceSpan = resourceSpans.get(resourceKey);
+    if (resourceSpan === undefined) {
+      resourceSpan = { resource: { attributes: toResourceAttributes(row) }, scopeSpans: [] };
+      resourceSpans.set(resourceKey, resourceSpan);
+    }
+
+    const scopeKey = JSON.stringify([resourceKey, row.ScopeName, row.ScopeVersion]);
+    let scopeSpan = scopeSpans.get(scopeKey);
+    if (scopeSpan === undefined) {
+      scopeSpan = { scope: { name: row.ScopeName, version: row.ScopeVersion }, spans: [] };
+      scopeSpans.set(scopeKey, scopeSpan);
+      resourceSpan.scopeSpans.push(scopeSpan);
+    }
+
+    scopeSpan.spans.push(toOTLPSpan(row));
+  }
+
+  return { resourceSpans: Array.from(resourceSpans.values()) };
+}
+
+function toResourceAttributes(row: ClickHouseTraceSpanRow): otlpcommonv1.KeyValue[] {
+  const attributes = toKeyValues(row.ResourceAttributes);
+  // The Gantt chart reads the service name from the resource attributes, the exporter also stores it in its own column
+  if (row.ServiceName !== '' && !attributes.some((attribute) => attribute.key === 'service.name')) {
+    attributes.unshift({ key: 'service.name', value: { stringValue: row.ServiceName } });
+  }
+  return attributes;
+}
+
+// The exporter stores every attribute value as a string, so the original value types cannot be recovered
+function toKeyValues(attributes: Record<string, string> = {}): otlpcommonv1.KeyValue[] {
+  return Object.entries(attributes).map(([key, value]) => ({ key, value: { stringValue: value } }));
+}
+
+function toOTLPSpan(row: ClickHouseTraceSpanRow): otlptracev1.Span {
+  return {
+    traceId: row.TraceId,
+    spanId: row.SpanId,
+    parentSpanId: row.ParentSpanId === '' ? undefined : row.ParentSpanId,
+    name: row.SpanName,
+    kind: SPAN_KIND_MAP[normalizeEnumName(row.SpanKind, 'span_kind_')],
+    startTimeUnixNano: row.StartTimeUnixNano,
+    // Nanoseconds since the epoch exceed Number.MAX_SAFE_INTEGER
+    endTimeUnixNano: (BigInt(row.StartTimeUnixNano) + BigInt(row.DurationNano)).toString(),
+    attributes: toKeyValues(row.SpanAttributes),
+    events: row.EventNames.map((name, i) => ({
+      timeUnixNano: row.EventTimesUnixNano[i] ?? row.StartTimeUnixNano,
+      name,
+      attributes: toKeyValues(row.EventAttributes[i]),
+    })),
+    links: row.LinkTraceIds.map((traceId, i) => ({
+      traceId,
+      spanId: row.LinkSpanIds[i] ?? '',
+      attributes: toKeyValues(row.LinkAttributes[i]),
+    })),
+    status: {
+      code: STATUS_CODE_MAP[normalizeEnumName(row.StatusCode, 'status_code_')],
+      message: row.StatusMessage === '' ? undefined : row.StatusMessage,
+    },
+  };
+}
+
+function normalizeEnumName(value: string | undefined, prefix: string): string {
+  const name = (value ?? '').toLowerCase();
+  return name.startsWith(prefix) ? name.slice(prefix.length) : name;
+}
+
+function clickHouseSpansToSearchResults(rows: ClickHouseSpanRow[]): {
+  searchResult: TraceSearchResult[];
+  skippedRows: number;
+} {
+  const summaries = new Map<string, TraceSummary>();
+  let skippedRows = 0;
+
+  for (const row of rows) {
+    const startTimeUnixMs = parseTimestampMs(row.Timestamp);
+    if (!row.TraceId || startTimeUnixMs === undefined) {
+      skippedRows++;
+      continue;
+    }
+
+    // Duration is stored in nanoseconds
+    const durationMs = Number(row.Duration ?? 0) / 1e6;
+    const endTimeUnixMs = startTimeUnixMs + (Number.isFinite(durationMs) ? durationMs : 0);
+    const serviceName = row.ServiceName || 'unknown';
+    const span = { hasParent: !!row.ParentSpanId, startTimeUnixMs, serviceName, spanName: row.SpanName ?? '' };
+
+    let summary = summaries.get(row.TraceId);
+    if (summary === undefined) {
+      summary = { startTimeUnixMs, endTimeUnixMs, root: span, serviceStats: {} };
+      summaries.set(row.TraceId, summary);
+    } else {
+      summary.startTimeUnixMs = Math.min(summary.startTimeUnixMs, startTimeUnixMs);
+      summary.endTimeUnixMs = Math.max(summary.endTimeUnixMs, endTimeUnixMs);
+      // The root is the span without a parent. If the query didn't return it, the earliest span stands in for it.
+      const isBetterRoot =
+        span.hasParent === summary.root.hasParent
+          ? span.startTimeUnixMs < summary.root.startTimeUnixMs
+          : !span.hasParent;
+      if (isBetterRoot) {
+        summary.root = span;
+      }
+    }
+
+    const stats = summary.serviceStats[serviceName] ?? { spanCount: 0 };
+    stats.spanCount += 1;
+    if (STATUS_CODE_MAP[normalizeEnumName(row.StatusCode, 'status_code_')] === 'STATUS_CODE_ERROR') {
+      stats.errorCount = (stats.errorCount ?? 0) + 1;
+    }
+    summary.serviceStats[serviceName] = stats;
+  }
+
+  const searchResult = Array.from(summaries, ([traceId, summary]) => ({
+    traceId,
+    rootServiceName: summary.root.serviceName,
+    rootTraceName: summary.root.spanName || traceId,
+    startTimeUnixMs: summary.startTimeUnixMs,
+    durationMs: summary.endTimeUnixMs - summary.startTimeUnixMs,
+    serviceStats: summary.serviceStats,
+  })).toSorted((a, b) => b.startTimeUnixMs - a.startTimeUnixMs);
+
+  return { searchResult, skippedRows };
+}
+
+function parseTimestampMs(timestamp: string | undefined): number | undefined {
+  if (timestamp === undefined) {
+    return undefined;
+  }
+
+  // ClickHouse renders DateTime64 without a timezone: read it as UTC, like the {start} and {end} placeholders
+  const match = CLICKHOUSE_DATETIME_PATTERN.exec(timestamp);
+  const unixMs = match
+    ? Date.parse(`${match[1]}T${match[2]}Z`) + Number(`0.${match[3] ?? '0'}`) * 1000
+    : Date.parse(timestamp);
+  return Number.isNaN(unixMs) ? undefined : unixMs;
+}

--- a/clickhouse/src/queries/click-house-trace-query/index.ts
+++ b/clickhouse/src/queries/click-house-trace-query/index.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from './click-house-time-series-query';
-export * from './click-house-log-query';
-export * from './click-house-trace-query';
+export * from './ClickHouseTraceQuery';
+export * from './ClickHouseTraceQueryEditor';
+export * from './get-click-house-trace-data';
+export * from './click-house-trace-query-types';

--- a/docs/clickhouse/README.md
+++ b/docs/clickhouse/README.md
@@ -34,3 +34,12 @@ See also technical docs related to this plugin:
 
 - [Data model](./model.md#clickhouselogquery)
 - [Dashboard-as-Code Go lib](./go-sdk/log-query.md)
+
+## Trace Query (`ClickHouseTraceQuery`)
+
+The ClickHouse trace query plugin reads traces stored with the schema of the [OpenTelemetry Collector ClickHouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter). A trace ID returns the whole trace, for the Tracing Gantt Chart panel. A SQL query returning spans returns trace search results, for the Trace Table panel.
+
+See also technical docs related to this plugin:
+
+- [Data model](./model.md#clickhousetracequery)
+- [Dashboard-as-Code Go lib](./go-sdk/trace-query.md)

--- a/docs/clickhouse/go-sdk/trace-query.md
+++ b/docs/clickhouse/go-sdk/trace-query.md
@@ -1,0 +1,100 @@
+# ClickHouse Trace Query Go SDK
+
+## Constructor
+
+```golang
+import "github.com/perses/plugins/clickhouse/sdk/go/query/trace"
+
+var options []trace.Option
+trace.ClickHouseTraceQuery("5b8efff798038103d269b633813fc60c", options...)
+```
+
+Need to provide a trace ID or a SQL query, and a list of options.
+
+## Default options
+
+- [Query()](#query): with the trace ID or the SQL query provided in the constructor.
+
+## Available options
+
+#### Query
+
+```golang
+import "github.com/perses/plugins/clickhouse/sdk/go/query/trace"
+
+trace.Query("$traceId")
+```
+
+Define the trace ID, or the SQL query returning one row per span.
+
+#### Datasource
+
+```golang
+import "github.com/perses/plugins/clickhouse/sdk/go/query/trace"
+
+trace.Datasource("MyClickHouseDatasource")
+```
+
+Define the datasource the query will use.
+
+#### Table
+
+```golang
+import "github.com/perses/plugins/clickhouse/sdk/go/query/trace"
+
+trace.Table("otel.otel_traces")
+```
+
+Define the table read when looking up a trace by ID. Defaults to `otel_traces`.
+
+#### Limit
+
+```golang
+import "github.com/perses/plugins/clickhouse/sdk/go/query/trace"
+
+trace.Limit(50)
+```
+
+Define the maximum number of traces returned by a search.
+
+## Example
+
+```golang
+package main
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/clickhouse/sdk/go/query/trace"
+	tracetable "github.com/perses/plugins/tracetable/sdk/go"
+	tracingganttchart "github.com/perses/plugins/tracingganttchart/sdk/go"
+)
+
+func main() {
+	dashboard.New("ClickHouse Traces Dashboard",
+		dashboard.AddPanelGroup("Traces",
+			panelgroup.AddPanel("Checkout traces",
+				tracetable.Chart(),
+				panel.AddQuery(
+					trace.ClickHouseTraceQuery(`
+						SELECT TraceId, ParentSpanId, SpanName, ServiceName, Timestamp, Duration, StatusCode
+						FROM otel.otel_traces
+						WHERE Timestamp BETWEEN '{start}' AND '{end}'
+						AND TraceId IN (
+							SELECT TraceId FROM otel.otel_traces
+							WHERE ServiceName = 'checkout' AND Timestamp BETWEEN '{start}' AND '{end}'
+						)
+					`, trace.Limit(50)),
+				),
+			),
+			panelgroup.AddPanel("Trace",
+				tracingganttchart.Chart(),
+				panel.AddQuery(
+					trace.ClickHouseTraceQuery("$traceId", trace.Table("otel.otel_traces")),
+				),
+			),
+		),
+	)
+}
+```

--- a/docs/clickhouse/model.md
+++ b/docs/clickhouse/model.md
@@ -129,6 +129,90 @@ spec:
       query: "SELECT timestamp, level, message, service FROM application_logs WHERE level = 'ERROR' AND timestamp >= now() - INTERVAL 1 HOUR ORDER BY timestamp DESC LIMIT 1000"
 ```
 
+## ClickHouseTraceQuery
+
+Perses supports trace queries for ClickHouse: `ClickHouseTraceQuery`. It reads traces stored with the schema of the [OpenTelemetry Collector ClickHouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter).
+
+```yaml
+kind: "ClickHouseTraceQuery"
+spec:
+  # `query` is either a trace ID or a SQL query.
+  # - A trace ID (16 or 32 hexadecimal characters) returns all the spans of this trace, read from `table`.
+  # - A SQL query must return one row per span. The spans are grouped by trace into search results.
+  query: <string>
+
+  # `table` is the table storing the spans, optionally prefixed with its database.
+  # It is only used to look up a trace by ID.
+  table: <string> | default = "otel_traces" # Optional
+
+  # `limit` is the maximum number of traces returned by a search.
+  limit: <int> | default = 20 # Optional
+
+  # `datasource` is a datasource selector. If not provided, the default ClickHouseDatasource is used.
+  # See the documentation about the datasources to understand how it is selected.
+  datasource: <ClickHouse Datasource selector> # Optional
+```
+
+- See [ClickHouse Datasource selector](#clickhouse-datasource-selector)
+
+### Trace ID lookup
+
+A trace ID returns all the spans of this trace from `table`, whatever the time range of the dashboard, so that a trace can be opened from a link.
+
+!!! note
+    The lookup is not bounded by time: it relies on the bloom filter index the exporter creates on `TraceId`. On large tables, a lookup bounded with the exporter's `<table>_trace_id_ts` table (`otel_traces_trace_id_ts` by default), which maps each trace ID to its start and end time, can be faster. That table is not used because it only exists when the exporter created the schema. This choice may be revisited, for example with an option to use it.
+
+### Search query columns
+
+A search query must return one row per span, with the column names of the exporter schema:
+
+| Column         | Required | Usage                                                                                  |
+|----------------|----------|----------------------------------------------------------------------------------------|
+| `TraceId`      | Yes      | Groups the spans into traces.                                                          |
+| `Timestamp`    | Yes      | Start time of the span. Values without a timezone are read as UTC.                     |
+| `Duration`     | No       | Duration of the span in nanoseconds, used to compute the duration of the trace.        |
+| `ParentSpanId` | No       | Identifies the root span, which names the trace. Otherwise the earliest span is used. |
+| `SpanName`     | No       | Name of the trace, taken from its root span.                                           |
+| `ServiceName`  | No       | Counts the spans of each service.                                                      |
+| `StatusCode`   | No       | Counts the spans with an error in each service.                                        |
+
+The span counts and the root span are computed from the returned spans only. To list whole traces, select the trace IDs in a subquery, as in the example below.
+
+Like the other ClickHouse queries, `{start}` and `{end}` are replaced with the time range of the dashboard.
+
+### Example
+
+A trace search listing the traces that went through the `checkout` service:
+
+```yaml
+kind: "TraceQuery"
+spec:
+  plugin:
+    kind: "ClickHouseTraceQuery"
+    spec:
+      query: |
+        SELECT TraceId, ParentSpanId, SpanName, ServiceName, Timestamp, Duration, StatusCode
+        FROM otel.otel_traces
+        WHERE Timestamp BETWEEN '{start}' AND '{end}'
+          AND TraceId IN (
+            SELECT TraceId FROM otel.otel_traces
+            WHERE ServiceName = 'checkout' AND Timestamp BETWEEN '{start}' AND '{end}'
+          )
+      limit: 50
+```
+
+A trace lookup, for example in a Tracing Gantt Chart panel showing the trace selected in the `traceId` variable:
+
+```yaml
+kind: "TraceQuery"
+spec:
+  plugin:
+    kind: "ClickHouseTraceQuery"
+    spec:
+      query: "$traceId"
+      table: "otel.otel_traces"
+```
+
 ## Shared definitions
 
 ### ClickHouse Datasource selector


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description

Adds `ClickHouseTraceQuery`, a `TraceQuery` plugin in the ClickHouse plugin module, so traces stored in ClickHouse can be displayed with the existing Trace Table and Tracing Gantt Chart panels. Until now the module had log and time series queries only.

Relates to perses/perses#4202 (ClickHouse traces as a datasource): this is the query plugin a ClickHouse trace explorer would build on.

## How it works

The plugin reads the schema created by the [OpenTelemetry Collector ClickHouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter), and follows the `TraceData` contract used by the Tempo plugin: a trace ID returns a trace, anything else returns search results.

- **Trace ID** (16 or 32 hex characters, after variable substitution): the plugin builds the SQL, reads every span of the trace from `table` (default `otel_traces`, optionally `database.table`), and converts the rows to OTLP, grouped by resource and instrumentation scope. Drill-down links such as `?var-traceId=${traceId}` work as they do with Tempo.
- **SQL**: returns one row per span, with the exporter's column names (`TraceId`, `Timestamp`, `Duration`, `ParentSpanId`, `SpanName`, `ServiceName`, `StatusCode`). The plugin uses it as a subquery, and ClickHouse groups the spans into traces: one row per trace with the root span, the start and end time, and the span and error counts per service, newest first, with `LIMIT limit + 1`. The extra trace is how the panels know more traces match, as in the Tempo and Jaeger plugins. `{start}` and `{end}` are replaced as in the log and time series queries.

```yaml
# Trace Table: traces that went through the payment service
kind: ClickHouseTraceQuery
spec:
  query: |
    SELECT TraceId, ParentSpanId, SpanName, ServiceName, Timestamp, Duration, StatusCode
    FROM otel.otel_traces
    WHERE Timestamp BETWEEN '{start}' AND '{end}'
      AND TraceId IN (
        SELECT TraceId FROM otel.otel_traces
        WHERE ServiceName = 'payment' AND Timestamp BETWEEN '{start}' AND '{end}'
      )
---
# Tracing Gantt Chart: the trace selected in the traceId variable
kind: ClickHouseTraceQuery
spec:
  query: $traceId
  table: otel.otel_traces
```

## Implementation notes

- **Timestamps.** Both queries convert timestamps to nanosecond strings in SQL (`toUnixTimestamp64Nano`). Otherwise `DateTime64` values are rendered in the server's timezone, and nanoseconds since the epoch exceed `Number.MAX_SAFE_INTEGER`, so they are summed and subtracted with `BigInt`.
- **SQL built by the plugin.** The trace ID is validated and normalized (lowercase, padded to 32 characters, as the exporter stores it), and `table` must be a plain identifier (checked in CUE and at runtime) before either goes into SQL. User-written search queries keep the existing behavior of the ClickHouse queries.
- **Limit.** `limit` is applied by ClickHouse, not after fetching: only the traces that are displayed cross the wire. On the verification data, the search panel returns 8 rows instead of 48 span rows, and a search over 48 traces with `limit: 20` returns 21 rows instead of 168. The cost is that the search query is used as a subquery: all the documented columns are required, it has to be a single `SELECT`, and a query ending with a `FORMAT` clause is rejected with an explicit error. A trailing `;` is removed.
- **Output format.** Both generated queries end with an explicit `FORMAT JSON`. The shared ClickHouse client only appends it when the query doesn't contain the word `FORMAT`, which a search query may well do (`formatDateTime(...)`), and would otherwise get TabSeparated back.
- **Errors.** The ClickHouse client returns `status: 'error'` and logs the server's message to the console, so the plugin throws rather than showing an empty panel. An unknown trace ID also throws, as in the Jaeger plugin.
- **Exporter details.** `SpanKind` and `StatusCode` are accepted as the exporter writes them (`Server`, `Error`) and as OTLP enum names (`SPAN_KIND_SERVER`, `STATUS_CODE_ERROR`). Attributes from the default `Map` schema are strings; with the exporter's `json: true` schema the value types are kept and mapped to the matching OTLP value (`intValue`, `doubleValue`, `boolValue`, `arrayValue`), and the nesting that ClickHouse's JSON type makes of dotted attribute names (`http.response.status_code` comes back as `{http: {response: {status_code: 200}}}`) is flattened back into the original names. 64-bit integers are accepted as JSON numbers or strings, since ClickHouse quotes them or not depending on `output_format_json_quote_64bit_integers`.

## Changes

| Path | Change |
| :- | :- |
| `clickhouse/src/queries/click-house-trace-query/` | Plugin, options editor, data fetching and conversion, types, tests |
| `clickhouse/schemas/queries/click-house-trace-query/` | CUE schema, with valid and invalid test cases |
| `clickhouse/sdk/go/query/trace/` | Go SDK builder (`Query`, `Datasource`, `Table`, `Limit`) and tests |
| `clickhouse/package.json`, `rsbuild.config.ts`, `src/queries/index.ts` | Register and expose the plugin |
| `docs/clickhouse/` | Overview, data model (including the trace ID lookup and the search query columns), Go SDK page |

## Tests

- 26 vitest tests. Trace lookup: SQL and its output format, OTLP conversion (resource and scope grouping, both span kind and status spellings, nanosecond end times, events, links, typed and flattened attributes from the JSON schema), trace ID normalization, variables, table validation, trace not found. Search: the generated query and its limit, the summary rows it returns, time range placeholders, more results than the limit, a 16 character SQL query running as a search, `formatDateTime` in the query, a trailing semicolon, a rejected `FORMAT` clause, unknown root service, counts of an empty service name and a service named `unknown`, ClickHouse errors. Editor: table committed on blur, limit.
- 2 Go tests for the SDK builder.
- 5 schema test cases: 2 valid, and 3 invalid (empty query, table that is not an identifier, non-positive limit).

## Verification

**CI-equivalent run.** I ran the steps of `react.yml`, `cue.yml`, `go.yml`, `doc.yml` and `ci.yml` at this branch's commit, in a container with the versions CI pins (Go 1.27.1, Node 24, CUE v0.16.1, percli v0.54.0, golangci-lint v2.13.2, mdox). All 17 steps passed:

| Steps | Result |
| :- | :- |
| `npm ci`, `npm run lint`, `npm run format:check`, `npm run type-check`, `npm run test` | Pass (clickhouse: 6 test files, 37 tests) |
| `make checkformat-cue`, `make lint-plugins`, `make test-schemas-plugins`, `make tidy-modules` with no `cue.mod` diff | Pass (the 2 valid and 3 invalid `click-house-trace-query` cases are evaluated) |
| `make test`, `go test ./...` in `clickhouse`, `make golangci-lint`, `make checklicense` | Pass |
| `make checkdocs` | Pass |
| `percli plugin build` for `clickhouse`, `tracetable` and `tracingganttchart` | Pass |

The advisory React Doctor scan (`react-doctor.yml`) reports no findings in the new files.

**End to end.** OTLP/HTTP → OpenTelemetry Collector contrib 0.160.0 (ClickHouse exporter, `create_schema: true`) → ClickHouse 25.8 → Perses (`main` image of 2026-09-10), with a `ClickHouseDatasource` going through the Perses proxy and the plugin archives built from this branch. The data: 8 traces across three services (with errors, exception events and span links), plus 40 traces from telemetrygen.

- The ClickHouse plugin module loads with `TraceQuery:ClickHouseTraceQuery`, and a dashboard using it is provisioned.
- `POST /api/validate/dashboards` accepts valid specs, and rejects a `table` that is not an identifier, `limit: 0`, an empty `query` and an unknown field, each with the corresponding CUE error.
- The trace lookup SQL, run against the table created by the exporter, returns the types the conversion expects: maps as JSON objects, events and links as arrays, nanoseconds as strings.
- A Trace Table with a search query lists the traces with their span and error counts. With 48 traces and `limit: 20`, it shows the "Not all matching traces are currently displayed" notice. ClickHouse's `query_log` confirms the limit is applied there: 21 rows returned for that panel, and 8 for the search on the payment service.
- A Tracing Gantt Chart with `query: $traceId` renders the trace: span hierarchy, error statuses, attributes and events. Following a Trace Table link (`?var-traceId=${traceId}`) shows the selected trace.
- An unknown trace ID shows "Trace ffffffffffffffffffffffffffffffff was not found in otel.otel_traces." in the panel. It is the only error in the browser console.

**Review round two** (Copilot's comments), checked on the same stack:

- A Trace Table whose search query contains `formatDateTime(...)` renders its traces. Sent through the Perses proxy, the same query without the explicit `FORMAT JSON` comes back as `text/tab-separated-values`, which is what broke before.
- A table created verbatim from the exporter's `traces_json_table.sql` (`json: true` schema, `SpanAttributes JSON`), holding a trace with a number, a float, a boolean, an array and nested keys, renders in the Tracing Gantt Chart with the attributes typed and under their original dotted names: `http.response.status_code 200`, `http.request.body.size 12.5`, `retry true`, `tags checkout, web`, `nested.feature.flag on`. ClickHouse returns those attributes as nested objects, which the plugin flattens back.

I can share the Compose setup used for this (collector config, seed script, provisioning) if it helps the review.

## Design decision to review: trace ID lookups are not bounded by time

> [!IMPORTANT]
> A trace ID lookup reads the spans with `WHERE TraceId = '…'` from `table`, with **no time bound**, so that a trace opens from a link whatever the time range of the dashboard. It relies on the bloom filter index the exporter creates on `TraceId`.
>
> The alternative is to first read the start and end time of the trace from the exporter's `<table>_trace_id_ts` table (`otel_traces_trace_id_ts` by default), and bound the scan with them, which lets ClickHouse skip the partitions outside the trace on large tables. I did not do it because that table only exists when the exporter created the schema, so the lookup would fail on custom tables and views that otherwise have the right columns.
>
> This is the part of the design most likely to need a change, for example an option to use that table, or using it by default. The choice is documented in the data model docs ("Trace ID lookup") and in a comment on the query builder, so it is easy to revisit. Happy to change it if you prefer the other way.

## Noticed while working on this, not changed in this PR

- **The existing ClickHouse Go SDK docs don't match the SDK.** `docs/clickhouse/go-sdk/datasource.md`, `log-query.md` and `timeseries-query.md` import `github.com/perses/perses-plugins/clickhouse/sdk/go/v1/...`, while the SDK packages are `github.com/perses/plugins/clickhouse/sdk/go/datasource`, `.../query/log` and `.../query/time-series`. The two query pages also use builders that don't exist (`query.LogQuery`, `query.TimeSeriesQuery`, `query.Format`): the SDK has `log.ClickHouseLogQuery` and `timeseries.ClickHouseTimeSeriesQuery`, with `Query` and `Datasource` options only. Likewise, `docs/clickhouse/model.md` documents an optional `format` field for `ClickHouseTimeSeriesQuery` and `ClickHouseLogQuery`, which their CUE schemas (closed, with `datasource` and `query` only) reject. I didn't find an existing issue about it. I left these pages unchanged to keep this PR focused (the new `trace-query.md` uses the actual packages), and I'm happy to fix them in a follow-up.
- **The Tracing Gantt Chart keeps the viewport and the selected span of the previous trace when its trace changes in place**, for example after following a Trace Table link to the same dashboard: `TracingGanttChart` initializes both with `useState`, and the panel doesn't key the component by trace. The lower timeline then shows offsets from the previous trace, and the details pane the previously selected span. It happens with any trace query plugin, so it isn't addressed here. The drill-down screenshot below was taken after reloading the page.

# Screenshots

Perses `main` with the plugin archives built from this branch, reading traces written by the OpenTelemetry Collector ClickHouse exporter.

**Dashboard: two Trace Tables with search queries, and a Tracing Gantt Chart with `query: $traceId`**

<img width="1600" height="1012" alt="01-dashboard" src="https://github.com/user-attachments/assets/ff93b458-807e-4f8a-b9ae-53102e403bd4" />


**Span details converted from the exporter's columns: kind, status, attributes, resource, scope, events**

<img width="1568" height="470" alt="03-span-detail" src="https://github.com/user-attachments/assets/79cfa754-c486-4115-8521-43a04f1a63f1" />


**Query editor: datasource, trace ID or SQL, trace table, max traces**

<img width="1600" height="1012" alt="05-query-editor" src="https://github.com/user-attachments/assets/14f80920-9890-4dc3-a3ca-f9df6b7222a0" />


**Search limit: `limit: 20` with 48 matching traces**

<img width="779" height="350" alt="02-limit-notice" src="https://github.com/user-attachments/assets/cea1131d-19ad-4832-8d1f-159d57128cb8" />


**A Trace Table link followed to the Gantt chart** (after a page reload, see the Tracing Gantt Chart note above)

<img width="1600" height="1012" alt="04-drilldown" src="https://github.com/user-attachments/assets/9cc0cd21-b82e-4f27-8aaa-2dc1f0d87fa2" />


**Unknown trace ID**

<img width="1568" height="470" alt="06-trace-not-found" src="https://github.com/user-attachments/assets/df8380da-9bee-4fb7-bd28-42e0dd19402c" />


**Review round two: a search using `formatDateTime`, and a trace from the exporter's JSON schema**

<img width="1600" height="900" alt="07-review-checks" src="https://github.com/user-attachments/assets/5c6ddb95-8f82-439a-b352-c8f5a9cd1c5c" />


**JSON schema attributes in the detail pane, typed and flattened**

<img width="911" height="470" alt="08-json-schema-attributes" src="https://github.com/user-attachments/assets/9d9075dd-6e13-4f6f-966c-f6fb16b8850a" />


# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [x] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [x] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
